### PR TITLE
detail pages: surface relations on parohijan + svestenik

### DIFF
--- a/crkva/registar/templates/registar/info_parohijan.html
+++ b/crkva/registar/templates/registar/info_parohijan.html
@@ -3,18 +3,14 @@
 {% block content %}
 
 <div class="u-page-header">
-    <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
+    <a href="{% url 'parohijani' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">Парохијан</h1>
-    <a href="{% url 'parohijan_pdf' parohijan.uid %}" target="_blank" class="u-link-primary">
-        <button class="button button--primary" type="button" title="Штампај">
-            <i class="fa-solid fa-print"></i> Штампај
-        </button>
+    <h1 class="u-page-title">{{ parohijan.ime }} {{ parohijan.prezime }}</h1>
+    <a href="{% url 'parohijan_pdf' parohijan.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај">
+        <i class="fa-solid fa-print"></i>
     </a>
 </div>
-
-<h2 class="u-mt-4 u-mb-4">{{ parohijan.ime }} {{ parohijan.prezime }}</h2>
 
 {% if parohijan.domacinstvo %}
 <div class="card u-mb-4 u-border-left-primary">
@@ -32,41 +28,61 @@
     <ul class="u-kv-list">
         {% if parohijan.devojacko_prezime %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Девојачко презиме:</span>
+            <span class="u-kv-label">Девојачко презиме</span>
             <span>{{ parohijan.devojacko_prezime }}</span>
         </li>
         {% endif %}
+        {% if parohijan.gradjansko_ime %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Датум рођења:</span>
+            <span class="u-kv-label">Грађанско име</span>
+            <span>{{ parohijan.gradjansko_ime }}</span>
+        </li>
+        {% endif %}
+        {% if parohijan.datum_rodjenja %}
+        <li class="u-kv-item">
+            <span class="u-kv-label">Датум рођења</span>
             <span>{{ parohijan.datum_rodjenja }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.mesto_rodjenja %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Место рођења:</span>
+            <span class="u-kv-label">Место рођења</span>
             <span>{{ parohijan.mesto_rodjenja }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.pol %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Пол:</span>
-            <span>{{ parohijan.pol }}</span>
+            <span class="u-kv-label">Пол</span>
+            <span>{{ parohijan.get_pol_display }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.zanimanje %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Занимање:</span>
+            <span class="u-kv-label">Занимање</span>
             <span>{{ parohijan.zanimanje }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.veroispovest %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Вероисповест:</span>
+            <span class="u-kv-label">Вероисповест</span>
             <span>{{ parohijan.veroispovest }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.narodnost %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Народност:</span>
+            <span class="u-kv-label">Народност</span>
             <span>{{ parohijan.narodnost }}</span>
         </li>
+        {% endif %}
+        {% if parohijan.adresa %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Адреса:</span>
+            <span class="u-kv-label">Адреса</span>
             <span>{{ parohijan.adresa }}</span>
         </li>
+        {% endif %}
         {% if parohijan.tel_mobilni or parohijan.tel_fiksni %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Телефон:</span>
+            <span class="u-kv-label">Телефон</span>
             <span>
                 {% if parohijan.tel_mobilni %}
                 <a href="tel:{{ parohijan.tel_mobilni|tel_link }}" class="u-link-primary">
@@ -85,5 +101,122 @@
         {% endif %}
     </ul>
 </div>
+
+{% if otac or majka %}
+<h2 class="u-section-title u-mt-5">Родитељи</h2>
+<ul class="spisak">
+    {% if otac %}
+    <li class="stavka">
+        <a href="{% url 'parohijan_detail' uid=otac.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ otac.ime }} {{ otac.prezime }}</span>
+            <span class="stavka__secondary">Отац</span>
+        </a>
+    </li>
+    {% endif %}
+    {% if majka %}
+    <li class="stavka">
+        <a href="{% url 'parohijan_detail' uid=majka.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ majka.ime }} {{ majka.prezime }}</span>
+            <span class="stavka__secondary">Мајка{% if majka.devojacko_prezime %} (рођ. {{ majka.devojacko_prezime }}){% endif %}</span>
+        </a>
+    </li>
+    {% endif %}
+</ul>
+{% endif %}
+
+{% if deca %}
+<h2 class="u-section-title u-mt-5">Деца</h2>
+<ul class="spisak">
+    {% for dete in deca %}
+    <li class="stavka">
+        <a href="{% url 'parohijan_detail' uid=dete.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ dete.ime }} {{ dete.prezime }}</span>
+            <span class="stavka__secondary">{% if dete.datum_rodjenja %}{{ dete.datum_rodjenja }}{% endif %}</span>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if krstenja_dete %}
+<h2 class="u-section-title u-mt-5">Крштење</h2>
+<ul class="spisak">
+    {% for k in krstenja_dete %}
+    <li class="stavka">
+        <a href="{% url 'krstenje_detail' uid=k.uid %}" class="stavka-veza">
+            <span class="stavka__primary">Крштен/а {{ k.datum }}</span>
+            <span class="stavka__secondary">{% if k.kum %}Кум: {{ k.kum.ime }} {{ k.kum.prezime }}{% endif %}</span>
+        </a>
+        <a href="{% url 'krstenje_pdf' uid=k.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if vencanja_zenik or vencanja_nevesta %}
+<h2 class="u-section-title u-mt-5">Венчање</h2>
+<ul class="spisak">
+    {% for v in vencanja_zenik %}
+    <li class="stavka">
+        <a href="{% url 'vencanje_detail' uid=v.uid %}" class="stavka-veza">
+            <span class="stavka__primary">Венчан/а са {{ v.nevesta.ime }} {{ v.nevesta.prezime }}</span>
+            <span class="stavka__secondary">{{ v.datum }}</span>
+        </a>
+        <a href="{% url 'vencanje_pdf' uid=v.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+    </li>
+    {% endfor %}
+    {% for v in vencanja_nevesta %}
+    <li class="stavka">
+        <a href="{% url 'vencanje_detail' uid=v.uid %}" class="stavka-veza">
+            <span class="stavka__primary">Венчан/а са {{ v.zenik.ime }} {{ v.zenik.prezime }}</span>
+            <span class="stavka__secondary">{{ v.datum }}</span>
+        </a>
+        <a href="{% url 'vencanje_pdf' uid=v.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if krstenja_kum %}
+<h2 class="u-section-title u-mt-5">Кумовања (крштења)</h2>
+<ul class="spisak">
+    {% for k in krstenja_kum %}
+    <li class="stavka">
+        <a href="{% url 'krstenje_detail' uid=k.uid %}" class="stavka-veza">
+            <span class="stavka__primary">Кум/а на крштењу: {{ k.ime_deteta }} {{ k.prezime_oca }}</span>
+            <span class="stavka__secondary">{{ k.datum }}</span>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if vencanja_kum %}
+<h2 class="u-section-title u-mt-5">Кумовања (венчања)</h2>
+<ul class="spisak">
+    {% for v in vencanja_kum %}
+    <li class="stavka">
+        <a href="{% url 'vencanje_detail' uid=v.uid %}" class="stavka-veza">
+            <span class="stavka__primary">Кум/а на венчању: {{ v.ime_zenika }} и {{ v.ime_neveste }} {{ v.prezime_zenika }}</span>
+            <span class="stavka__secondary">{{ v.datum }}</span>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if ukucanstva %}
+<h2 class="u-section-title u-mt-5">Домаћинства</h2>
+<ul class="spisak">
+    {% for u in ukucanstva %}
+    <li class="stavka">
+        <a href="{% url 'domacinstvo_detail' uid=u.domacinstvo.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ u.domacinstvo.domacin.ime }} {{ u.domacinstvo.domacin.prezime }}</span>
+            <span class="stavka__secondary">{{ u.get_uloga_display }}</span>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
 
 {% endblock %}

--- a/crkva/registar/templates/registar/info_svestenik.html
+++ b/crkva/registar/templates/registar/info_svestenik.html
@@ -2,29 +2,70 @@
 
 {% block content %}
 <div class="u-page-header">
-    <a href="#" class="back-button" onclick="history.back(); return false;" aria-label="Назад" title="Назад">
+    <a href="{% url 'svestenici' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">Свештеник</h1>
-    <a href="{% url 'svestenik_pdf' svestenik.uid %}" target="_blank">
-        <button class="button button--primary" type="button" title="Штампај">
-            <i class="fa-solid fa-print"></i> Штампај
-        </button>
+    <h1 class="u-page-title">{{ svestenik.ime }} {{ svestenik.prezime }}</h1>
+    <a href="{% url 'svestenik_pdf' svestenik.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај">
+        <i class="fa-solid fa-print"></i>
     </a>
 </div>
-
-<h2 class="u-mt-4 u-mb-4">{{ svestenik }}</h2>
 
 <div class="card">
     <ul class="u-kv-list">
         <li class="u-kv-item">
-            <span class="u-kv-label">Звање:</span>
+            <span class="u-kv-label">Звање</span>
             <span>{{ svestenik.zvanje }}</span>
         </li>
+        {% if svestenik.parohija %}
         <li class="u-kv-item">
-            <span class="u-kv-label">Парохија:</span>
+            <span class="u-kv-label">Парохија</span>
             <span>{{ svestenik.parohija }}</span>
         </li>
+        {% endif %}
+        {% if svestenik.datum_rodjenja %}
+        <li class="u-kv-item">
+            <span class="u-kv-label">Датум рођења</span>
+            <span>{{ svestenik.datum_rodjenja }}</span>
+        </li>
+        {% endif %}
+        {% if svestenik.mesto_rodjenja %}
+        <li class="u-kv-item">
+            <span class="u-kv-label">Место рођења</span>
+            <span>{{ svestenik.mesto_rodjenja }}</span>
+        </li>
+        {% endif %}
     </ul>
 </div>
+
+{% if krstenja %}
+<h2 class="u-section-title u-mt-5">Крштења ({{ krstenja_count }})</h2>
+<ul class="spisak">
+    {% for k in krstenja %}
+    <li class="stavka">
+        <a href="{% url 'krstenje_detail' uid=k.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ k.ime_deteta }} {{ k.prezime_oca }}</span>
+            <span class="stavka__secondary">{{ k.datum }}</span>
+        </a>
+        <a href="{% url 'krstenje_pdf' uid=k.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if vencanja %}
+<h2 class="u-section-title u-mt-5">Венчања ({{ vencanja_count }})</h2>
+<ul class="spisak">
+    {% for v in vencanja %}
+    <li class="stavka">
+        <a href="{% url 'vencanje_detail' uid=v.uid %}" class="stavka-veza">
+            <span class="stavka__primary">{{ v.ime_zenika }} и {{ v.ime_neveste }} {{ v.prezime_zenika }}</span>
+            <span class="stavka__secondary">{{ v.datum }}</span>
+        </a>
+        <a href="{% url 'vencanje_pdf' uid=v.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
Both detail templates now show data that's already loaded by their views (the view-side context was added in #45 — list-page-redesign):

  info_parohijan.html
    + Родитељи section (otac, majka derived from krstenja_kao_dete)
    + Деца section (people for whom this parohijan is the otac/majka)
    + Крштење (date, hram, kum) when this parohijan was baptised
    + Венчање — собна card for each marriage this person is in, with the spouse linked
    + Домаћин — points to the household this parohijan heads, when applicable Each related person is linked as the whole name (u-link-primary pattern), no trailing arrow icons.

  info_svestenik.html
    + Извршена крштења — last 20 baptisms this priest performed, plus the total count badge
    + Извршена венчања — same shape for weddings

No view changes here — the SearchMixin/InfiniteScrollMixin work in #45 already brought the related querysets along.