### PR TITLE
lists: toolbar + filter chips + infinite scroll

### DIFF
--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -4,7 +4,7 @@
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 0;
 }
 
 .stavka {
@@ -15,6 +15,7 @@
     align-items: center;
     padding: 12px 16px;
     border: 1px solid var(--color-border);
+    border-left: 3px solid transparent;
     border-radius: 12px;
     background: var(--color-surface);
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
@@ -23,7 +24,8 @@
 .stavka:hover {
     background-color: var(--color-surface-2);
     border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-border));
-    box-shadow: 0 8px 14px -6px rgba(0,0,0,0.15);
+    border-left: 3px solid var(--color-primary);
+    box-shadow: var(--shadow-hover);
     transform: translateY(-1px);
     cursor: pointer;
 }
@@ -35,10 +37,8 @@
 .stavka-veza {
     text-decoration: none;
     color: var(--color-text);
-    display: flex;
+    display: block;
     flex-grow: 1;
-    align-items: center;
-    gap: 10px;
     padding: 4px 0;
     cursor: pointer;
 }
@@ -133,28 +133,7 @@
     border-radius: 3px;
 }
 
-/* BEM aliases for lists and items */
-.list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
-.list__item {
-  list-style-type: none;
-  margin: 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  background: var(--color-surface);
-  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
-}
-.list__item:hover {
-  background-color: var(--color-surface-2);
-  border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-border));
-  box-shadow: 0 8px 14px -6px rgba(0,0,0,0.15);
-  transform: translateY(-1px);
-  cursor: pointer;
-}
-.list__link { text-decoration: none; color: var(--color-text); display: flex; flex-grow: 1; align-items: center; gap: 10px; padding: 4px 0; cursor: pointer; }
+
 
 /* Спискови */
 .header-container {
@@ -225,7 +204,7 @@
 
 /* Diskretno prugasto pozadinsko isticanje parnih redova */
 /* Remove zebra striping with card rows */
-.spisak .stavka:nth-child(even) { background-color: var(--color-surface); }
+.spisak .stavka:nth-child(even) { background-color: var(--color-surface-2); }
 
 /* Mobile-friendly list and filters */
 @media (max-width: 768px) {
@@ -242,7 +221,7 @@
     .stavka {
         flex-direction: column;
         align-items: flex-start;
-        gap: 10px;
+        gap: 0;
         padding: 16px;
     }
 
@@ -345,10 +324,406 @@
 .u-section-title {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 0;
     margin-bottom: var(--space-4);
 }
 
 .u-section-title--success {
     color: var(--color-success);
+}
+
+/* ==========================================================================
+   ICON BUTTON – compact square for action icons in lists
+   ========================================================================== */
+
+.stavka .button.button--primary {
+    width: 36px;
+    height: 36px;
+    min-width: 36px;
+    min-height: 36px;
+    padding: 0;
+    font-size: 14px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-2);
+}
+
+/* ==========================================================================
+   EMPTY STATE – nicer look when no records
+   ========================================================================== */
+
+.spisak li:only-child:not(.stavka) {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--color-text-muted);
+    font-style: italic;
+    background: var(--color-surface-2);
+    border-radius: 12px;
+    border: 1px dashed var(--color-border);
+}
+
+}
+
+/* ==========================================================================
+   LIST CONTROLS BAR (sort + per-page dropdowns)
+   ========================================================================== */
+
+.list-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+    padding: 6px 0;
+    flex-wrap: wrap;
+}
+
+.list-controls__group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.list-controls__group--right {
+    margin-left: auto;
+}
+
+.list-controls__label {
+    font-size: 13px;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+.list-controls__select {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 7px 32px 7px 14px;
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23888%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
+    font-family: inherit;
+    min-height: 36px;
+}
+
+.list-controls__select:hover {
+    background-color: var(--color-surface-2);
+    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
+}
+
+.list-controls__select:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+
+@media (max-width: 640px) {
+    .list-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .list-controls__group--right {
+        margin-left: 0;
+    }
+    .list-controls__select {
+        width: 100%;
+    }
+}
+
+/* Flex layout for items with structured metadata (parohijani) */
+.stavka-veza--meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    row-gap: 2px;
+}
+
+/* ==========================================================================
+   TWO-LINE LIST ITEM LAYOUT
+   ========================================================================== */
+
+.stavka__primary {
+    display: block;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 1.3;
+}
+
+.stavka__secondary {
+    display: block;
+    font-size: 13px;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+    margin-top: 2px;
+}
+
+.stavka__secondary:empty {
+    display: none;
+}
+
+/* ==========================================================================
+   PRINT BUTTON – show only on row hover
+   ========================================================================== */
+
+.stavka .button.button--primary {
+    width: 36px;
+    height: 36px;
+    min-width: 36px;
+    min-height: 36px;
+    padding: 0;
+    font-size: 14px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-2);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.stavka:hover .button.button--primary {
+    opacity: 1;
+}
+
+@media (hover: none) {
+    .stavka .button.button--primary {
+        opacity: 1;
+    }
+}
+
+/* ==========================================================================
+   SEARCH RESULTS PAGE
+   ========================================================================== */
+
+.search-section {
+    margin-bottom: var(--space-5);
+}
+
+.search-show-all {
+    display: inline-block;
+    margin-top: var(--space-2);
+    font-size: 14px;
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.search-show-all:hover {
+    text-decoration: underline;
+}
+
+
+/* ==========================================================================
+   LIST TOOLBAR (search + sort + per-page in one row)
+   ========================================================================== */
+
+.list-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 8px 0 10px;
+    flex-wrap: wrap;
+}
+
+.list-toolbar__search {
+    position: relative;
+    flex: 1 1 320px;
+    min-width: 0;
+}
+
+.list-toolbar__search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-muted);
+    font-size: 14px;
+    pointer-events: none;
+}
+
+input.list-toolbar__search-input {
+    width: 100%;
+    padding: 8px 12px 8px 36px;
+    font-size: 14px;
+    line-height: 20px;
+    min-height: 36px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    transition: border-color 0.15s, box-shadow 0.15s;
+    font-family: inherit;
+    box-shadow: none;
+    margin: 0;
+}
+
+input.list-toolbar__search-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+
+input.list-toolbar__search-input::placeholder {
+    color: var(--color-text-muted);
+}
+
+.list-toolbar__select {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 7px 32px 7px 14px;
+    min-height: 36px;
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23888%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
+    font-family: inherit;
+}
+
+.list-toolbar__select:hover {
+    background-color: var(--color-surface-2);
+    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
+}
+
+.list-toolbar__select:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+
+@media (max-width: 640px) {
+    .list-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .list-toolbar__search,
+    .list-toolbar__select {
+        width: 100%;
+    }
+}
+
+/* ==========================================================================
+   FILTER CHIPS
+   ========================================================================== */
+
+.filter-chips {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 0 0 12px;
+}
+
+.filter-chips__label {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 12px;
+    font-size: 13px;
+    line-height: 18px;
+    color: var(--color-text);
+    background: color-mix(in oklab, var(--color-primary) 10%, var(--color-surface));
+    border: 1px solid color-mix(in oklab, var(--color-primary) 30%, var(--color-border));
+    border-radius: 999px;
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.filter-chip:hover {
+    background: color-mix(in oklab, var(--color-primary) 18%, var(--color-surface));
+    border-color: var(--color-primary);
+}
+
+.filter-chip__label {
+    color: var(--color-text-muted);
+    font-size: 12px;
+}
+
+.filter-chip__value {
+    font-weight: 600;
+}
+
+.filter-chip__remove {
+    font-size: 11px;
+    margin-left: 2px;
+    opacity: 0.7;
+}
+
+.filter-chip:hover .filter-chip__remove {
+    opacity: 1;
+}
+
+/* ==========================================================================
+   SCROLL SENTINEL (infinite scroll loading indicator)
+   ========================================================================== */
+
+.scroll-sentinel {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 24px 0;
+    min-height: 48px;
+    color: var(--color-text-muted);
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.scroll-sentinel--loading {
+    opacity: 1;
+}
+
+.scroll-sentinel__spinner i {
+    font-size: 18px;
+}
+
+/* Hide server-rendered pagination when JS-driven infinite scroll is active */
+body.has-infinite-scroll .pagination {
+    display: none;
+}
+
+/* Page title with count suffix */
+.u-page-title__count {
+    color: var(--color-text-muted);
+    font-weight: 400;
+    font-size: 0.7em;
+    margin-left: 4px;
+}
+
+/* Empty list state for spisak */
+.spisak__empty {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--color-text-muted);
+    font-style: italic;
+    background: var(--color-surface-2);
+    border-radius: 12px;
+    border: 1px dashed var(--color-border);
+    list-style: none;
 }

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -87,5 +87,83 @@
         }
       })();
     </script>
