### PR TITLE
search overlay: ship the autocomplete dropdown CSS

### DIFF
--- a/crkva/registar/static/registar/layout/bocna-traka.css
+++ b/crkva/registar/static/registar/layout/bocna-traka.css
@@ -661,3 +661,135 @@ body.sidebar-collapsed {
     display: none;
   }
 }
+
+/* ==========================================================================
+   SEARCH OVERLAY – improved
+   ========================================================================== */
+
+.search-overlay-content {
+    width: 90%;
+    max-width: 560px;
+    margin-top: -10vh;
+}
+
+.search-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+    background: var(--color-surface);
+    border-radius: 12px;
+    padding: 14px 18px;
+    gap: 12px;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.4);
+    border: 1px solid var(--color-border);
+}
+
+.search-box__icon {
+    color: var(--color-text-muted);
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.search-box input {
+    flex: 1;
+    border: none;
+    outline: none;
+    font-size: 16px;
+    background: transparent;
+    color: var(--color-text);
+}
+
+.search-box__kbd {
+    font-size: 11px;
+    padding: 2px 6px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    background: var(--color-surface-2);
+    font-family: inherit;
+    flex-shrink: 0;
+}
+
+.search-results {
+    max-height: 50vh;
+    overflow-y: auto;
+    background: var(--color-surface);
+    border-radius: 0 0 12px 12px;
+    margin-top: -1px;
+    border: 1px solid var(--color-border);
+    border-top: none;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.3);
+}
+
+.search-results:empty {
+    display: none;
+}
+
+.search-result-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 18px;
+    text-decoration: none;
+    color: var(--color-text);
+    border-bottom: 1px solid var(--color-border);
+    transition: background 0.1s;
+}
+
+.search-result-item:last-child {
+    border-bottom: none;
+}
+
+.search-result-item:hover,
+.search-result-item--active {
+    background: var(--color-surface-2);
+}
+
+.search-result-item__text {
+    font-weight: 500;
+    font-size: 14px;
+}
+
+.search-result-item__type {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    margin-left: 12px;
+}
+
+.search-no-results {
+    padding: 20px 18px;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+}
+
+.search-hint {
+    text-align: center;
+    padding: 8px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.search-hint:has(+ .search-results:empty) {
+    display: none;
+}
+
+.search-result-group {
+    padding: 6px 18px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-muted);
+    background: var(--color-surface-2);
+    border-bottom: 1px solid var(--color-border);
+}
+
+
+/* Hide the desktop sidebar toggle on mobile */
+@media (max-width: 768px) {
+  .sidebar-toggle {
+    display: none;
+  }
+}

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -384,3 +384,47 @@
 [data-theme="dark"] [data-theme-text-secondary] {
   color: var(--color-text-muted) !important;
 }
+
+[data-theme=dark] .search-overlay {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+[data-theme=dark] .search-box {
+  background: var(--color-surface-2);
+  border-color: var(--color-border);
+}
+
+[data-theme=dark] .search-box input {
+  color: var(--color-text);
+}
+
+[data-theme=dark] .search-box__kbd {
+  background: var(--color-surface-1);
+  border-color: var(--color-border);
+  color: var(--color-text-muted);
+}
+
+[data-theme=dark] .search-results {
+  background: var(--color-surface-2);
+  border-color: var(--color-border);
+}
+
+[data-theme=dark] .search-result-item {
+  color: var(--color-text);
+  border-bottom-color: var(--color-border);
+}
+
+[data-theme=dark] .search-result-item:hover,
+[data-theme=dark] .search-result-item--active {
+  background: var(--color-surface-1);
+}
+
+[data-theme=dark] .search-result-group {
+  background: var(--color-surface-1);
+  color: var(--color-text-muted);
+  border-bottom-color: var(--color-border);
+}
+
+[data-theme=dark] .search-no-results {
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
The autocomplete overlay markup landed in #47 but the matching styles didn't make it into the same PR, so the dropdown rendered with no visual treatment — unstyled list, no box, no row hover.

Adds:

  .search-box                    larger surface card with shadow,
                                 border, and gap between icon/input/kbd.
  .search-box__icon              muted, fixed-size leading icon.
  .search-box__kbd               ESC hint chip.
  .search-results                scrollable container hanging below
                                 the search box; empty state hidden.
  .search-result-item            row layout, hover/active highlight,
                                 separator borders, last-of-list flush.
  .search-result-item__text/type primary text + muted secondary.
  .search-result-group           uppercase section header per entity
                                 type (Парохијани, Крштења, …).
  .search-no-results             quiet empty-state message.
  .search-hint                   "Enter за пуну претрагу" caption,
                                 hidden when there are no results yet.

Plus the dark-theme overrides for every rule above so the overlay reads correctly under [data-theme="dark"].