### PR TITLE
quick-add osoba modal: inline person creation from entry forms

### DIFF
--- a/crkva/registar/templates/registar/_modal_osoba.html
+++ b/crkva/registar/templates/registar/_modal_osoba.html
@@ -1,0 +1,179 @@
+<!-- Модал за брзо додавање особе -->
+<div id="osoba-modal" class="osoba-modal-overlay" style="display:none;">
+  <div class="osoba-modal">
+    <div class="osoba-modal__header">
+      <h3><i class="fa-solid fa-user-plus"></i> Нова особа</h3>
+      <button type="button" class="osoba-modal__close" onclick="osobaModal.close()">&times;</button>
+    </div>
+    <div class="osoba-modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-ime">Име *</label>
+          <input type="text" id="modal-ime" autocomplete="off" required>
+        </div>
+        <div class="form-field">
+          <label for="modal-prezime">Презиме *</label>
+          <input type="text" id="modal-prezime" autocomplete="off" required>
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">
+          <label>Пол</label>
+          <div class="toggle-group" id="modal-pol-toggle">
+            <button type="button" class="toggle-button" data-value="М">мушки</button>
+            <button type="button" class="toggle-button" data-value="Ж">женски</button>
+          </div>
+        </div>
+      </div>
+      <div id="modal-error" class="error-text" style="display:none;"></div>
+    </div>
+    <div class="osoba-modal__footer">
+      <button type="button" class="button" onclick="osobaModal.close()" style="background:var(--color-surface-1);color:var(--color-text);border:1px solid var(--color-border);">Откажи</button>
+      <button type="button" class="button button--primary" onclick="osobaModal.save()">
+        <i class="fa-solid fa-check" style="margin-right:6px;"></i>Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+.osoba-modal-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,0.5);
+  display: flex; align-items: center; justify-content: center;
+}
+.osoba-modal {
+  background: var(--color-surface); border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  width: 90%; max-width: 440px;
+  animation: modalIn 0.15s ease-out;
+}
+@keyframes modalIn { from { opacity:0; transform:scale(0.95); } to { opacity:1; transform:scale(1); } }
+.osoba-modal__header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 20px; border-bottom: 1px solid var(--color-border);
+}
+.osoba-modal__header h3 { margin: 0; font-size: 16px; }
+.osoba-modal__close {
+  background: none; border: none; font-size: 24px; cursor: pointer;
+  color: var(--color-text-muted); line-height: 1; padding: 0 4px;
+}
+.osoba-modal__close:hover { color: var(--color-primary); }
+.osoba-modal__body { padding: 20px; }
+.osoba-modal__body .form-row { margin-bottom: 12px; }
+.osoba-modal__body input[type="text"] {
+  width: 100%; padding: 10px 12px; font-size: 16px;
+  border: 1px solid var(--color-border); border-radius: var(--radius-2);
+  background: var(--color-surface); color: var(--color-text);
+  box-sizing: border-box;
+}
+.osoba-modal__body input:focus {
+  outline: 2px solid var(--color-primary); outline-offset: 2px;
+}
+.osoba-modal__footer {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 12px 20px; border-top: 1px solid var(--color-border);
+}
+</style>
+
+<script>
+var osobaModal = (function() {
+  var overlay = document.getElementById('osoba-modal');
+  var imeInput = document.getElementById('modal-ime');
+  var prezimeInput = document.getElementById('modal-prezime');
+  var errorDiv = document.getElementById('modal-error');
+  var polToggle = document.getElementById('modal-pol-toggle');
+  var targetFieldId = null;
+  var selectedPol = '';
+
+  // Pol toggle buttons
+  polToggle.querySelectorAll('.toggle-button').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      polToggle.querySelectorAll('.toggle-button').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      selectedPol = btn.dataset.value;
+    });
+  });
+
+  function open(fieldId) {
+    targetFieldId = fieldId;
+    imeInput.value = '';
+    prezimeInput.value = '';
+    selectedPol = '';
+    errorDiv.style.display = 'none';
+    polToggle.querySelectorAll('.toggle-button').forEach(function(b) { b.classList.remove('active'); });
+    overlay.style.display = 'flex';
+    setTimeout(function() { imeInput.focus(); }, 50);
+  }
+
+  function close() {
+    overlay.style.display = 'none';
+    targetFieldId = null;
+  }
+
+  function save() {
+    var ime = imeInput.value.trim();
+    var prezime = prezimeInput.value.trim();
+    if (!ime || !prezime) {
+      errorDiv.textContent = 'Име и презиме су обавезни.';
+      errorDiv.style.display = 'block';
+      return;
+    }
+    errorDiv.style.display = 'none';
+
+    var csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    var formData = new FormData();
+    formData.append('ime', ime);
+    formData.append('prezime', prezime);
+    formData.append('pol', selectedPol);
+
+    fetch('{% url "brzi_unos_osobe" %}', {
+      method: 'POST',
+      headers: { 'X-CSRFToken': csrfToken },
+      body: formData
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) {
+        errorDiv.textContent = data.error;
+        errorDiv.style.display = 'block';
+        return;
+      }
+      // Add the new option to the select2 widget and select it
+      var select = document.getElementById(targetFieldId);
+      if (select) {
+        var option = new Option(data.text, data.id, true, true);
+        select.appendChild(option);
+        // Trigger select2 change event
+        if (window.jQuery) {
+          jQuery(select).trigger('change');
+        }
+      }
+      close();
+    })
+    .catch(function(err) {
+      errorDiv.textContent = 'Грешка при чувању. Покушајте поново.';
+      errorDiv.style.display = 'block';
+    });
+  }
+
+  // Close on ESC
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && overlay.style.display === 'flex') close();
+  });
+
+  // Close on overlay click
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) close();
+  });
+
+  // Enter key saves
+  [imeInput, prezimeInput].forEach(function(input) {
+    input.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') { e.preventDefault(); save(); }
+    });
+  });
+
+  return { open: open, close: close, save: save };
+})();
+</script>