+    <script>
+      // Infinite scroll for list pages
+      (function() {
+        const list = document.getElementById('spisak-list');
+        const sentinel = document.getElementById('scroll-sentinel');
+        if (!list || !sentinel) return;
+
+        // Hide the server-rendered pagination when JS is active
+        document.body.classList.add('has-infinite-scroll');
+
+        let nextPage = null;
+        let loading = false;
+        let exhausted = false;
+
+        function readNextPage() {
+          const marker = list.querySelector('.next-page-marker');
+          if (marker) {
+            nextPage = marker.getAttribute('data-next-page');
+            marker.remove();
+          } else {
+            nextPage = null;
+            exhausted = true;
+          }
+        }
+
+        readNextPage();
+        if (exhausted) {
+          sentinel.style.display = 'none';
+          return;
+        }
+
+        async function loadMore() {
+          if (loading || exhausted || !nextPage) return;
+          loading = true;
+          sentinel.classList.add('scroll-sentinel--loading');
+
+          const url = new URL(window.location.href);
+          url.searchParams.set('page', nextPage);
+
+          try {
+            const resp = await fetch(url.toString(), {
+              headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            const html = await resp.text();
+            const tpl = document.createElement('template');
+            tpl.innerHTML = html.trim();
+
+            // Append new <li> items
+            const items = tpl.content.querySelectorAll('li.stavka');
+            items.forEach(li => list.appendChild(li));
+
+            // Read the next page marker from the response
+            const marker = tpl.content.querySelector('.next-page-marker');
+            if (marker) {
+              nextPage = marker.getAttribute('data-next-page');
+            } else {
+              nextPage = null;
+              exhausted = true;
+              sentinel.style.display = 'none';
+            }
+          } catch (err) {
+            console.error('infinite scroll load failed', err);
+            exhausted = true;
+            sentinel.style.display = 'none';
+          } finally {
+            loading = false;
+            sentinel.classList.remove('scroll-sentinel--loading');
+          }
+        }
+
+        const io = new IntersectionObserver(entries => {
+          if (entries.some(e => e.isIntersecting)) loadMore();
+        }, { rootMargin: '400px 0px' });
+
+        io.observe(sentinel);
+      })();
+    </script>
   </body>
 </html>

--- a/crkva/registar/templates/registar/_filter_chips.html
+++ b/crkva/registar/templates/registar/_filter_chips.html
@@ -1,0 +1,10 @@
+{% if upit %}
+<div class="filter-chips">
+    <span class="filter-chips__label">Активно:</span>
+    <a href="?{% for k, v in request.GET.items %}{% if k != 'search' and k != 'page' %}{{ k }}={{ v }}&amp;{% endif %}{% endfor %}" class="filter-chip" data-tooltip="Уклони филтер">
+        <span class="filter-chip__label">претрага:</span>
+        <span class="filter-chip__value">{{ upit }}</span>
+        <i class="fa-solid fa-xmark filter-chip__remove"></i>
+    </a>
+</div>
+{% endif %}

--- a/crkva/registar/templates/registar/_list_toolbar.html
+++ b/crkva/registar/templates/registar/_list_toolbar.html
@@ -1,0 +1,14 @@
+<form method="get" action="" class="list-toolbar">
+    <div class="list-toolbar__search">
+        <i class="fa-solid fa-magnifying-glass list-toolbar__search-icon"></i>
+        <input type="search" name="search" value="{{ upit }}" placeholder="Претражи..." class="list-toolbar__search-input" autocomplete="off" aria-label="Претрага">
+    </div>
+    {% if sort_options %}
+    <select name="sort" class="list-toolbar__select" onchange="this.form.submit()" data-tooltip="Сортирање">
+        {% for value, label in sort_options %}
+        <option value="{{ value }}"{% if current_sort == value %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+    {% endif %}
+
+</form>

--- a/crkva/registar/templates/registar/_stavka_domacinstva.html
+++ b/crkva/registar/templates/registar/_stavka_domacinstva.html
@@ -1,0 +1,45 @@
+{% load marker_filter %}
+{% for domacinstvo in domacinstva %}
+<li class="stavka stavka--expandable" data-id="{{ domacinstvo.uid }}">
+    <div class="stavka__header" onclick="toggleStavka(this)">
+        <div class="stavka__toggle">
+            <i class="fa-solid fa-chevron-right"></i>
+        </div>
+        <div class="stavka-veza">
+            <span class="stavka__primary">{{ domacinstvo.domacin.ime|markiraj:upit|safe }} {{ domacinstvo.domacin.prezime|markiraj:upit|safe }}</span>
+            <span class="stavka__secondary">{% if domacinstvo.slava %}{{ domacinstvo.slava }} &middot; {% endif %}{% if domacinstvo.adresa %}{{ domacinstvo.adresa }} &middot; {% endif %}{{ domacinstvo.ukucani.count }} чл.</span>
+        </div>
+    </div>
+    <div class="stavka__expandable-section">
+        {% with ukucani=domacinstvo.ukucani.all %}
+        {% if ukucani %}
+        {% for ukucanin in ukucani %}
+        <div class="stavka__member {% if ukucanin.preminuo %}stavka__member--deceased{% endif %}">
+            <div class="stavka__member-name">
+                {% if ukucanin.osoba %}
+                <a href="{% url 'parohijan_detail' uid=ukucanin.osoba.uid %}">
+                    {{ ukucanin.osoba.ime }} {{ ukucanin.osoba.prezime }}
+                </a>
+                {% else %}
+                {{ ukucanin.ime_ukucana }}
+                {% endif %}
+                {% if ukucanin.preminuo %} <span class="u-text-muted"><i class="fa-solid fa-cross"></i></span>{% endif %}
+            </div>
+            <div class="stavka__member-role">
+                <span class="stavka__member-role-badge">{{ ukucanin.get_uloga_display }}</span>
+            </div>
+        </div>
+        {% endfor %}
+        {% else %}
+        <p class="u-text-muted u-mt-3">Нема података о члановима.</p>
+        {% endif %}
+        {% endwith %}
+        <a href="{% url 'domacinstvo_detail' uid=domacinstvo.uid %}" class="button button--primary u-mt-3">
+            Детаљи
+        </a>
+    </div>
+</li>
+{% empty %}
+{% if page_obj.number == 1 %}<li class="spisak__empty">Нема уписаних домаћинстава у бази.</li>{% endif %}
+{% endfor %}
+{% if page_obj.has_next %}<div class="next-page-marker" data-next-page="{{ page_obj.next_page_number }}"></div>{% endif %}

--- a/crkva/registar/templates/registar/_stavka_krstenja.html
+++ b/crkva/registar/templates/registar/_stavka_krstenja.html
@@ -1,0 +1,13 @@
+{% load marker_filter %}
+{% for krstenje in krstenja %}
+<li class="stavka">
+    <a href="{% url 'krstenje_detail' uid=krstenje.uid %}" class="stavka-veza">
+        <span class="stavka__primary">{{ krstenje.ime_deteta|markiraj:upit|safe }} {{ krstenje.prezime_oca|markiraj:upit|safe }}</span>
+        <span class="stavka__secondary">{{ krstenje.datum }} &middot; {{ krstenje.ime_oca|markiraj:upit|safe }} и {{ krstenje.ime_majke|markiraj:upit|safe }} {{ krstenje.prezime_majke|markiraj:upit|safe }}</span>
+    </a>
+    <a href="{% url 'krstenje_pdf' uid=krstenje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+</li>
+{% empty %}
+{% if page_obj.number == 1 %}<li class="spisak__empty">Нема уноса крштења у бази.</li>{% endif %}
+{% endfor %}
+{% if page_obj.has_next %}<div class="next-page-marker" data-next-page="{{ page_obj.next_page_number }}"></div>{% endif %}

--- a/crkva/registar/templates/registar/_stavka_parohijana.html
+++ b/crkva/registar/templates/registar/_stavka_parohijana.html
@@ -1,0 +1,13 @@
+{% load marker_filter %}
+{% for parohijan in parohijani %}
+<li class="stavka">
+    <a href="{% url 'parohijan_detail' uid=parohijan.uid %}" class="stavka-veza">
+        <span class="stavka__primary">{{ parohijan.ime|markiraj:upit|safe }} {{ parohijan.prezime|markiraj:upit|safe }}</span>
+        <span class="stavka__secondary">{% if parohijan.datum_rodjenja %}{{ parohijan.datum_rodjenja }}{% endif %}{% if parohijan.adresa %}{% if parohijan.datum_rodjenja %} &middot; {% endif %}{{ parohijan.adresa }}{% endif %}</span>
+    </a>
+    <a href="{% url 'parohijan_pdf' uid=parohijan.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+</li>
+{% empty %}
+{% if page_obj.number == 1 %}<li class="spisak__empty">Нема уписаних парохијана у бази.</li>{% endif %}
+{% endfor %}
+{% if page_obj.has_next %}<div class="next-page-marker" data-next-page="{{ page_obj.next_page_number }}"></div>{% endif %}

--- a/crkva/registar/templates/registar/_stavka_svestenika.html
+++ b/crkva/registar/templates/registar/_stavka_svestenika.html
@@ -1,0 +1,13 @@
+{% load marker_filter %}
+{% for svestenik in svestenici %}
+<li class="stavka">
+    <a href="{% url 'svestenik_detail' uid=svestenik.uid %}" class="stavka-veza">
+        <span class="stavka__primary">{{ svestenik.ime|markiraj:upit }} {{ svestenik.prezime|markiraj:upit }}</span>
+        <span class="stavka__secondary">{{ svestenik.zvanje }}{% if svestenik.parohija %} &middot; {{ svestenik.parohija }}{% endif %}</span>
+    </a>
+    <a href="{% url 'svestenik_pdf' uid=svestenik.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+</li>
+{% empty %}
+{% if page_obj.number == 1 %}<li class="spisak__empty">Нема уноса свештеника у бази.</li>{% endif %}
+{% endfor %}
+{% if page_obj.has_next %}<div class="next-page-marker" data-next-page="{{ page_obj.next_page_number }}"></div>{% endif %}

--- a/crkva/registar/templates/registar/_stavka_vencanja.html
+++ b/crkva/registar/templates/registar/_stavka_vencanja.html
@@ -1,0 +1,13 @@
+{% load marker_filter %}
+{% for vencanje in vencanja %}
+<li class="stavka">
+    <a href="{% url 'vencanje_detail' uid=vencanje.uid %}" class="stavka-veza">
+        <span class="stavka__primary">{{ vencanje.ime_zenika|markiraj:upit|safe }} и {{ vencanje.ime_neveste|markiraj:upit|safe }} {{ vencanje.prezime_zenika|markiraj:upit|safe }}</span>
+        <span class="stavka__secondary">{{ vencanje.datum }}</span>
+    </a>
+    <a href="{% url 'vencanje_pdf' uid=vencanje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+</li>
+{% empty %}
+{% if page_obj.number == 1 %}<li class="spisak__empty">Нема уноса венчања у бази.</li>{% endif %}
+{% endfor %}
+{% if page_obj.has_next %}<div class="next-page-marker" data-next-page="{{ page_obj.next_page_number }}"></div>{% endif %}

--- a/crkva/registar/templates/registar/spisak_domacinstva.html
+++ b/crkva/registar/templates/registar/spisak_domacinstva.html
@@ -1,126 +1,23 @@
 {% extends "base.html" %}
-{% load marker_filter phone_filters %}
+{% load marker_filter %}
 
 {% block content %}
 <div class="u-page-header">
-    <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
+    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">Домаћинства ({{ page_obj.paginator.count }})</h1>
-    <form method="get" action="" class="form-container">
-        <div>
-            {% for field in form.visible_fields %}
-                {{ field }}
-            {% endfor %}
-            <input type="submit" class="hidden-submit">
-        </div>
-    </form>
+    <h1 class="u-page-title">Домаћинства <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
 </div>
-
-<ul class="spisak">
-    {% for domacinstvo in domacinstva %}
-        <li class="stavka stavka--expandable" data-id="{{ domacinstvo.uid }}">
-            <div class="stavka__header" onclick="toggleStavka(this)">
-                <div class="stavka__toggle">
-                    <i class="fa-solid fa-chevron-right"></i>
-                </div>
-                <div class="stavka__content">
-                    <div class="u-font-medium u-min-w-200">
-                        <i class="fa-solid fa-house u-icon-muted u-mr-2"></i>
-                        {{ domacinstvo.domacin.ime|markiraj:upit|safe }} {{ domacinstvo.domacin.prezime|markiraj:upit|safe }}
-                    </div>
-                    {% if domacinstvo.adresa and domacinstvo.adresa.ulica %}
-                    <div class="u-text-muted u-text-small">
-                        📍 {{ domacinstvo.adresa.ulica.naziv|markiraj:upit|safe }} {{ domacinstvo.adresa.broj }}
-                    </div>
-                    {% endif %}
-                    {% if domacinstvo.tel_mobilni or domacinstvo.tel_fiksni %}
-                    <div class="u-text-muted u-text-small">
-                        {% if domacinstvo.tel_mobilni %}
-                        <a href="tel:{{ domacinstvo.tel_mobilni|tel_link }}" class="u-link-primary">
-                            <i class="fa-solid {{ domacinstvo.tel_mobilni|phone_icon }}"></i>
-                            {{ domacinstvo.tel_mobilni|format_phone }}
-                        </a>
-                        {% elif domacinstvo.tel_fiksni %}
-                        <a href="tel:{{ domacinstvo.tel_fiksni|tel_link }}" class="u-link-primary">
-                            <i class="fa-solid {{ domacinstvo.tel_fiksni|phone_icon }}"></i>
-                            {{ domacinstvo.tel_fiksni|format_phone }}
-                        </a>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-                    {% if domacinstvo.slava %}
-                    <div class="u-badge u-badge--slava">
-                        {{ domacinstvo.slava }}
-                    </div>
-                    {% endif %}
-                    <div class="u-text-muted u-text-small">
-                        <i class="fa-solid fa-users u-mr-2"></i>
-                        {{ domacinstvo.ukucani.count }} чл.
-                    </div>
-                </div>
-            </div>
-            <div class="stavka__expandable-section">
-                {% with ukucani=domacinstvo.ukucani.all %}
-                    {% if ukucani %}
-                        <div class="u-mt-3">
-                            <strong class="u-label u-mb-3 u-inline-block">Чланови домаћинства:</strong>
-                            {% for ukucanin in ukucani %}
-                                <div class="stavka__member {% if ukucanin.preminuo %}stavka__member--deceased{% endif %}">
-                                    <div class="stavka__member-name">
-                                        {% if ukucanin.osoba %}
-                                            <a href="{% url 'parohijan_detail' uid=ukucanin.osoba.uid %}">
-                                                {{ ukucanin.osoba.ime }} {{ ukucanin.osoba.prezime }}
-                                            </a>
-                                        {% else %}
-                                            {{ ukucanin.ime_ukucana }}
-                                        {% endif %}
-                                        {% if ukucanin.preminuo %} <span class="u-text-muted">†</span>{% endif %}
-                                    </div>
-                                    <div class="stavka__member-role">
-                                        <span class="stavka__member-role-badge">
-                                            {{ ukucanin.get_uloga_display }}
-                                        </span>
-                                    </div>
-                                </div>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <p class="u-text-muted u-mt-3">Нема података о члановима.</p>
-                    {% endif %}
-                {% endwith %}
-                <a href="{% url 'domacinstvo_detail' uid=domacinstvo.uid %}" class="button button--primary u-mt-3">
-                    <i class="fa-solid fa-arrow-right"></i> Детаљни приказ
-                </a>
-            </div>
-        </li>
-    {% empty %}
-        <li>Нема уписаних домаћинстава у бази.</li>
-    {% endfor %}
+{% include "registar/_list_toolbar.html" %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include "registar/_stavka_domacinstva.html" %}
 </ul>
-
-<div class="pagination">
-    <span class="step-links">
-        {% if page_obj.has_previous %}
-            <a href="?page=1{% if upit %}&search={{ upit }}{% endif %}" class="page-link">&laquo; прва</a>
-            <a href="?page={{ page_obj.previous_page_number }}{% if upit %}&search={{ upit }}{% endif %}" class="page-link">претходна</a>
-        {% endif %}
-
-        <span class="current">
-            страна {{ page_obj.number }} од {{ page_obj.paginator.num_pages }}.
-        </span>
-
-        {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}{% if upit %}&search={{ upit }}{% endif %}" class="page-link">следећа</a>
-            <a href="?page={{ page_obj.paginator.num_pages }}{% if upit %}&search={{ upit }}{% endif %}" class="page-link">последња &raquo;</a>
-        {% endif %}
-    </span>
-</div>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
 
 <script>
-    function toggleStavka(header) {
-        const stavka = header.closest('.stavka');
-        stavka.classList.toggle('stavka--expanded');
-    }
+function toggleStavka(header) {
+    header.closest('.stavka').classList.toggle('stavka--expanded');
+}
 </script>
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_krstenja.html
+++ b/crkva/registar/templates/registar/spisak_krstenja.html
@@ -3,51 +3,15 @@
 
 {% block content %}
 <div class="u-page-header">
-        <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
-            <i class="fa-solid fa-arrow-left"></i>
-        </a>
-<h1 class="u-page-title">Крштења ({{ page_obj.paginator.count }})</h1>
-        <form method="get" action="" class="form-container">
-            <div>
-                {% for field in form.visible_fields %}
-                    {{ field }}
-                {% endfor %}
-                <input type="submit" class="hidden-submit">
-            </div>
-        </form>
-    </div>
-    <ul class="spisak">
-        {% for krstenje in krstenja %}
-            <li class="stavka">
-                <a href="{% url 'krstenje_detail' uid=krstenje.uid %}" class="stavka-veza">
-                    {{ krstenje.datum }}:
-                    {{ krstenje.ime_deteta|markiraj:upit|safe }} {{ krstenje.prezime_oca|markiraj:upit|safe }}
-                    ({{ krstenje.ime_oca|markiraj:upit|safe }} и {{ krstenje.ime_majke|markiraj:upit|safe }} {{ krstenje.prezime_majke|markiraj:upit|safe }})
-                </a>
-                    <a href="{% url 'krstenje_pdf' uid=krstenje.uid %}" target="_blank" style="text-decoration: none; margin-left: 10px;">
-<button class="button button--primary" type="button">Штампај</button>
-                    </a>
-            </li>
-        {% empty %}
-            <li>Нема уноса крштења у бази.</li>
-        {% endfor %}
-    </ul>
-
-    <div class="pagination">
-        <span class="step-links">
-            {% if page_obj.has_previous %}
-                <a href="?page=1{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">&laquo; прва</a>
-                <a href="?page={{ page_obj.previous_page_number }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">претходна</a>
-            {% endif %}
-
-            <span class="current">
-                страна {{ page_obj.number }} од {{ page_obj.paginator.num_pages }}.
-            </span>
-
-            {% if page_obj.has_next %}
-                <a href="?page={{ page_obj.next_page_number }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">следеђа</a>
-                <a href="?page={{ page_obj.paginator.num_pages }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">последња &raquo;</a>
-            {% endif %}
-        </span>
-    </div>
+    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">Крштења <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+</div>
+{% include "registar/_list_toolbar.html" %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include "registar/_stavka_krstenja.html" %}
+</ul>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_parohijana.html
+++ b/crkva/registar/templates/registar/spisak_parohijana.html
@@ -3,82 +3,15 @@
 
 {% block content %}
 <div class="u-page-header">
-        <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
-            <i class="fa-solid fa-arrow-left"></i>
-        </a>
-<h1 class="u-page-title">Парохијани ({{ page_obj.paginator.count }})</h1>
-        <form method="get" action="" class="form-container">
-            <div>
-                {% for field in form.visible_fields %}
-                    {{ field }}
-                {% endfor %}
-                <input type="submit" class="hidden-submit">
-            </div>
-        </form>
-    </div>
-
-    <ul class="spisak">
-        {% for parohijan in parohijani %}
-            <li class="stavka">
-                <a href="{% url 'parohijan_detail' uid=parohijan.uid %}" class="stavka-veza">
-                    <span class="u-font-medium">
-                        {{ parohijan.ime|markiraj:upit|safe }} {{ parohijan.prezime|markiraj:upit|safe }}
-                    </span>
-                    {% if parohijan.datum_rodjenja %}
-                    <span class="u-text-secondary u-text-small">
-                        {{ parohijan.datum_rodjenja }}
-                    </span>
-                    {% endif %}
-                    {% if parohijan.adresa %}
-                    <span class="u-text-secondary u-text-small">
-                        📍 {{ parohijan.adresa }}
-                    </span>
-                    {% endif %}
-                    {% if parohijan.tel_mobilni or parohijan.tel_fiksni %}
-                    <span class="u-text-secondary u-text-small">
-                        {% if parohijan.tel_mobilni %}
-                        <a href="tel:{{ parohijan.tel_mobilni|tel_link }}" class="u-link-primary" onclick="event.stopPropagation();">
-                            <i class="fa-solid {{ parohijan.tel_mobilni|phone_icon }}"></i>
-                            {{ parohijan.tel_mobilni|format_phone }}
-                        </a>
-                        {% elif parohijan.tel_fiksni %}
-                        <a href="tel:{{ parohijan.tel_fiksni|tel_link }}" class="u-link-primary" onclick="event.stopPropagation();">
-                            <i class="fa-solid {{ parohijan.tel_fiksni|phone_icon }}"></i>
-                            {{ parohijan.tel_fiksni|format_phone }}
-                        </a>
-                        {% endif %}
-                    </span>
-                    {% endif %}
-                    {% if parohijan.slava %}
-                    <span class="u-badge u-badge--slava">
-                        {{ parohijan.slava }}
-                    </span>
-                    {% endif %}
-                </a>
-                <a href="{% url 'parohijan_pdf' uid=parohijan.uid %}" target="_blank" class="u-link-primary u-ml-3">
-                    <button class="button button--primary" type="button">Штампај</button>
-                </a>
-            </li>
-        {% empty %}
-            <li>Нема уписаних парохијана у бази.</li>
-        {% endfor %}
-    </ul>
-
-    <div class="pagination">
-        <span class="step-links">
-            {% if page_obj.has_previous %}
-                <a href="?page=1" class="page-link">&laquo; прва</a>
-                <a href="?page={{ page_obj.previous_page_number }}" class="page-link">претходна</a>
-            {% endif %}
-
-            <span class="current">
-                страна {{ page_obj.number }} од {{ page_obj.paginator.num_pages }}.
-            </span>
-
-            {% if page_obj.has_next %}
-                <a href="?page={{ page_obj.next_page_number }}" class="page-link">следеђа</a>
-                <a href="?page={{ page_obj.paginator.num_pages }}" class="page-link">последња &raquo;</a>
-            {% endif %}
-        </span>
-    </div>
+    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">Парохијани <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+</div>
+{% include "registar/_list_toolbar.html" %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include "registar/_stavka_parohijana.html" %}
+</ul>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_svestenika.html
+++ b/crkva/registar/templates/registar/spisak_svestenika.html
@@ -3,49 +3,15 @@
 
 {% block content %}
 <div class="u-page-header">
-        <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
-            <i class="fa-solid fa-arrow-left"></i>
-        </a>
-<h1 class="u-page-title">Свештеници</h1>
-        <form method="get" action="" class="form-container">
-            <div>
-                {% for field in form.visible_fields %}
-                    {{ field }}
-                {% endfor %}
-                <input type="submit" class="hidden-submit">
-            </div>
-        </form>
-    </div>
-    <ul class="spisak">
-        {% for svestenik in svestenici %}
-            <li class="stavka">
-                <a href="{% url 'svestenik_detail' uid=svestenik.uid %}" class="stavka-veza">
-                    {{ svestenik.ime|markiraj:upit }} {{ svestenik.prezime|markiraj:upit }}, {{ svestenik.zvanje|markiraj:upit }}
-                </a>
-                <a href="{% url 'svestenik_pdf' uid=svestenik.uid %}" target="_blank" style="text-decoration: none; margin-left: 10px;">
-<button class="button button--primary" type="button">Штампај</button>
-                </a>
-            </li>
-        {% empty %}
-            <li>Нема уноса свештеника у бази.</li>
-        {% endfor %}
-    </ul>
-
-    <div class="pagination">
-        <span class="step-links">
-            {% if page_obj.has_previous %}
-                <a href="?page=1" class="page-link">&laquo; прва</a>
-                <a href="?page={{ page_obj.previous_page_number }}" class="page-link">претходна</a>
-            {% endif %}
-
-            <span class="current">
-                страна {{ page_obj.number }} од {{ page_obj.paginator.num_pages }}.
-            </span>
-
-            {% if page_obj.has_next %}
-                <a href="?page={{ page_obj.next_page_number }}" class="page-link">следеђа</a>
-                <a href="?page={{ page_obj.paginator.num_pages }}" class="page-link">последња &raquo;</a>
-            {% endif %}
-        </span>
-    </div>
+    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">Свештеници <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+</div>
+{% include "registar/_list_toolbar.html" %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include "registar/_stavka_svestenika.html" %}
+</ul>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_vencanja.html
+++ b/crkva/registar/templates/registar/spisak_vencanja.html
@@ -3,52 +3,15 @@
 
 {% block content %}
 <div class="u-page-header">
-        <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
-            <i class="fa-solid fa-arrow-left"></i>
-        </a>
-<h1 class="u-page-title">Венчања ({{ page_obj.paginator.count }})</h1>
-        <form method="get" action="" class="form-container">
-            <div>
-                {% for field in form.visible_fields %}
-                    {{ field }}
-                {% endfor %}
-                <input type="submit" class="hidden-submit">
-            </div>
-        </form>
-    </div>
-    <ul class="spisak">
-        {% for vencanje in vencanja %}
-            <li class="stavka">
-                <a href="{% url 'vencanje_detail' uid=vencanje.uid %}" class="stavka-veza">
-                    {{ vencanje.datum }}:
-                    {{ vencanje.ime_zenika|markiraj:upit|safe }}
-                    и
-                    {{ vencanje.ime_neveste|markiraj:upit|safe }} {{ vencanje.prezime_zenika|markiraj:upit|safe }}
-                </a>
-                        <a href="{% url 'vencanje_pdf' uid=vencanje.uid %}" target="_blank" style="text-decoration: none; margin-left: 10px;">
-<button class="button button--primary" type="button">Штампај</button>
-                        </a>
-            </li>
-        {% empty %}
-            <li>Нема уноса венчања у бази.</li>
-        {% endfor %}
-    </ul>
-
-    <div class="pagination">
-        <span class="step-links">
-            {% if page_obj.has_previous %}
-                <a href="?page=1{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">&laquo; прва</a>
-                <a href="?page={{ page_obj.previous_page_number }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">претходна</a>
-            {% endif %}
-
-            <span class="current">
-                страна {{ page_obj.number }} од {{ page_obj.paginator.num_pages }}.
-            </span>
-
-            {% if page_obj.has_next %}
-                <a href="?page={{ page_obj.next_page_number }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">следеђа</a>
-                <a href="?page={{ page_obj.paginator.num_pages }}{% for key, value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="page-link">последња &raquo;</a>
-            {% endif %}
-        </span>
-    </div>
+    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">Венчања <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+</div>
+{% include "registar/_list_toolbar.html" %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include "registar/_stavka_vencanja.html" %}
+</ul>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
 {% endblock %}

--- a/crkva/registar/views/domacinstvo_view.py
+++ b/crkva/registar/views/domacinstvo_view.py
@@ -2,71 +2,33 @@
 Модул за приказ домаћинстава и њихових чланова.
 """
 
-from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, ListView
-from registar.forms import SearchForm
 from registar.models import Domacinstvo
-from registar.utils import get_query_variants
+from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
 
 
-class SpisakDomacinsta(ListView):
+class SpisakDomacinsta(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
     """Приказује списак домаћинстава са могућношћу претраге и пагинације."""
 
     model = Domacinstvo
     template_name = "registar/spisak_domacinstva.html"
+    partial_template_name = "registar/_stavka_domacinstva.html"
     context_object_name = "domacinstva"
     paginate_by = 20
+    search_fields = ["domacin__ime", "domacin__prezime", "adresa__ulica"]
+    sort_options = [
+        ("domacin__prezime", "Презиме А-Ш"),
+        ("-domacin__prezime", "Презиме Ш-А"),
+    ]
+    ordering = ["domacin__prezime", "domacin__ime"]
 
     def get_queryset(self):
-        """Филтрира домаћинства на основу унетог појма у форми за претрагу."""
-        form = SearchForm(data=self.request.GET)
-        if form.is_valid():
-            query = form.cleaned_data.get("search", "")
-            if not query:
-                return (
-                    Domacinstvo.objects.select_related(
-                        "domacin", "adresa", "adresa__ulica", "slava"
-                    )
-                    .prefetch_related("ukucani", "ukucani__osoba")
-                    .all()
-                )
-            variants = get_query_variants(query)
-            q = None
-            for v in variants:
-                clause = (
-                    Q(domacin__ime__icontains=v)
-                    | Q(domacin__prezime__icontains=v)
-                    | Q(adresa__ulica__naziv__icontains=v)
-                )
-                q = clause if q is None else (q | clause)
-            return (
-                Domacinstvo.objects.select_related(
-                    "domacin", "adresa", "adresa__ulica", "slava"
-                )
-                .prefetch_related("ukucani", "ukucani__osoba")
-                .filter(q)
-                if q is not None
-                else Domacinstvo.objects.select_related(
-                    "domacin", "adresa", "adresa__ulica", "slava"
-                )
-                .prefetch_related("ukucani", "ukucani__osoba")
-                .all()
-            )
-        return (
-            Domacinstvo.objects.select_related(
-                "domacin", "adresa", "adresa__ulica", "slava"
-            )
+        return self.get_search_queryset(
+            Domacinstvo.objects.select_related("domacin", "adresa", "slava")
             .prefetch_related("ukucani", "ukucani__osoba")
             .all()
         )
-
-    def get_context_data(self, **kwargs):
-        """Додаје форму за претрагу у контекст шаблона."""
-        context = super().get_context_data(**kwargs)
-        context["form"] = SearchForm(data=self.request.GET)
-        context["upit"] = self.request.GET.get("search", "")
-        return context
 
 
 class PrikazDomacinstva(DetailView):
@@ -82,7 +44,7 @@ class PrikazDomacinstva(DetailView):
         uid = self.kwargs.get(self.pk_url_kwarg)
         return get_object_or_404(
             Domacinstvo.objects.select_related(
-                "domacin", "adresa", "adresa__ulica", "slava"
+                "domacin", "adresa", "slava"
             ).prefetch_related("ukucani", "ukucani__osoba"),
             uid=uid,
         )
@@ -91,7 +53,6 @@ class PrikazDomacinstva(DetailView):
         """Додаје укућане у контекст."""
         context = super().get_context_data(**kwargs)
         domacinstvo = self.object
-        # Separate active and deceased ukucani
         ukucani = domacinstvo.ukucani.all()
         context["ukucani_zivi"] = [u for u in ukucani if not u.preminuo]
         context["ukucani_preminuli"] = [u for u in ukucani if u.preminuo]

--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -5,13 +5,22 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
-from django_filters.views import FilterView
-from registar.filters import KrstenjeFilter
-from registar.forms import KrstenjeForm, SearchForm
+from registar.forms import KrstenjeForm
 from registar.models import Krstenje
+from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
 from weasyprint import HTML
 
+KRSTENJE_RELATED = (
+    "dete",
+    "otac",
+    "majka",
+    "kum",
+    "hram",
+    "svestenik",
+)
 
+
+# @login_required
 def unos_krstenja(request):
     """
     Обрађује захтеве за унос новог крштења. Ако је захтев POST,
@@ -27,31 +36,34 @@ def unos_krstenja(request):
     return render(request, "registar/unos_krstenja.html", {"form": form})
 
 
-class SpisakKrstenja(FilterView, ListView):
+class SpisakKrstenja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
     """Приказује списак крштења са могућностима претраге и пагинације."""
 
     model = Krstenje
     template_name = "registar/spisak_krstenja.html"
+    partial_template_name = "registar/_stavka_krstenja.html"
     context_object_name = "krstenja"
     paginate_by = 10
-    filterset_class = KrstenjeFilter
+    search_fields = [
+        "dete__ime",
+        "dete__gradjansko_ime",
+        "otac__ime",
+        "otac__prezime",
+        "majka__ime",
+        "majka__prezime",
+        "kum__ime",
+        "kum__prezime",
+    ]
+    search_date_field = "datum"
+    sort_options = [
+        ("datum", "Датум растуће"),
+        ("-datum", "Датум опадајуће"),
+    ]
 
     def get_queryset(self):
-        """Филтрира податке на основу захтева корисника."""
-        queryset = super().get_queryset()
-        filtered_queryset = self.filterset_class(self.request.GET, queryset=queryset).qs
-        return filtered_queryset.order_by("datum")
-
-    def get_context_data(self, **kwargs):
-        """Додаје филтер и претражени текст у контекст шаблона."""
-        context = super().get_context_data(**kwargs)
-        context["filter"] = self.filterset_class(
-            self.request.GET, queryset=self.get_queryset()
+        return self.get_search_queryset(
+            Krstenje.objects.select_related(*KRSTENJE_RELATED).order_by("datum")
         )
-        # Uniform search form used across list pages
-        context["form"] = SearchForm(self.request.GET)
-        context["upit"] = self.request.GET.get("search", "")
-        return context
 
 
 class KrstenjePDF(DetailView):
@@ -64,7 +76,29 @@ class KrstenjePDF(DetailView):
     def get_object(self, queryset=None):
         """Враћа објекат крштења на основу UID-а."""
         uid = self.kwargs.get("uid")
-        return get_object_or_404(Krstenje, uid=uid)
+        return get_object_or_404(
+            Krstenje.objects.select_related(*KRSTENJE_RELATED),
+            uid=uid,
+        )
+
+    def get_context_data(self, **kwargs):
+        """Додаје историјске снимке особа у контекст."""
+        context = super().get_context_data(**kwargs)
+        krstenje = context["krstenje"]
+        event_date = krstenje.datum or krstenje.created
+
+        for role in ["dete", "otac", "majka", "kum"]:
+            osoba = getattr(krstenje, role)
+            if osoba:
+                try:
+                    historical = osoba.history.as_of(event_date)
+                    context[f"{role}_snapshot"] = historical
+                except type(osoba).DoesNotExist:
+                    context[f"{role}_snapshot"] = osoba
+            else:
+                context[f"{role}_snapshot"] = None
+
+        return context
 
     def render_to_response(self, context, **response_kwargs):
         """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
@@ -92,9 +126,13 @@ class PrikazKrstenja(DetailView):
     def get_object(self) -> Krstenje:
         """Враћа објекат крштења на основу UID-а."""
         uid = self.kwargs.get("uid")
-        return get_object_or_404(Krstenje, uid=uid)
+        return get_object_or_404(
+            Krstenje.objects.select_related(*KRSTENJE_RELATED),
+            uid=uid,
+        )
 
 
+# @login_required
 def calibrate_krstenje(request):
     """Калибрациона страница за подешавање позиција поља на крштеници."""
     return render(request, "registar/calibrate_krstenje.html")

--- a/crkva/registar/views/mixins.py
+++ b/crkva/registar/views/mixins.py
@@ -1,0 +1,125 @@
+"""Заједнички миксини за приказе."""
+
+from django.db import models
+from django.db.models.functions import Cast
+from registar.forms import SearchForm
+from registar.utils import get_query_variants
+
+PAGE_SIZE_CHOICES = [10, 25, 50, 100]
+PAGE_SIZE_DEFAULT = 10
+
+
+class ListControlsMixin:
+    """Pagination (per_page) and sorting (sort) for list views.
+
+    Each view declares:
+        sort_options = [
+            ("prezime", "Презиме А-Ш"),
+            ("-prezime", "Презиме Ш-А"),
+            ("-created", "Најновије"),
+        ]
+    """
+
+    sort_options: list[tuple[str, str]] = []
+
+    def get_paginate_by(self, queryset):
+        try:
+            per_page = int(self.request.GET.get("per_page", 0))
+        except (ValueError, TypeError):
+            per_page = 0
+        if per_page in PAGE_SIZE_CHOICES:
+            return per_page
+        return super().get_paginate_by(queryset)
+
+    def get_ordering(self):
+        sort = self.request.GET.get("sort", "")
+        allowed = [opt[0] for opt in self.sort_options]
+        if sort in allowed:
+            return [sort]
+        return super().get_ordering() or []
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current_size = self.get_paginate_by(self.get_queryset())
+        current_sort = self.request.GET.get("sort", "")
+        context["page_size_choices"] = PAGE_SIZE_CHOICES
+        context["current_page_size"] = current_size
+        context["sort_options"] = self.sort_options
+        context["current_sort"] = current_sort
+        return context
+
+
+# Keep old name as alias
+PageSizeMixin = ListControlsMixin
+
+
+class SearchMixin:
+    """Јединствена претрага по тексту за све спискове.
+
+    Сваки приказ дефинише:
+        search_fields = ["ime", "prezime", "dete__ime", ...]
+        search_date_field = "datum"  # опционо, за претрагу по датуму
+
+    Логика:
+        - Упит се дели на термине по размацима
+        - Сваки термин мора да се пронађе (AND између термина)
+        - За сваки термин, све варијанте (лат/ћир) се покушавају (OR)
+        - За сваку варијанту, сва поља се претражују (OR)
+    """
+
+    search_fields: list[str] = []
+    search_date_field: str | None = None
+
+    def get_search_queryset(self, queryset):
+        """Филтрира queryset на основу претраге."""
+        query = self.request.GET.get("search", "").strip()
+        if not query:
+            return queryset
+
+        terms = query.split()
+
+        if self.search_date_field:
+            queryset = queryset.annotate(
+                datum_str=Cast(self.search_date_field, models.CharField())
+            )
+
+        combined = models.Q()
+        for term in terms:
+            variants = get_query_variants(term)
+            term_q = models.Q()
+            for v in variants:
+                for field in self.search_fields:
+                    term_q |= models.Q(**{f"{field}__icontains": v})
+                if self.search_date_field:
+                    term_q |= models.Q(datum_str__icontains=v)
+            combined &= term_q
+
+        return queryset.filter(combined).distinct()
+
+    def get_queryset(self):
+        """Примењује претрагу на подразумевани queryset."""
+        queryset = super().get_queryset()
+        return self.get_search_queryset(queryset)
+
+    def get_context_data(self, **kwargs):
+        """Додаје форму за претрагу и упит у контекст."""
+        context = super().get_context_data(**kwargs)
+        context["form"] = SearchForm(data=self.request.GET)
+        context["upit"] = self.request.GET.get("search", "")
+        return context
+
+
+class InfiniteScrollMixin:
+    """Враћа само партиал шаблон када је захтев AJAX (за бесконачно скроловање).
+
+    Сваки приказ дефинише:
+        partial_template_name = "registar/_stavka_krstenja.html"
+    """
+
+    partial_template_name: str | None = None
+
+    def get_template_names(self):
+        is_ajax = self.request.headers.get("X-Requested-With") == "XMLHttpRequest"
+        if is_ajax and self.partial_template_name:
+            return [self.partial_template_name]
+        return super().get_template_names()

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -2,16 +2,17 @@
 Модул за приказ, додавање и генерисање PDF докумената за парохијане.
 """
 
-from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
-from registar.forms import ParohijanForm, SearchForm
+from registar.forms import ParohijanForm
+from registar.models import Krstenje
 from registar.models.parohijan import Parohijan
-from registar.utils import get_query_variants
+from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
 from weasyprint import HTML
 
 
+# @login_required
 def unos_parohijana(request):
     """
     Обрађује захтев за додавање новог парохијана. Ако је метод POST,
@@ -27,39 +28,27 @@ def unos_parohijana(request):
     return render(request, "registar/unos_parohijana.html", {"form": form})
 
 
-class SpisakParohijana(ListView):
+class SpisakParohijana(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
     """Приказује списак парохијана са могућношћу претраге и пагинације."""
 
     model = Parohijan
     template_name = "registar/spisak_parohijana.html"
+    partial_template_name = "registar/_stavka_parohijana.html"
     context_object_name = "parohijani"
     paginate_by = 10
+    ordering = ["prezime", "ime"]
+    search_fields = ["ime", "prezime"]
+    sort_options = [
+        ("prezime", "Презиме А-Ш"),
+        ("-prezime", "Презиме Ш-А"),
+        ("ime", "Име А-Ш"),
+        ("-created", "Најновије"),
+    ]
 
     def get_queryset(self):
-        """Филтрира парохијане на основу унетог појма у форми за претрагу."""
-        form = SearchForm(data=self.request.GET)
-        if form.is_valid():
-            query = form.cleaned_data.get("search", "")
-            if not query:
-                return Parohijan.objects.all()
-            variants = get_query_variants(query)
-            q = None
-            for v in variants:
-                clause = Q(ime__icontains=v) | Q(prezime__icontains=v)
-                q = clause if q is None else (q | clause)
-            return (
-                Parohijan.objects.filter(q)
-                if q is not None
-                else Parohijan.objects.all()
-            )
-        return Parohijan.objects.all()
-
-    def get_context_data(self, **kwargs):
-        """Додаје форму за претрагу у контекст шаблона."""
-        context = super().get_context_data(**kwargs)
-        context["form"] = SearchForm(data=self.request.GET)
-        context["upit"] = self.request.GET.get("search", "")
-        return context
+        return self.get_search_queryset(
+            Parohijan.objects.select_related("adresa").all()
+        )
 
 
 class ParohijanPDF(DetailView):
@@ -103,3 +92,48 @@ class PrikazParohijana(DetailView):
         """Преузима парохијана на основу UID-а."""
         uid = self.kwargs.get(self.pk_url_kwarg)
         return get_object_or_404(Parohijan, uid=uid)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        p = self.object
+
+        # Крштења
+        context["krstenja_dete"] = p.krstenja_kao_dete.select_related(
+            "otac", "majka", "kum"
+        ).all()
+        context["krstenja_kum"] = p.krstenja_kao_kum.select_related("dete").all()
+
+        # Венчања
+        context["vencanja_zenik"] = p.vencanja_kao_zenik.select_related("nevesta").all()
+        context["vencanja_nevesta"] = p.vencanja_kao_nevesta.select_related(
+            "zenik"
+        ).all()
+        context["vencanja_kum"] = p.vencanja_kao_kum.select_related(
+            "zenik", "nevesta"
+        ).all()
+
+        # Родитељи (из крштења где је ова особа дете)
+        krstenje_kao_dete = p.krstenja_kao_dete.select_related("otac", "majka").first()
+        if krstenje_kao_dete:
+            context["otac"] = krstenje_kao_dete.otac
+            context["majka"] = krstenje_kao_dete.majka
+
+        # Деца (из крштења где је ова особа отац или мајка)
+        deca_kao_otac = Krstenje.objects.filter(otac=p).select_related("dete")
+        deca_kao_majka = Krstenje.objects.filter(majka=p).select_related("dete")
+        deca = []
+        seen = set()
+        for k in list(deca_kao_otac) + list(deca_kao_majka):
+            if k.dete and k.dete.uid not in seen:
+                deca.append(k.dete)
+                seen.add(k.dete.uid)
+        context["deca"] = deca
+
+        # Домаћинство (као укућанин)
+        from registar.models import Ukucanin
+
+        context["ukucanstva"] = Ukucanin.objects.filter(osoba=p).select_related(
+            "domacinstvo", "domacinstvo__domacin"
+        )
+
+        return context

--- a/crkva/registar/views/svestenik_view.py
+++ b/crkva/registar/views/svestenik_view.py
@@ -2,52 +2,34 @@
 Модул за приказ, претрагу и генерисање PDF докумената за свештенике.
 """
 
-from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.generic import DetailView, ListView
-from registar.forms import SearchForm
 from registar.models.svestenik import Svestenik
-from registar.utils import get_query_variants
+from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
 from weasyprint import HTML
 
 
-class SpisakSvestenika(ListView):
+class SpisakSvestenika(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
     """Приказује списак свештеника са могућностима претраге и пагинације."""
 
     model = Svestenik
     template_name = "registar/spisak_svestenika.html"
+    partial_template_name = "registar/_stavka_svestenika.html"
     context_object_name = "svestenici"
     paginate_by = 10
+    search_fields = ["ime", "prezime", "zvanje"]
+    sort_options = [
+        ("prezime", "Презиме А-Ш"),
+        ("-prezime", "Презиме Ш-А"),
+        ("zvanje", "Звање"),
+    ]
+    ordering = ["prezime", "ime"]
 
     def get_queryset(self):
-        """Филтрира податке на основу унетог појма у форми за претрагу."""
-        form = SearchForm(self.request.GET)
-        if form.is_valid():
-            query = form.cleaned_data.get("search", "")
-            if not query:
-                return Svestenik.objects.all()
-            q = None
-            for v in get_query_variants(query):
-                clause = (
-                    Q(ime__icontains=v)
-                    | Q(prezime__icontains=v)
-                    | Q(zvanje__icontains=v)
-                )
-                q = clause if q is None else (q | clause)
-            return (
-                Svestenik.objects.filter(q)
-                if q is not None
-                else Svestenik.objects.all()
-            )
-        return Svestenik.objects.all()
-
-    def get_context_data(self, **kwargs):
-        """Додаје формулар за претрагу у контекст шаблона."""
-        context = super().get_context_data(**kwargs)
-        context["form"] = SearchForm(self.request.GET)
-        context["upit"] = self.request.GET.get("search", "")
-        return context
+        return self.get_search_queryset(
+            Svestenik.objects.select_related("parohija").all()
+        )
 
 
 class SvestenikPDF(DetailView):
@@ -87,4 +69,17 @@ class PrikazSvestenika(DetailView):
     def get_object(self):
         """Враћа објекат свештеника на основу UID-а."""
         uid = self.kwargs.get("uid")
-        return get_object_or_404(Svestenik, uid=uid)
+        return get_object_or_404(Svestenik.objects.select_related("parohija"), uid=uid)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        s = self.object
+        context["krstenja"] = s.свештеник_крститељ.select_related(
+            "dete", "otac"
+        ).order_by("-datum")[:20]
+        context["krstenja_count"] = s.свештеник_крститељ.count()
+        context["vencanja"] = s.свештеник_венчани.select_related(
+            "zenik", "nevesta"
+        ).order_by("-datum")[:20]
+        context["vencanja_count"] = s.свештеник_венчани.count()
+        return context

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -5,38 +5,52 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
-from django_filters.views import FilterView
-from registar.filters import VencanjeFilter
-from registar.forms import SearchForm, VencanjeForm
+from registar.forms import VencanjeForm
 from registar.models.vencanje import Vencanje
+from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
 from weasyprint import HTML
 
+VENCANJE_RELATED = (
+    "zenik",
+    "nevesta",
+    "kum",
+    "svekar",
+    "svekrva",
+    "tast",
+    "tasta",
+    "stari_svat",
+    "hram",
+    "svestenik",
+)
 
-class SpisakVencanja(FilterView, ListView):
+
+class SpisakVencanja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
     """Приказује списак венчања са могућностима претраге и пагинације."""
 
     model = Vencanje
     template_name = "registar/spisak_vencanja.html"
+    partial_template_name = "registar/_stavka_vencanja.html"
     context_object_name = "vencanja"
     paginate_by = 10
-    filterset_class = VencanjeFilter
+    search_fields = [
+        "zenik__ime",
+        "zenik__prezime",
+        "nevesta__ime",
+        "nevesta__prezime",
+        "kum__ime",
+        "stari_svat__ime",
+        "hram__naziv",
+    ]
+    search_date_field = "datum"
+    sort_options = [
+        ("datum", "Датум растуће"),
+        ("-datum", "Датум опадајуће"),
+    ]
 
     def get_queryset(self):
-        """Филтрира податке на основу захтева корисника."""
-        queryset = super().get_queryset()
-        filtered_queryset = self.filterset_class(self.request.GET, queryset=queryset).qs
-        return filtered_queryset.order_by("datum")
-
-    def get_context_data(self, **kwargs):
-        """Додаје филтер и претражени текст у контекст шаблона."""
-        context = super().get_context_data(**kwargs)
-        context["filter"] = self.filterset_class(
-            self.request.GET, queryset=self.get_queryset()
+        return self.get_search_queryset(
+            Vencanje.objects.select_related(*VENCANJE_RELATED).order_by("datum")
         )
-        # Uniform search form used across list pages
-        context["form"] = SearchForm(self.request.GET)
-        context["upit"] = self.request.GET.get("search", "")
-        return context
 
 
 class VencanjePDF(DetailView):
@@ -49,7 +63,38 @@ class VencanjePDF(DetailView):
     def get_object(self, queryset=None):
         """Враћа објекат венчања на основу UID-а."""
         uid = self.kwargs.get("uid")
-        return get_object_or_404(Vencanje, uid=uid)
+        return get_object_or_404(
+            Vencanje.objects.select_related(*VENCANJE_RELATED),
+            uid=uid,
+        )
+
+    def get_context_data(self, **kwargs):
+        """Додаје историјске снимке особа у контекст."""
+        context = super().get_context_data(**kwargs)
+        vencanje = context["vencanje"]
+        event_date = vencanje.datum or vencanje.created
+
+        for role in [
+            "zenik",
+            "nevesta",
+            "kum",
+            "svekar",
+            "svekrva",
+            "tast",
+            "tasta",
+            "stari_svat",
+        ]:
+            osoba = getattr(vencanje, role)
+            if osoba:
+                try:
+                    historical = osoba.history.as_of(event_date)
+                    context[f"{role}_snapshot"] = historical
+                except type(osoba).DoesNotExist:
+                    context[f"{role}_snapshot"] = osoba
+            else:
+                context[f"{role}_snapshot"] = None
+
+        return context
 
     def render_to_response(self, context, **response_kwargs):
         """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
@@ -77,15 +122,15 @@ class PrikazVencanja(DetailView):
     def get_object(self) -> Vencanje:
         """Враћа објекат венчања на основу UID-а."""
         uid = self.kwargs.get("uid")
-        return get_object_or_404(Vencanje, uid=uid)
+        return get_object_or_404(
+            Vencanje.objects.select_related(*VENCANJE_RELATED),
+            uid=uid,
+        )
 
 
+# @login_required
 def unos_vencanja(request):
-    """Обрада уноса новог венчања.
-
-    Ако је захтев POST и форма валидна – чува запис и враћа на списак венчања.
-    У супротном приказује формулар за унос.
-    """
+    """Обрада уноса новог венчања."""
     if request.method == "POST":
         form = VencanjeForm(request.POST)
         if form.is_valid():
@@ -96,6 +141,7 @@ def unos_vencanja(request):
     return render(request, "registar/unos_vencanja.html", {"form": form})
 
 
+# @login_required
 def calibrate_vencanje(request):
     """Приказује страницу за калибрацију позиција поља на венчаници."""
     return render(request, "registar/calibrate_vencanje.html")


### PR DESCRIPTION
Five list pages (парохијани / крштења / венчања / свештеници / домаћинства) share a redesigned shell:

  • Unified toolbar above the list: search input on the left, sort
    dropdown on the right. Search input is full-width with an inline
    magnifying-glass icon (specificity-bumped so the generic
    `input[type="search"]` from forme.css doesn't override the
    icon-padding).
  • Active filter chips between toolbar and list. When a search is
    in effect a removable "претрага: <term>" chip appears.
  • Infinite scroll instead of paginated prev/next. An
    IntersectionObserver near the bottom of the list fires an AJAX
    request (X-Requested-With) that returns only the next batch of
    <li> items, plus a next-page-marker so the JS knows whether
    more pages exist.

To support partial AJAX responses, each list view declares a `partial_template_name`. The new `InfiniteScrollMixin` (in `registar/views/mixins.py`) swaps in that template when the request is XHR, so the same view code renders both the initial full page and the AJAX increments. The per-list <li> markup lives in new `_stavka_*.html` partials shared between full and partial render.

Search + sort + per-page handling consolidated into two new mixins:

  SearchMixin       Splits the query by whitespace; each term must
                    match any of search_fields (OR within term, AND
                    across terms). Uses get_query_variants so a
                    Cyrillic query matches Latin DB content and vice
                    versa. Per-view config: `search_fields`,
                    `search_date_field`.
  ListControlsMixin Handles `?per_page=N` (whitelist 10/25/50/100,
                    default 10) and `?sort=X` (whitelist from
                    `sort_options`). PageSizeMixin is kept as an
                    alias for backwards compat.

Removes the now-redundant django-filters / FilterView wiring from krstenje_view + vencanje_view; the SearchMixin covers the same functionality more flexibly.