### PR TITLE
ci: bump pylint workflow to Python 3.13 + use repo's pylint config

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.13"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pylint pylint-junit pylint-django
-    - name: Analysing the code with pylint
-      run: |
-        pylint $(git ls-files '*.py')
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pylint pylint-junit pylint-django
+      - name: Analysing the code with pylint
+        run: |
+          pylint --rcfile=.pylintrc --django-settings-module=crkva.settings $(git ls-files '*.py')


### PR DESCRIPTION
Action was running on Python 3.10 and not honouring the repo's `.pylintrc` or Django settings module. Results were noisy and the build was failing on environment issues unrelated to code quality.

Changes:
  * python-version: 3.10 → 3.13 (matches what local dev/runtime uses).
  * actions/checkout@v3 → @v4, setup-python@v3 → @v5 (current LTS).
  * pylint command now passes `--rcfile=.pylintrc` and `--django-settings-module=crkva.settings` so the run matches the local pre-commit pylint (already in .pre-commit-config.yaml).