### PR TITLE
detail pages: tabs component + standard data view for крштење/венчање

### DIFF
--- a/crkva/registar/static/registar/components/tabovi.css
+++ b/crkva/registar/static/registar/components/tabovi.css
@@ -1,0 +1,232 @@
+/* ==========================================================================
+   TABS COMPONENT
+   ==========================================================================
+   CSS-only tabs: sibling radio inputs drive selection. No JS, full keyboard
+   nav (arrow keys move between radios in the same group).
+
+   Markup:
+     <div class="tabs tabs--segmented">
+       <div class="tabs__nav">
+         <input id="tab-a" name="my-tabs" type="radio" class="tabs__radio" checked>
+         <label for="tab-a" class="tabs__tab">
+           <i class="tabs__icon fa-solid fa-list"></i> Подаци
+         </label>
+         <input id="tab-b" name="my-tabs" type="radio" class="tabs__radio">
+         <label for="tab-b" class="tabs__tab">
+           <i class="tabs__icon fa-solid fa-file"></i> Преглед
+           <span class="tabs__count">3</span>
+         </label>
+       </div>
+       <section class="tabs__panel">…</section>
+       <section class="tabs__panel">…</section>
+     </div>
+
+   Variants: tabs--segmented (default) | tabs--underline
+
+   The Nth radio (counted among <input> children of .tabs__nav) shows the Nth
+   panel (counted among <section> children of .tabs), so order matters but
+   you don't need any per-instance CSS.
+   ========================================================================== */
+
+.tabs {
+    display: block;
+    width: 100%;
+    text-align: center;  /* centers the inline-flex nav horizontally */
+}
+
+/* Radios: visually hidden but keep them focusable for keyboard nav. */
+.tabs__radio {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.tabs__nav {
+    display: inline-flex;
+    margin: 0 0 var(--space-3);
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+.tabs__nav::-webkit-scrollbar { display: none; }
+
+.tabs__tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 18px;
+    min-height: 40px;
+    line-height: 20px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.tabs__tab[aria-disabled="true"],
+.tabs__tab.is-disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.tabs__icon {
+    font-size: 14px;
+    line-height: 1;
+}
+
+.tabs__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    border-radius: 999px;
+    background: var(--color-surface-2);
+    color: var(--color-text-muted);
+    transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+/* ========================================================================
+   Panel visibility — show the Nth panel when the Nth radio is :checked.
+   Uses :has() (Chrome 105+, Safari 15.4+, Firefox 121+) for cross-container
+   correlation, plus :nth-of-type to pair radios with panels by position.
+   ======================================================================== */
+
+.tabs__panel {
+    display: none;
+    width: 100%;
+    text-align: left;
+    animation: tabs-fade-in 0.18s ease;
+}
+
+.tabs:has(.tabs__radio:nth-of-type(1):checked) > .tabs__panel:nth-of-type(1),
+.tabs:has(.tabs__radio:nth-of-type(2):checked) > .tabs__panel:nth-of-type(2),
+.tabs:has(.tabs__radio:nth-of-type(3):checked) > .tabs__panel:nth-of-type(3),
+.tabs:has(.tabs__radio:nth-of-type(4):checked) > .tabs__panel:nth-of-type(4),
+.tabs:has(.tabs__radio:nth-of-type(5):checked) > .tabs__panel:nth-of-type(5),
+.tabs:has(.tabs__radio:nth-of-type(6):checked) > .tabs__panel:nth-of-type(6) {
+    display: block;
+}
+
+@keyframes tabs-fade-in {
+    from { opacity: 0; transform: translateY(2px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ==========================================================================
+   VARIANT: SEGMENTED (joined buttons, filled active)
+   Best for 2–3 short, mutually-exclusive choices (view modes, filters).
+   ========================================================================== */
+
+.tabs--segmented .tabs__nav {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    background: var(--color-surface);
+}
+
+.tabs--segmented .tabs__tab {
+    background: transparent;
+}
+
+.tabs--segmented .tabs__tab + .tabs__radio + .tabs__tab,
+.tabs--segmented .tabs__radio:not(:first-of-type) + .tabs__tab {
+    border-left: 1px solid var(--color-border);
+}
+
+.tabs--segmented .tabs__tab:hover:not([aria-disabled="true"]) {
+    background: var(--color-surface-2);
+}
+
+/* Active tab — primary fill, white text, count badge inverted */
+.tabs--segmented .tabs__radio:checked + .tabs__tab {
+    background: var(--color-primary);
+    color: #fff;
+    border-left-color: transparent;
+}
+
+.tabs--segmented .tabs__radio:checked + .tabs__tab .tabs__count {
+    background: rgba(255, 255, 255, 0.22);
+    color: #fff;
+}
+
+/* Hide the divider directly to the right of the active tab so the fill
+   meets its neighbour seamlessly. Approximate: the tab immediately after
+   the active label drops its left border. */
+.tabs--segmented .tabs__radio:checked + .tabs__tab + .tabs__radio + .tabs__tab {
+    border-left-color: transparent;
+}
+
+.tabs--segmented .tabs__radio:focus-visible + .tabs__tab {
+    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 55%, transparent);
+}
+
+/* ==========================================================================
+   VARIANT: UNDERLINE (quieter, scales to many tabs)
+   Best for content sections with longer labels or 3+ tabs.
+   ========================================================================== */
+
+.tabs--underline .tabs__nav {
+    border-bottom: 1px solid var(--color-border);
+    gap: 4px;
+}
+
+.tabs--underline .tabs__tab {
+    background: transparent;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    padding: 0 14px;
+    color: var(--color-text-muted);
+    font-weight: 500;
+}
+
+.tabs--underline .tabs__tab:hover:not([aria-disabled="true"]) {
+    color: var(--color-text);
+    border-bottom-color: var(--color-border);
+}
+
+.tabs--underline .tabs__radio:checked + .tabs__tab {
+    color: var(--color-primary);
+    border-bottom-color: var(--color-primary);
+    font-weight: 600;
+}
+
+.tabs--underline .tabs__radio:checked + .tabs__tab .tabs__count {
+    background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+    color: var(--color-primary);
+}
+
+.tabs--underline .tabs__radio:focus-visible + .tabs__tab {
+    color: var(--color-primary);
+    outline: 2px solid color-mix(in oklab, var(--color-primary) 35%, transparent);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* ==========================================================================
+   MOBILE
+   ========================================================================== */
+
+@media (max-width: 640px) {
+    .tabs__nav {
+        margin-left: calc(-1 * var(--space-3));
+        margin-right: calc(-1 * var(--space-3));
+        padding: 0 var(--space-3);
+        max-width: 100vw;
+        justify-content: flex-start;
+    }
+}

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -44,6 +44,7 @@
       <link rel="stylesheet" href="{% static 'registar/components/spiskovi.css' %}">
       <link rel="stylesheet" href="{% static 'registar/components/forme.css' %}">
       <link rel="stylesheet" href="{% static 'registar/components/oznake.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/components/tabovi.css' %}">
       <!-- Dark theme overrides (loaded last for correct specificity) -->
       <link rel="stylesheet" href="{% static 'registar/themes/tamna.css' %}">
     {% endcompress %}

--- a/crkva/registar/templates/registar/info_krstenje.html
+++ b/crkva/registar/templates/registar/info_krstenje.html
@@ -8,126 +8,222 @@
 {% block content %}
 
 <div class="u-page-header">
-    <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
+    <a href="{% url 'krstenja' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">Крштеница</h1>
-    <a href="{% url 'krstenje_pdf' krstenje.uid %}" target="_blank" class="u-link-primary">
-        <button class="button button--primary" type="button" title="Штампај">
-          <i class="fa-solid fa-print u-mr-2"></i> Штампај
-        </button>
+    <h1 class="u-page-title">Крштење — {{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}</h1>
+    <a href="{% url 'krstenje_pdf' krstenje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај">
+        <i class="fa-solid fa-print"></i>
     </a>
 </div>
 
+<div class="tabs tabs--segmented">
+    <div class="tabs__nav">
+        <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
+        <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+        <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
+        <label for="krst-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Крштеница</label>
+    </div>
+
+    <!-- ============ STANDARD DATA VIEW ============ -->
+    <section class="tabs__panel">
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Дете</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Име</span>
+                        <span>{% if krstenje.dete %}<a href="{% url 'parohijan_detail' uid=krstenje.dete.uid %}" class="u-link-primary">{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}</a>{% else %}{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}{% endif %}</span>
+                    </li>
+                    {% if krstenje.dete.get_pol_display %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Пол</span>
+                        <span>{{ krstenje.dete.get_pol_display }}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.datum_rodjenja %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Датум рођења</span>
+                        <span>{{ krstenje.datum_rodjenja }}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.mesto_rodjenja %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Место рођења</span>
+                        <span>{{ krstenje.mesto_rodjenja }}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.dete_po_redu_po_majci %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Дете по реду (по мајци)</span>
+                        <span>{{ krstenje.dete_po_redu_po_majci }}</span>
+                    </li>
+                    {% endif %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Брачно</span>
+                        <span>{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</span>
+                    </li>
+                    {% if krstenje.dete_blizanac %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Близанац</span>
+                        <span>Да{% if krstenje.drugo_dete_blizanac_ime %} ({{ krstenje.drugo_dete_blizanac_ime }}){% endif %}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.dete_sa_telesnom_manom %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Телесна мана</span>
+                        <span>Да</span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Родитељи</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Отац</span>
+                        <span>{% if krstenje.otac %}<a href="{% url 'parohijan_detail' uid=krstenje.otac.uid %}" class="u-link-primary">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}</a>{% else %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}{% endif %}{% if krstenje.zanimanje_oca %}, {{ krstenje.zanimanje_oca|lower }}{% endif %}</span>
+                    </li>
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Мајка</span>
+                        <span>{% if krstenje.majka %}<a href="{% url 'parohijan_detail' uid=krstenje.majka.uid %}" class="u-link-primary">{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}</a>{% else %}{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}{% endif %}{% if krstenje.zanimanje_majke %}, {{ krstenje.zanimanje_majke|lower }}{% endif %}</span>
+                    </li>
+                    {% if krstenje.veroispovest_oca %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Вероисповест</span>
+                        <span>{{ krstenje.veroispovest_oca }}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.adresa_deteta %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Адреса</span>
+                        <span>{{ krstenje.adresa_deteta }}</span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Кум</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Име</span>
+                        <span>{% if krstenje.kum %}<a href="{% url 'parohijan_detail' uid=krstenje.kum.uid %}" class="u-link-primary">{{ krstenje.ime_kuma }}</a>{% else %}{{ krstenje.ime_kuma }}{% endif %}{% if krstenje.zanimanje_kuma %}, {{ krstenje.zanimanje_kuma|lower }}{% endif %}</span>
+                    </li>
+                    {% if krstenje.adresa_kuma_mesto %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Место</span>
+                        <span>{{ krstenje.adresa_kuma_mesto }}</span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Крштење</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    {% if krstenje.datum %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Датум</span>
+                        <span>{{ krstenje.datum }}{% if krstenje.vreme %}, {{ krstenje.vreme }} час{% endif %}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.hram %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Храм</span>
+                        <span>{{ krstenje.hram }}{% if krstenje.hram.mesto %}, {{ krstenje.hram.mesto }}{% endif %}</span>
+                    </li>
+                    {% endif %}
+                    {% if krstenje.svestenik %}
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Свештеник</span>
+                        <span><a href="{% url 'svestenik_detail' uid=krstenje.svestenik.uid %}" class="u-link-primary">{{ krstenje.svestenik }}</a></span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Запис</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item"><span class="u-kv-label">Књига</span><span>{{ krstenje.knjiga }}</span></li>
+                    <li class="u-kv-item"><span class="u-kv-label">Страна</span><span>{{ krstenje.strana }}</span></li>
+                    <li class="u-kv-item"><span class="u-kv-label">Текући број</span><span>{{ krstenje.broj }}</span></li>
+                    {% if krstenje.godina_registracije %}
+                    <li class="u-kv-item"><span class="u-kv-label">Година регистрације</span><span>{{ krstenje.godina_registracije }}</span></li>
+                    {% endif %}
+                    {% if krstenje.primedba %}
+                    <li class="u-kv-item"><span class="u-kv-label">Примедба</span><span>{{ krstenje.primedba }}</span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+    </section>
+
+    <!-- ============ CERTIFICATE PREVIEW ============ -->
+    <section class="tabs__panel">
+
 <div class="krstenica">
     <div class="krstenica-frame">
-
-        <!-- ============================================================
-        HEADER
-        ============================================================ -->
-
-        <!-- Књига / Страна / Број -->
         <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>
         <div class="krst-field-strana">{{ krstenje.strana }}</div>
         <div class="krst-field-broj">{{ krstenje.broj }}</div>
-
-        <!-- Епархије -->
         <div class="krst-field-eparhija">БЕОГРАДСКО - КАРЛОВАЧКЕ</div>
-
-        <!-- Храм / Место / Година -->
         <div class="krst-field-hram">{{ krstenje.hram }}</div>
-        <div class="krst-field-mesto">{{ krstenje.mesto }}у</div>
+        <div class="krst-field-mesto">{{ krstenje.hram.mesto }}у</div>
         <div class="krst-field-godina">{{ krstenje.datum|date:"y" }}</div>
-
-        <!-- ============================================================
-        MAIN TABLE FIELDS
-        ============================================================ -->
-
-        <!-- 1: Година, месец, дан и време рођења -->
         <div class="krst-table-field krst-field-rodjenje_datum">
             {{ krstenje.datum_rodjenja|julian_date }}, {{ krstenje.vreme_rodjenja }} часова
         </div>
-
-        <!-- 2: Место и општина рођења -->
         <div class="krst-table-field krst-field-rodjenje_mesto">
             {{ krstenje.mesto_rodjenja }}
         </div>
-
-        <!-- 3: Година, месец, дан и време крштења -->
         <div class="krst-table-field krst-field-krstenje_datum">
             {{ krstenje.datum|julian_date|default_if_none:"" }}{% if krstenje.vreme is not none %}, {{ krstenje.vreme }} часова{% endif %}
         </div>
-
-        <!-- 4: Место и храм крштења -->
         <div class="krst-table-field krst-field-krstenje_mesto">
-            {{ krstenje.mesto }}, {{ krstenje.hram }}
+            {{ krstenje.hram.mesto }}, {{ krstenje.hram }}
         </div>
-
-        <!-- 5: Име и пол детета -->
         <div class="krst-table-field krst-field-ime_pol">
             {{ krstenje.ime_deteta }}{{ krstenje.gradjansko_ime_deteta }}, {{ krstenje.get_pol_deteta_display }}
         </div>
-
-        <!-- 6: Родитељи -->
         <div class="krst-table-field krst-field-roditelji">
             {{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}, {{ krstenje.zanimanje_oca|lower }} и<br>
             {{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}, {{ krstenje.zanimanje_majke|lower }}<br>
-            {{ krstenje.mesto }}, {{ krstenje.adresa_deteta_ulica }} {{ krstenje.adresa_deteta_broj }}<br>
+            {{ krstenje.hram.mesto }}, {{ krstenje.adresa_deteta }}<br>
             {{ krstenje.veroispovest_oca }}
         </div>
-
-        <!-- 7: Које је дете по рођењу матери -->
-        <div class="krst-table-field krst-field-dete_po_redu">
-            {{ krstenje.dete_po_redu_po_majci }}
-        </div>
-
-        <!-- 8: Је ли дете црквено брачно -->
-        <div class="krst-table-field krst-field-bracno">
-            {{ krstenje.dete_vanbracno|yesno:"није,јесте" }}
-        </div>
-
-        <!-- 9: Је ли дете близанац -->
-        <div class="krst-table-field krst-field-blizanac">
-            {{ krstenje.dete_blizanac|yesno:"јесте,није" }}
-        </div>
-
-        <!-- 10: Је ли дете рођено са телесним недостатком -->
-        <div class="krst-table-field krst-field-telesna_mana">
-            {{ krstenje.dete_sa_telesnom_manom|yesno:"јесте,није,непознато" }}
-        </div>
-
-        <!-- 11: Име и презиме свештеника -->
-        <div class="krst-table-field krst-field-svestenik">
-            {{ krstenje.svestenik|default_if_none:"" }}
-        </div>
-
-        <!-- 12: Име и презиме кума -->
+        <div class="krst-table-field krst-field-dete_po_redu">{{ krstenje.dete_po_redu_po_majci }}</div>
+        <div class="krst-table-field krst-field-bracno">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div>
+        <div class="krst-table-field krst-field-blizanac">{{ krstenje.dete_blizanac|yesno:"јесте,није" }}</div>
+        <div class="krst-table-field krst-field-telesna_mana">{{ krstenje.dete_sa_telesnom_manom|yesno:"јесте,није,непознато" }}</div>
+        <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|default_if_none:"" }}</div>
         <div class="krst-table-field krst-field-kum">
             {{ krstenje.ime_kuma }}, {{ krstenje.zanimanje_kuma }}<br>
             {{ krstenje.adresa_kuma_mesto }}
         </div>
-
-        <!-- 13: Страна домовника - анаграфа -->
-        <div class="krst-table-field krst-field-domovnik">
-            <!-- Empty -->
-        </div>
-
-        <!-- 14: Примедба -->
-        <div class="krst-table-field krst-field-primedba">
-            {{ krstenje.primedba|default_if_none:"" }}
-        </div>
-
-        <!-- ============================================================
-        FOOTER
-        ============================================================ -->
-
+        <div class="krst-table-field krst-field-domovnik"></div>
+        <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|default_if_none:"" }}</div>
         <div class="krst-field-footer_br">{% now "d.m" %}</div>
         <div class="krst-field-footer_godina">{% now "y" %}</div>
         <div class="krst-field-footer_u">Београду</div>
         <div class="krst-field-footer_parohija">{% if krstenje.svestenik %}{{ krstenje.svestenik.parohija }}{% endif %}</div>
         <div class="krst-field-footer_paroh">{% if krstenje.svestenik %}{{ krstenje.svestenik }}{% endif %}</div>
-
     </div>
+</div>
+
+    </section>
 </div>
 
 {% endblock %}

--- a/crkva/registar/templates/registar/info_vencanje.html
+++ b/crkva/registar/templates/registar/info_vencanje.html
@@ -8,50 +8,188 @@
 {% block content %}
 
 <div class="u-page-header">
-    <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
+    <a href="{% url 'vencanja' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">Венчаница</h1>
-    <a href="{% url 'vencanje_pdf' vencanje.uid %}" target="_blank" class="u-link-primary">
-        <button class="button button--primary" type="button" title="Штампај">
-          <i class="fa-solid fa-print u-mr-2"></i> Штампај
-        </button>
+    <h1 class="u-page-title">Венчање — {{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</h1>
+    <a href="{% url 'vencanje_pdf' vencanje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај">
+        <i class="fa-solid fa-print"></i>
     </a>
 </div>
 
+<div class="tabs tabs--segmented">
+    <div class="tabs__nav">
+        <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
+        <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+        <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
+        <label for="venc-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Венчаница</label>
+    </div>
+
+    <!-- ============ STANDARD DATA VIEW ============ -->
+    <section class="tabs__panel">
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Женик</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Име</span>
+                        <span>{% if vencanje.zenik %}<a href="{% url 'parohijan_detail' uid=vencanje.zenik.uid %}" class="u-link-primary">{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}</a>{% else %}{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}{% endif %}</span>
+                    </li>
+                    {% if vencanje.zanimanje_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Занимање</span><span>{{ vencanje.zanimanje_zenika|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.adresa_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Адреса</span><span>{{ vencanje.adresa_zenika }}</span></li>
+                    {% endif %}
+                    {% if vencanje.datum_rodjenja_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Датум рођења</span><span>{{ vencanje.datum_rodjenja_zenika }}</span></li>
+                    {% endif %}
+                    {% if vencanje.mesto_rodjenja_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Место рођења</span><span>{{ vencanje.mesto_rodjenja_zenika }}</span></li>
+                    {% endif %}
+                    {% if vencanje.veroispovest_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Вероисповест</span><span>{{ vencanje.veroispovest_zenika|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.narodnost_zenika %}
+                    <li class="u-kv-item"><span class="u-kv-label">Народност</span><span>{{ vencanje.narodnost_zenika|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.zenik_rb_brak %}
+                    <li class="u-kv-item"><span class="u-kv-label">Редни брак</span><span>{{ vencanje.zenik_rb_brak }}</span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Невеста</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item">
+                        <span class="u-kv-label">Име</span>
+                        <span>{% if vencanje.nevesta %}<a href="{% url 'parohijan_detail' uid=vencanje.nevesta.uid %}" class="u-link-primary">{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}</a>{% else %}{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}{% endif %}</span>
+                    </li>
+                    {% if vencanje.zanimanje_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Занимање</span><span>{{ vencanje.zanimanje_neveste|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.adresa_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Адреса</span><span>{{ vencanje.adresa_neveste }}</span></li>
+                    {% endif %}
+                    {% if vencanje.datum_rodjenja_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Датум рођења</span><span>{{ vencanje.datum_rodjenja_neveste }}</span></li>
+                    {% endif %}
+                    {% if vencanje.mesto_rodjenja_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Место рођења</span><span>{{ vencanje.mesto_rodjenja_neveste }}</span></li>
+                    {% endif %}
+                    {% if vencanje.veroispovest_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Вероисповест</span><span>{{ vencanje.veroispovest_neveste|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.narodnost_neveste %}
+                    <li class="u-kv-item"><span class="u-kv-label">Народност</span><span>{{ vencanje.narodnost_neveste|lower }}</span></li>
+                    {% endif %}
+                    {% if vencanje.nevesta_rb_brak %}
+                    <li class="u-kv-item"><span class="u-kv-label">Редни брак</span><span>{{ vencanje.nevesta_rb_brak }}</span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        {% if vencanje.svekar or vencanje.svekrva or vencanje.tast or vencanje.tasta %}
+        <div class="detail-section">
+            <h2 class="detail-section__title">Родитељи</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    {% if vencanje.svekar %}
+                    <li class="u-kv-item"><span class="u-kv-label">Свекар</span><span><a href="{% url 'parohijan_detail' uid=vencanje.svekar.uid %}" class="u-link-primary">{{ vencanje.svekar }}</a></span></li>
+                    {% endif %}
+                    {% if vencanje.svekrva %}
+                    <li class="u-kv-item"><span class="u-kv-label">Свекрва</span><span><a href="{% url 'parohijan_detail' uid=vencanje.svekrva.uid %}" class="u-link-primary">{{ vencanje.svekrva }}</a></span></li>
+                    {% endif %}
+                    {% if vencanje.tast %}
+                    <li class="u-kv-item"><span class="u-kv-label">Таст</span><span><a href="{% url 'parohijan_detail' uid=vencanje.tast.uid %}" class="u-link-primary">{{ vencanje.tast }}</a></span></li>
+                    {% endif %}
+                    {% if vencanje.tasta %}
+                    <li class="u-kv-item"><span class="u-kv-label">Ташта</span><span><a href="{% url 'parohijan_detail' uid=vencanje.tasta.uid %}" class="u-link-primary">{{ vencanje.tasta }}</a></span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if vencanje.kum or vencanje.stari_svat %}
+        <div class="detail-section">
+            <h2 class="detail-section__title">Сведоци</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    {% if vencanje.kum %}
+                    <li class="u-kv-item"><span class="u-kv-label">Кум</span><span><a href="{% url 'parohijan_detail' uid=vencanje.kum.uid %}" class="u-link-primary">{{ vencanje.kum }}</a></span></li>
+                    {% endif %}
+                    {% if vencanje.stari_svat %}
+                    <li class="u-kv-item"><span class="u-kv-label">Стари сват</span><span><a href="{% url 'parohijan_detail' uid=vencanje.stari_svat.uid %}" class="u-link-primary">{{ vencanje.stari_svat }}</a></span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Венчање</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    {% if vencanje.datum %}
+                    <li class="u-kv-item"><span class="u-kv-label">Датум</span><span>{{ vencanje.datum }}</span></li>
+                    {% endif %}
+                    {% if vencanje.datum_ispita %}
+                    <li class="u-kv-item"><span class="u-kv-label">Датум испита</span><span>{{ vencanje.datum_ispita }}</span></li>
+                    {% endif %}
+                    {% if vencanje.hram %}
+                    <li class="u-kv-item"><span class="u-kv-label">Храм</span><span>{{ vencanje.hram }}{% if vencanje.hram.mesto %}, {{ vencanje.hram.mesto }}{% endif %}</span></li>
+                    {% endif %}
+                    {% if vencanje.svestenik %}
+                    <li class="u-kv-item"><span class="u-kv-label">Свештеник</span><span><a href="{% url 'svestenik_detail' uid=vencanje.svestenik.uid %}" class="u-link-primary">{{ vencanje.svestenik }}</a></span></li>
+                    {% endif %}
+                    <li class="u-kv-item"><span class="u-kv-label">Разрешење</span><span>{{ vencanje.razresenje|yesno:"Да,Не" }}</span></li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="detail-section">
+            <h2 class="detail-section__title">Запис</h2>
+            <div class="card">
+                <ul class="u-kv-list">
+                    <li class="u-kv-item"><span class="u-kv-label">Књига</span><span>{{ vencanje.knjiga }}</span></li>
+                    <li class="u-kv-item"><span class="u-kv-label">Страна</span><span>{{ vencanje.strana }}</span></li>
+                    <li class="u-kv-item"><span class="u-kv-label">Текући број</span><span>{{ vencanje.broj }}</span></li>
+                    {% if vencanje.godina_registracije %}
+                    <li class="u-kv-item"><span class="u-kv-label">Година регистрације</span><span>{{ vencanje.godina_registracije }}</span></li>
+                    {% endif %}
+                    {% if vencanje.primedba %}
+                    <li class="u-kv-item"><span class="u-kv-label">Примедба</span><span>{{ vencanje.primedba }}</span></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+    </section>
+
+    <!-- ============ CERTIFICATE PREVIEW ============ -->
+    <section class="tabs__panel">
+
 <div class="vencanica">
     <div class="vencanica-frame">
-
-        <!-- ============================================================
-        HEADER
-        ============================================================ -->
-
-        <!-- Књига / Страна / Текући број -->
         <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>
         <div class="venc-field-strana">{{ vencanje.strana }}</div>
         <div class="venc-field-tekuci">{{ vencanje.broj }}</div>
-
-        <!-- храма ___ епархије -->
         <div class="venc-field-hram">{{ vencanje.hram }}</div>
         <div class="venc-field-eparhija">Београдско-Карловачке</div>
-
-        <!-- У ___ за 20__ годину -->
-        <div class="venc-field-mesto">{{ vencanje.mesto_zenika }}</div>
+        <div class="venc-field-mesto">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}</div>
         <div class="venc-field-godina">{{ vencanje.datum|date:"y" }}</div>
-
-        <!-- ============================================================
-        MAIN
-        ============================================================ -->
-
-        <!-- 1: Име, презиме и занимање венчаних -->
         <div class="venc-table-field venc-field-ime_zenika">
-            <span>{{ vencanje.ime_zenika }} | {{ vencanje.zanimanje_zenika|lower }} | {{ vencanje.adresa_zenika }} | {{ vencanje.veroispovest_zenika|lower }}, {{ vencanje.narodnost_zenika|lower }}
+            <span>{{ vencanje.ime_zenika }} | {{ vencanje.zanimanje_zenika|lower }} | {{ vencanje.adresa_zenika }} | {{ vencanje.veroispovest_zenika|lower }}, {{ vencanje.narodnost_zenika|lower }}</span>
         </div>
         <div class="venc-table-field venc-field-ime_neveste">
             <span>{{ vencanje.ime_neveste }} | {{ vencanje.zanimanje_neveste|lower }} | {{ vencanje.adresa_neveste }} | {{ vencanje.veroispovest_neveste|lower }}, {{ vencanje.narodnost_neveste|lower }}</span>
         </div>
-
-        <!-- 2: Родитеља венчаних -->
         <div class="venc-table-field venc-field-roditelji_zenika">
             <span>{{ vencanje.svekar|default_if_none:"" }}</span>
             <span>{{ vencanje.svekrva|default_if_none:"" }}</span>
@@ -60,8 +198,6 @@
             <span>{{ vencanje.tast|default_if_none:"" }}</span>
             <span>{{ vencanje.tasta|default_if_none:"" }}</span>
         </div>
-
-        <!-- 3: Рођења венчаних -->
         <div class="venc-table-field venc-field-rodjenje_zenika">
             <span>{{ vencanje.datum_rodjenja_zenika|julian_date }}</span>
             <span class="venc-text-sm">{{ vencanje.mesto_rodjenja_zenika }}</span>
@@ -70,48 +206,29 @@
             <span>{{ vencanje.datum_rodjenja_neveste|julian_date }}</span>
             <span class="venc-text-sm">{{ vencanje.mesto_rodjenja_neveste }}</span>
         </div>
-
-        <!-- 4: У који брак ступају -->
         <div class="venc-table-field venc-field-brak_zenika">{{ vencanje.zenik_rb_brak }}</div>
         <div class="venc-table-field venc-field-brak_neveste">{{ vencanje.nevesta_rb_brak }}</div>
-
-        <!-- 5: Испитани и оглашени -->
         <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date }}</div>
-
-        <!-- 6: Датум венчања -->
         <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date }}</div>
-
-        <!-- 7: Место и храм -->
-        <div class="venc-table-field venc-field-mesto_hram">{{ vencanje.mesto_zenika }}, {{ vencanje.hram }}</div>
-
-        <!-- 8: Свештеник -->
+        <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}, {{ vencanje.hram }}</div>
         <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|default_if_none:"" }}</div>
-
-        <!-- 9: Сведоци (кум и стари сват) -->
         <div class="venc-table-field venc-field-svedoci">
             <span>{{ vencanje.kum|default_if_none:"" }}</span>
             <span>{{ vencanje.stari_svat|default_if_none:"" }}</span>
         </div>
-
-        <!-- 10: Разрешење -->
         <div class="venc-table-field venc-field-razresenje">{% if vencanje.razresenje %}Да{% else %}Не{% endif %}</div>
-
-        <!-- 11: Примедба -->
         <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|default_if_none:"" }}</div>
-
-        <!-- ============================================================
-        FOOTER
-        ============================================================ -->
         <div class="venc-field-footer_hram">{{ vencanje.hram }}</div>
         <div class="venc-field-footer_eparhija">Београдске</div>
-
         <div class="venc-field-footer_mesto">Београду</div>
         <div class="venc-field-footer_datum">{% now "j. F" %}</div>
         <div class="venc-field-footer_godina">{% now "y" %}</div>
         <div class="venc-field-footer_paroh">{% if vencanje.svestenik %}{{ vencanje.svestenik }}{% endif %}</div>
         <div class="venc-field-footer_parohija">{% if vencanje.svestenik %}{{ vencanje.svestenik.parohija }}{% endif %}</div>
-
     </div>
+</div>
+
+    </section>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Adds a reusable, CSS-only tabs component (`tabovi.css`) used to split the крштење and венчање detail pages into two views:

  • Подаци    — labeled, browsable card view of every field, grouped
                into sections (дете / родитељи / кум / крштење / запис;
                женик / невеста / родитељи / сведоци / венчање / запис).
                Every linked person is a full-text `u-link-primary`
                anchor; no trailing arrow icon — matches the link pattern
                used elsewhere in the app.

  • Крштеница / Венчаница  — the existing positioned-field replica of
                the official paper certificate. Stripped of the link
                arrows that used to clutter it; the data tab already
                exposes the same navigation more clearly.

Tabs component overview:

  .tabs (--segmented | --underline)  generic container
  .tabs__nav  + .tabs__tab           label-as-tab pattern
  .tabs__radio                       hidden but focusable; keyboard
                                     arrow-keys move between tabs
  .tabs__panel                       fade-in on switch (0.18s)
  .tabs__icon, .tabs__count          optional decorations

Panel visibility is positional: the Nth radio shows the Nth panel via `:has(.tabs__radio:nth-of-type(N):checked) > .tabs__panel:nth-of-type(N)`, so consumers don't need per-instance show/hide CSS. Works in all current browsers (Chrome 105+, Firefox 121+, Safari 15.4+). Active tab style matches the primary button (red fill, white text) so the segmented control reads as part of the same control language as the print button.

Also drops the literal "час" suffix from the Датум рођења row — time isn't meaningful for a birth-date display.