### PR TITLE
sidebar: fix collapse toggle clipping + tighten labels

### DIFF
--- a/crkva/registar/static/registar/layout/bocna-traka.css
+++ b/crkva/registar/static/registar/layout/bocna-traka.css
@@ -54,9 +54,10 @@
 
 /* Toggle Button */
 .sidebar-toggle {
-  position: absolute;
+  position: fixed;
   bottom: 20px;
-  right: -20px;
+  left: var(--sidebar-width-expanded);
+  transform: translateX(-50%);
   width: 40px;
   height: 40px;
   display: flex;
@@ -68,14 +69,24 @@
   color: var(--sidebar-text-color);
   cursor: pointer;
   font-size: 18px;
-  transition: all 0.3s ease;
+  transition: left 0.3s ease, transform 0.2s ease, background 0.2s ease;
   z-index: 1001;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .sidebar-toggle:hover {
   background: rgba(255, 255, 255, 0.15);
-  transform: scale(1.1);
+  transform: translateX(-50%) scale(1.1);
+}
+
+/* Toggle follows sidebar width when collapsed */
+body.sidebar-collapsed .sidebar-toggle {
+  left: var(--sidebar-width-collapsed);
+}
+
+/* Hide the desktop toggle on mobile (hamburger handles it) */
+@media (max-width: 768px) {
+  .sidebar-toggle { display: none; }
 }
 
 .sidebar-toggle i {

--- a/crkva/registar/templates/registar/index.html
+++ b/crkva/registar/templates/registar/index.html
@@ -38,7 +38,7 @@
       <a href="{% url 'kalendar' %}" class="actions__item">
         <div class="actions__icon"><i class="fa-solid fa-calendar-days"></i></div>
         <div class="actions__text">
-          <div class="actions__title">Календар слава</div>
+          <div class="actions__title">Календар</div>
           <div class="actions__desc">Прегледај славе</div>
         </div>
       </a>
@@ -48,7 +48,7 @@
   <!-- Slava Calendar Widget -->
   <div class="card">
     <div class="card__header">
-      <h3><i class="fa-solid fa-calendar-days"></i> Актуелне славе</h3>
+      <h3><i class="fa-solid fa-calendar-days"></i> Текући дани</h3>
       <a href="{% url 'kalendar' %}" class="card__link">
         <i class="fa-solid fa-arrow-right"></i> Календар
       </a>

--- a/crkva/registar/templates/registar/kalendar.html
+++ b/crkva/registar/templates/registar/kalendar.html
@@ -4,14 +4,14 @@
 <link rel="stylesheet" href="{% static 'registar/pages/kalendar.css' %}">
 {% endblock %}
 
-{% block title %}Календар слава{% endblock %}
+{% block title %}Календар{% endblock %}
 
 {% block content %}
 <div class="u-page-header">
   <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
     <i class="fa-solid fa-arrow-left"></i>
   </a>
-<h1 class="u-page-title">Календар слава</h1>
+<h1 class="u-page-title">Календар</h1>
 </div>
 
 <!-- Single, centered navigation -->

--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -68,9 +68,9 @@
     </div>
 
     <div class="sidebar-menu-item">
-      <a href="{{ kalendar_url }}" class="{% if request.path == kalendar_url %}active{% endif %}" title="Календар слава">
+      <a href="{{ kalendar_url }}" class="{% if request.path == kalendar_url %}active{% endif %}" title="Календар">
         <i class="fa-solid fa-calendar-days"></i>
-        <span class="sidebar-text">Календар слава</span>
+        <span class="sidebar-text">Календар</span>
       </a>
     </div>
   </nav>
@@ -89,12 +89,13 @@
       <span class="sidebar-text">Тема</span>
     </button>
 
-    <!-- Toggle Button -->
-    <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar">
-      <i class="fa-solid fa-arrow-left"></i>
-    </button>
   </div>
 </aside>
+
+<!-- Sidebar toggle button (moved outside aside so overflow-x:hidden on .sidebar doesn't clip the half that's supposed to overflow onto the page) -->
+<button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar">
+  <i class="fa-solid fa-arrow-left"></i>
+</button>
 
 <!-- Search Overlay -->
 <div id="search-overlay" class="search-overlay" style="display: none;">

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -75,7 +75,7 @@ def index(request) -> HttpResponse:
             by_day[(datum.month, datum.day)].append(s)
 
     # Build cells for template
-    weekday_labels = ["Пон", "Уто", "Сре", "Чет", "Пет", "Суб", "Нед"]
+    weekday_labels = ["пон", "уто", "сре", "чет", "пет", "суб", "нед"]
 
     # Major feast days
     major_feasts = {

--- a/crkva/registar/views/kalendar_view.py
+++ b/crkva/registar/views/kalendar_view.py
@@ -48,7 +48,7 @@ def kalendar(
 
     # Обогаћени подаци за темплат
     # Weekday labels (Mon..Sun) in Serbian abbreviations
-    weekday_labels = ["Пон", "Уто", "Сре", "Чет", "Пет", "Суб", "Нед"]
+    weekday_labels = ["пон", "уто", "сре", "чет", "пет", "суб", "нед"]
 
     # Major feast days (important observances)
     major_feasts = {


### PR DESCRIPTION
* Toggle button moved out of the <aside> so the half that's supposed to overflow onto the page isn't clipped by .sidebar { overflow-x: hidden }. Now position: fixed, anchored to the sidebar's right edge via left: var(--sidebar-width-expanded), and follows the sidebar width when collapsed. Hidden entirely on mobile (≤768px) so the hamburger handles toggling.

* Labels: "Календар слава" → "Календар" (sidebar nav + page title
  + home shortcut). "Актуелне славе" → "Текући дани" on the home dashboard card.

* Weekday strip in the calendar lowercased: Пон/Уто/Сре… → пон/уто/сре… so it matches the relative-day labels ("данас", "јуче", "сутра") already in lowercase.