### PR TITLE
auth: login page + sidebar prijava/odjava buttons

### DIFF
--- a/crkva/registar/templates/registar/login.html
+++ b/crkva/registar/templates/registar/login.html
@@ -1,0 +1,165 @@
+{% load static %}
+{% load compress %}
+<!DOCTYPE html>
+<html lang="sr">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
+    <meta name="theme-color" content="#A21514">
+    <script>
+      (function() {
+        try {
+          var saved = localStorage.getItem('theme');
+          if (saved) {
+            document.documentElement.setAttribute('data-theme', saved);
+          }
+        } catch (e) {}
+      })();
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+    {% compress css %}
+      <link rel="stylesheet" href="{% static 'registar/base/fonts.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/base/tokens.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/themes/tamna.css' %}">
+    {% endcompress %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="icon" href="{% static 'registar/favicon.png' %}" type="image/x-icon">
+    <title>Пријава — Црквени регистар</title>
+    <style>
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        background: var(--color-surface-2);
+      }
+      .login-card {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 12px;
+        box-shadow: var(--shadow-lg);
+        padding: 40px 36px 32px;
+        width: 100%;
+        max-width: 400px;
+        margin: var(--space-4);
+      }
+      .login-header {
+        text-align: center;
+        margin-bottom: var(--space-6);
+      }
+      .login-header i {
+        font-size: 48px;
+        color: var(--color-primary);
+        margin-bottom: var(--space-3);
+        display: block;
+      }
+      .login-header h1 {
+        font-size: 22px;
+        font-weight: 600;
+        margin: 0 0 var(--space-2);
+        color: var(--color-text);
+      }
+      .login-header p {
+        color: var(--color-text-muted);
+        font-size: 14px;
+        margin: 0;
+      }
+      .login-form .form-group {
+        margin-bottom: var(--space-4);
+      }
+      .login-form label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 6px;
+        font-size: 14px;
+        color: var(--color-text);
+      }
+      .login-form input[type="text"],
+      .login-form input[type="password"] {
+        width: 100%;
+        padding: 10px 12px;
+        font-size: 16px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-2);
+        background: var(--color-surface);
+        color: var(--color-text);
+        box-shadow: var(--shadow-sm);
+        box-sizing: border-box;
+      }
+      .login-form input:focus {
+        outline: 2px solid var(--color-primary);
+        outline-offset: 2px;
+      }
+      .login-form .login-button {
+        width: 100%;
+        font-size: 16px;
+        line-height: 20px;
+        background: var(--color-primary);
+        padding: 10px 15px;
+        min-height: 44px;
+        color: #fff;
+        box-shadow: 0px 6px 10px -4px rgba(0, 0, 0, 0.25);
+        font-weight: 600;
+        transition: all ease 0.3s;
+        border: 1px solid rgba(255,255,255,0.2);
+        border-radius: var(--radius-2);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .login-form .login-button:hover {
+        background: var(--color-primary-700);
+        box-shadow: 0 8px 14px -6px rgba(0,0,0,0.3);
+      }
+      .login-errors {
+        background: #fef2f2;
+        border: 1px solid #fca5a5;
+        border-radius: var(--radius-2);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-4);
+        color: #991b1b;
+        font-size: 14px;
+      }
+      :root[data-theme="dark"] .login-errors {
+        background: rgba(185, 28, 28, 0.15);
+        border-color: rgba(185, 28, 28, 0.4);
+        color: #fca5a5;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="login-card">
+      <div class="login-header">
+        <i class="fas fa-church"></i>
+        <h1>Црквени регистар</h1>
+        <p>Пријавите се на свој налог</p>
+      </div>
+
+      {% if form.errors %}
+      <div class="login-errors">
+        <i class="fas fa-exclamation-circle"></i>
+        Погрешно корисничко име или лозинка.
+      </div>
+      {% endif %}
+
+      <form method="post" class="login-form" novalidate>
+        {% csrf_token %}
+        <div class="form-group">
+          <label for="id_username">Корисничко име</label>
+          <input type="text" name="username" id="id_username" autofocus autocapitalize="none" autocomplete="username" maxlength="150" required>
+        </div>
+        <div class="form-group">
+          <label for="id_password">Лозинка</label>
+          <input type="password" name="password" id="id_password" autocomplete="current-password" required>
+        </div>
+        <button type="submit" class="login-button">
+          <i class="fas fa-sign-in-alt" style="margin-right: 8px;"></i> Пријава
+        </button>
+        <input type="hidden" name="next" value="{{ next }}">
+      </form>
+    </div>
+  </body>
+</html>

--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -89,6 +89,28 @@
       <span class="sidebar-text">Тема</span>
     </button>
 
+    {% if user.is_authenticated %}
+    <div class="sidebar-action-btn" style="cursor: default; opacity: 0.7;">
+      <i class="fa-solid fa-user"></i>
+      <span class="sidebar-text">{{ user.username }}</span>
+    </div>
+
+    <!-- Logout -->
+    <form method="post" action="{% url 'logout' %}" style="margin:0;padding:0;">
+      {% csrf_token %}
+      <button type="submit" class="sidebar-action-btn" aria-label="Одјава" title="Одјава">
+        <i class="fa-solid fa-right-from-bracket"></i>
+        <span class="sidebar-text">Одјава</span>
+      </button>
+    </form>
+    {% else %}
+    <!-- Login -->
+    <a href="{% url 'login' %}" class="sidebar-action-btn" aria-label="Пријава" title="Пријава">
+      <i class="fa-solid fa-right-to-bracket"></i>
+      <span class="sidebar-text">Пријава</span>
+    </a>
+    {% endif %}
+
   </div>
 </aside>
 

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -1,11 +1,18 @@
 """Овај модул дефинише URL обрасце за апликацију регистар."""
 
+from django.contrib.auth import views as auth_views
 from django.urls import include, path
 
 from . import views
 
 handler404 = "registar.views.custom_404"
 urlpatterns = [
+    path(
+        "prijava/",
+        auth_views.LoginView.as_view(template_name="registar/login.html"),
+        name="login",
+    ),
+    path("odjava/", auth_views.LogoutView.as_view(next_page="/"), name="logout"),
     path("", views.index, name="pocetna"),
     path("select2/", include("django_select2.urls")),
     path("slava-kalendar/", views.kalendar, name="kalendar"),


### PR DESCRIPTION
Brings auth UI in from feature/final.

* New `registar/login.html` template — full-bleed centred card with the project logo, a clear username/password form, and an inline error block when credentials are wrong.
* URL patterns: `/prijava/` (LoginView) and `/odjava/` (LogoutView → redirects to /), both named (`login` / `logout`).
* Sidebar bottom block:
    - When user is authenticated: shows the username + a logout submit-button (POST so it's CSRF-protected).
    - When anonymous: shows a "Пријава" link to the login page. Uses the existing `sidebar-action-btn` styling so the buttons match the rest of the bottom-row actions (Претрага, Тема, …).

The `@login_required` decorators on views are still commented out elsewhere, so navigating the site doesn't require login yet — but the auth machinery is in place for when we flip those on.