### PR TITLE
ui polish: home counts, FA icons in domacinstvo, tooltip + dark-theme…

### DIFF
--- a/crkva/registar/static/registar/components/dugmad.css
+++ b/crkva/registar/static/registar/components/dugmad.css
@@ -91,3 +91,34 @@
 .u-btn-primary:hover {
     background: var(--color-primary-hover);
 }
+
+/* ==========================================================================
+   TOOLTIP – instant hover label (replaces slow native title)
+   ========================================================================== */
+
+[data-tooltip] {
+    position: relative;
+}
+
+[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 8px;
+    background: var(--color-text, #333);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 400;
+    white-space: nowrap;
+    border-radius: 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    margin-bottom: 6px;
+}
+
+[data-tooltip]:hover::after {
+    opacity: 1;
+}

--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -250,3 +250,18 @@ input[name="vreme_rodjenja"]:focus {
 .form__actions { display: flex; gap: 8px; }
 .form__help-text { color: var(--color-text-muted); font-size: 14px; margin-top: 6px; }
 .form__error-text { color: #b91c1c; font-size: 14px; margin-top: 6px; }
+
+
+/* FK поље са акцијским дугметом (+ за додавање) */
+.form-field-with-action {
+  display: flex;
+  gap: 8px;
+  align-items: start;
+}
+.form-field-with-action__input {
+  flex: 1;
+}
+.form-field-with-action__btn {
+  min-height: 38px;
+  white-space: nowrap;
+}

--- a/crkva/registar/static/registar/components/kartice.css
+++ b/crkva/registar/static/registar/components/kartice.css
@@ -176,3 +176,11 @@
     border-left: 4px solid var(--color-primary);
     border-radius: 4px;
 }
+
+.registry__count {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin-left: auto;
+    flex-shrink: 0;
+}

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -428,3 +428,57 @@
 [data-theme=dark] .search-no-results {
   color: var(--color-text-muted);
 }
+
+/* ==========================================================================
+   10. НОВЕ КОМПОНЕНТЕ (tooltip, list controls)
+   ========================================================================== */
+
+/* Tooltip */
+[data-theme=dark] [data-tooltip]::after {
+  background: var(--color-surface-1);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+/* Page-size selector */
+[data-theme=dark] .page-size-link {
+  background: var(--color-surface-2) !important;
+  color: var(--color-text-muted) !important;
+  border-color: var(--color-border) !important;
+}
+
+[data-theme=dark] .page-size-link:hover {
+  background: var(--color-surface-1) !important;
+  color: var(--color-primary) !important;
+}
+
+[data-theme=dark] .page-size-link--active {
+  background: var(--color-primary) !important;
+  color: #fff !important;
+}
+
+/* List controls bar */
+[data-theme=dark] .list-controls {
+  border-color: var(--color-border);
+}
+
+[data-theme=dark] .list-controls__select {
+  background-color: var(--color-surface-2);
+  color: var(--color-text);
+  border-color: var(--color-border);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23bbb%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+}
+
+[data-theme=dark] .list-controls__select:hover {
+  background-color: var(--color-surface);
+}
+
+[data-theme=dark] .list-controls__select option {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
+/* Primary/secondary text in list items */
+[data-theme=dark] .stavka__secondary {
+  color: var(--color-text-muted);
+}

--- a/crkva/registar/templates/registar/index.html
+++ b/crkva/registar/templates/registar/index.html
@@ -109,6 +109,7 @@
     <div class="registry__grid">
       <a href="{% url 'parohijani' %}" class="registry__card">
         <div class="registry__icon"><i class="fa-solid fa-users"></i></div>
+        <div class="registry__count">{{ stats.parohijani }}</div>
         <div class="registry__info">
           <div class="registry__title">Парохијани</div>
           <div class="registry__desc">Евиденција парохијана</div>
@@ -116,6 +117,7 @@
       </a>
       <a href="{% url 'krstenja' %}" class="registry__card">
         <div class="registry__icon"><i class="fa-solid fa-droplet"></i></div>
+        <div class="registry__count">{{ stats.krstenja }}</div>
         <div class="registry__info">
           <div class="registry__title">Крштења</div>
           <div class="registry__desc">Књига крштених</div>
@@ -123,6 +125,7 @@
       </a>
       <a href="{% url 'vencanja' %}" class="registry__card">
         <div class="registry__icon"><i class="icon-rings"></i></div>
+        <div class="registry__count">{{ stats.vencanja }}</div>
         <div class="registry__info">
           <div class="registry__title">Венчања</div>
           <div class="registry__desc">Књига венчаних</div>
@@ -130,6 +133,7 @@
       </a>
       <a href="{% url 'svestenici' %}" class="registry__card">
         <div class="registry__icon"><i class="fa-solid fa-id-badge"></i></div>
+        <div class="registry__count">{{ stats.svestenici }}</div>
         <div class="registry__info">
           <div class="registry__title">Свештеници</div>
           <div class="registry__desc">Евиденција свештеника</div>

--- a/crkva/registar/templates/registar/info_domacinstvo.html
+++ b/crkva/registar/templates/registar/info_domacinstvo.html
@@ -22,7 +22,7 @@
         {% if domacinstvo.adresa %}
         <div>
             <strong class="u-label">Адреса:</strong><br>
-            📍 {{ domacinstvo.adresa }}
+            <i class="fa-solid fa-location-dot"></i> {{ domacinstvo.adresa }}
         </div>
         {% endif %}
 
@@ -55,8 +55,8 @@
 
         <div>
             <strong class="u-label">Водице:</strong><br>
-            {% if domacinstvo.slavska_vodica %}✅ Славска водица<br>{% endif %}
-            {% if domacinstvo.vaskrsnja_vodica %}✅ Васкршња водица{% endif %}
+            {% if domacinstvo.slavska_vodica %}<i class="fa-solid fa-circle-check" style="color: var(--color-success)"></i> Славска водица<br>{% endif %}
+            {% if domacinstvo.vaskrsnja_vodica %}<i class="fa-solid fa-circle-check" style="color: var(--color-success)"></i> Васкршња водица{% endif %}
             {% if not domacinstvo.slavska_vodica and not domacinstvo.vaskrsnja_vodica %}—{% endif %}
         </div>
     </div>
@@ -72,14 +72,12 @@
 {% if ukucani_zivi or ukucani_preminuli %}
 <div class="u-mt-6">
     <h2 class="u-section-title u-mb-5">
-        <i class="fa-solid fa-users"></i>
-        Чланови домаћинства
+        Чланови
     </h2>
 
     {% if ukucani_zivi %}
     <div class="u-mb-6">
         <h3 class="u-section-title u-section-title--success">
-            <i class="fa-solid fa-circle u-text-small"></i>
             Живи чланови ({{ ukucani_zivi|length }})
         </h3>
         <ul class="spisak">
@@ -110,20 +108,19 @@
     {% if ukucani_preminuli %}
     <div>
         <h3 class="u-section-title u-text-muted">
-            <i class="fa-solid fa-circle u-text-small"></i>
             Преминули чланови ({{ ukucani_preminuli|length }})
         </h3>
         <ul class="spisak">
             {% for ukucanin in ukucani_preminuli %}
             <li class="stavka u-border-left-muted u-opacity-70">
                 <div class="u-flex-1">
-                    <div class="u-font-medium u-mb-2 u-text-strikethrough">
+                    <div class="u-font-medium u-mb-2">
                         {% if ukucanin.osoba %}
                             {{ ukucanin.osoba.ime }} {{ ukucanin.osoba.prezime }}
                         {% else %}
                             {{ ukucanin.ime_ukucana }}
                         {% endif %}
-                        †
+                        <i class="fa-solid fa-cross u-text-muted"></i>
                     </div>
                     <div class="u-text-muted u-text-small">
                         <span class="u-badge u-badge--role">

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -180,6 +180,12 @@ def index(request) -> HttpResponse:
         )
 
     context = {
+        "stats": {
+            "parohijani": Parohijan.objects.count(),
+            "krstenja": Krstenje.objects.count(),
+            "vencanja": Vencanje.objects.count(),
+            "svestenici": Svestenik.objects.count(),
+        },
         "calendar_cells": cells,
     }
 


### PR DESCRIPTION
… overrides

Six small visual fixes that were drifting between feature branches.

* **Home dashboard** — each registry card on the home page now shows the entity count next to its title (Парохијани · 12329, Крштења · 3550, Венчања · 233, Свештеници · 21). `index` view passes a `stats` dict; `.registry__count` styled in kartice.css.

* **info_domacinstvo template** — drop the emoji-as-icon pattern: 📍  → fa-location-dot ✅  → fa-circle-check (with the success colour)
    †   → fa-cross
  Section heading "Чланови домаћинства" → "Чланови", and the
  decorative icons in front of "Живи чланови" / "Преминули чланови"
  removed. The strikethrough on deceased names is gone — the cross
  icon already carries that meaning.

* **Instant tooltip on `[data-tooltip]`** — replaces the slow native `title` behaviour (multi-second hover wait). The `print` button, the toolbar dropdowns, the filter chip, the back arrow, and the search-kbd ESC chip all already use the attribute; the CSS was missing on main.

* **Form field with action button** (`.form-field-with-action`) — a small helper for FK fields that have a + button next to them. Pre-staged for future quick-add work.

* **Dark theme overrides** for the tooltip, page-size selector, list-controls dropdowns, and `.stavka__secondary` muted text — these were unstyled under `[data-theme=dark]` after the list-page redesign landed.