--- a/crkva/registar/templates/registar/unos_krstenja.html
+++ b/crkva/registar/templates/registar/unos_krstenja.html
@@ -73,7 +73,10 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.dete.label_tag }}
-          {{ form.dete }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.dete }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_dete')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -83,13 +86,19 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.otac.label_tag }}
-          {{ form.otac }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.otac }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_otac')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.majka.label_tag }}
-          {{ form.majka }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.majka }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_majka')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -113,7 +122,10 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.kum.label_tag }}
-          {{ form.kum }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.kum }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -137,5 +149,6 @@
 
     <!-- Bottom save removed as per request: action button is now at the top -->
   </form>
-{{ form.media.js }}
+  {% include "registar/_modal_osoba.html" %}
+  {{ form.media.js }}
 {% endblock %}

--- a/crkva/registar/templates/registar/unos_vencanja.html
+++ b/crkva/registar/templates/registar/unos_vencanja.html
@@ -68,7 +68,10 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.zenik.label_tag }}
-          {{ form.zenik }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.zenik }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_zenik')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -78,7 +81,10 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.nevesta.label_tag }}
-          {{ form.nevesta }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.nevesta }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_nevesta')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -88,21 +94,33 @@
       <div class="form-row">
         <div class="form-field">
           {{ form.svekar.label_tag }}
-          {{ form.svekar }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.svekar }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekar')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
         <div class="form-field">
           {{ form.svekrva.label_tag }}
-          {{ form.svekrva }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.svekrva }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekrva')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
       <div class="form-row">
         <div class="form-field">
           {{ form.tast.label_tag }}
-          {{ form.tast }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.tast }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tast')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
         <div class="form-field">
           {{ form.tasta.label_tag }}
-          {{ form.tasta }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.tasta }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tasta')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -127,11 +145,17 @@
       <div class="form-row">
         <div class="form-field">
           {{ form.kum.label_tag }}
-          {{ form.kum }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.kum }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
         <div class="form-field">
           {{ form.stari_svat.label_tag }}
-          {{ form.stari_svat }}
+          <div class="form-field-with-action">
+            <div class="form-field-with-action__input">{{ form.stari_svat }}</div>
+            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_stari_svat')"><i class="fa-solid fa-plus"></i></button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -148,5 +172,6 @@
 
     <!-- Bottom save removed as per request: action button is now at the top -->
   </form>
-{{ form.media.js }}
+  {% include "registar/_modal_osoba.html" %}
+  {{ form.media.js }}
 {% endblock %}

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -68,6 +68,7 @@ urlpatterns = [
     ),
     path("search/", views.search_view, name="search_view"),
     path("api/search/", views.search_autocomplete, name="search_autocomplete"),
+    path("api/brzi-unos-osobe/", views.brzi_unos_osobe, name="brzi_unos_osobe"),
     path("unos/parohijan/", views.unos_parohijana, name="unos_parohijana"),
     path("unos/krstenje/", views.unos_krstenja, name="unos_krstenja"),
     path("unos/vencanje/", views.unos_vencanja, name="unos_vencanja"),

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -411,3 +411,19 @@ def search_autocomplete(request):
         groups.append({"label": "Венчања", "items": items})
 
     return JsonResponse({"groups": groups})
+
+
+def brzi_unos_osobe(request):
+    """AJAX endpoint за брзо креирање особе из модалног дијалога."""
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    ime = request.POST.get("ime", "").strip()
+    prezime = request.POST.get("prezime", "").strip()
+    pol = request.POST.get("pol", "").strip()
+
+    if not ime or not prezime:
+        return JsonResponse({"error": "Име и презиме су обавезни"}, status=400)
+
+    osoba = Parohijan.objects.create(ime=ime, prezime=prezime, pol=pol or None)
+    return JsonResponse({"id": osoba.uid, "text": str(osoba)})


### PR DESCRIPTION
Adds the "+" button next to every FK person field on the entry forms. Click it → a modal opens, you fill in ime/prezime/pol, hit save, and the new Osoba gets created and the FK field is set to it — no need to navigate away from the krštenje/venčanje you're entering.

What's wired up:

  * _modal_osoba.html (179 lines) — Bootstrap-style modal with a small form (ime, prezime, pol). Submits via fetch to the new brzi_unos_osobe endpoint, picks up the JSON {id, text} response, and assigns it to the originating Select2 widget.
  * brzi_unos_osobe view — POST-only JSON endpoint. Creates the Parohijan and returns {id, text}. Returns 400 if ime/prezime missing.
  * /api/brzi-unos-osobe/ URL.
  * Re-wired form-field-with-action blocks on unos_krstenja.html and unos_vencanja.html so each FK person field (дете, отац, мајка, кум, женик, невеста, свекар, свекрва, таст, ташта, стари сват) has its + button.

Replaces the bare Select2 widgets that were in the previous fix/entry-pages-redesign PR — that PR intentionally left the
+ buttons out so the modal could land separately and atomically.