### PR TITLE
refactor: extract reusable Modal component from _modal_osoba

### DIFF
--- a/crkva/registar/static/registar/components/modal.js
+++ b/crkva/registar/static/registar/components/modal.js
@@ -1,0 +1,202 @@
+/* ==========================================================================
+   MODAL — generic open/close + bindForm helper
+   ==========================================================================
+   Used by quick-add modals (e.g. osoba). One global `Modal` object.
+
+   API:
+     Modal.open(modalId, targetFieldId?)
+         Show the modal. If targetFieldId is given, the Select2 widget with
+         that id receives the new option on save.
+
+     Modal.close(modalId)
+         Hide the modal.
+
+     var inst = Modal.bindForm(modalId, options)
+         Bind a quick-add form. Returns { open, close, save } so existing
+         inline onclick="osobaModal.open('id_dete')" calls keep working.
+
+         options = {
+             url:          "/api/brzi-unos-osobe/",  // POST endpoint
+             fields:       ["ime", "prezime", "pol"],  // input ids: "modal-<field>"
+             toggleGroups: { pol: "modal-pol-toggle" },  // optional: data-value toggle buttons
+             requiredMessage: "Име и презиме су обавезни.",
+             requiredFields: ["ime", "prezime"],
+             onSuccess:    function(data, targetFieldId) { ... }
+                           // default: appends new <option> to the Select2 widget
+         }
+
+   Global behaviours wired automatically:
+     - Esc closes any open modal
+     - Click on the overlay (not its child) closes
+     - Enter inside a text input triggers save
+   ========================================================================== */
+
+(function () {
+    "use strict";
+
+    const _openModals = new Set();
+
+    function _csrfToken() {
+        const el = document.querySelector("[name=csrfmiddlewaretoken]");
+        return el ? el.value : "";
+    }
+
+    function open(modalId, targetFieldId) {
+        const overlay = document.getElementById(modalId);
+        if (!overlay) return;
+        overlay._targetFieldId = targetFieldId || null;
+        overlay.style.display = "flex";
+        _openModals.add(modalId);
+        // Clear inputs / errors
+        overlay.querySelectorAll("input[type=text]").forEach((i) => (i.value = ""));
+        overlay
+            .querySelectorAll(".toggle-button.active")
+            .forEach((b) => b.classList.remove("active"));
+        const err = overlay.querySelector(".error-text");
+        if (err) err.style.display = "none";
+        // Focus the first input
+        setTimeout(() => {
+            const first = overlay.querySelector("input[type=text]");
+            if (first) first.focus();
+        }, 50);
+    }
+
+    function close(modalId) {
+        const overlay = document.getElementById(modalId);
+        if (!overlay) return;
+        overlay.style.display = "none";
+        overlay._targetFieldId = null;
+        _openModals.delete(modalId);
+    }
+
+    function _defaultOnSuccess(data, targetFieldId) {
+        if (!targetFieldId) return;
+        const select = document.getElementById(targetFieldId);
+        if (!select) return;
+        const option = new Option(data.text, data.id, true, true);
+        select.appendChild(option);
+        if (window.jQuery) {
+            jQuery(select).trigger("change");
+        }
+    }
+
+    function bindForm(modalId, options) {
+        const overlay = document.getElementById(modalId);
+        if (!overlay) {
+            console.warn("Modal.bindForm: no element with id", modalId);
+            return null;
+        }
+        const opts = Object.assign(
+            {
+                url: "",
+                fields: [],
+                toggleGroups: {},
+                requiredFields: [],
+                requiredMessage: "Сва обавезна поља морају бити попуњена.",
+                onSuccess: _defaultOnSuccess,
+            },
+            options || {},
+        );
+
+        // Wire toggle-group buttons (e.g. pol: M/Ж)
+        const toggleState = {};
+        Object.entries(opts.toggleGroups).forEach(([fieldName, groupId]) => {
+            const group = document.getElementById(groupId);
+            if (!group) return;
+            group.querySelectorAll(".toggle-button").forEach((btn) => {
+                btn.addEventListener("click", () => {
+                    group
+                        .querySelectorAll(".toggle-button")
+                        .forEach((b) => b.classList.remove("active"));
+                    btn.classList.add("active");
+                    toggleState[fieldName] = btn.dataset.value;
+                });
+            });
+        });
+
+        // Enter inside any text input → save
+        overlay.querySelectorAll("input[type=text]").forEach((input) => {
+            input.addEventListener("keydown", (e) => {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    save();
+                }
+            });
+        });
+
+        function _showError(msg) {
+            const err = overlay.querySelector(".error-text");
+            if (err) {
+                err.textContent = msg;
+                err.style.display = "block";
+            }
+        }
+
+        function save() {
+            const values = {};
+            for (const f of opts.fields) {
+                const el = document.getElementById("modal-" + f);
+                if (el) values[f] = el.value.trim();
+            }
+            Object.entries(toggleState).forEach(([k, v]) => {
+                values[k] = v;
+            });
+
+            // Validate required
+            const missing = opts.requiredFields.filter((f) => !values[f]);
+            if (missing.length) {
+                _showError(opts.requiredMessage);
+                return;
+            }
+            _showError("");
+            const err = overlay.querySelector(".error-text");
+            if (err) err.style.display = "none";
+
+            const formData = new FormData();
+            Object.entries(values).forEach(([k, v]) => formData.append(k, v || ""));
+
+            fetch(opts.url, {
+                method: "POST",
+                headers: { "X-CSRFToken": _csrfToken() },
+                body: formData,
+            })
+                .then((r) => r.json())
+                .then((data) => {
+                    if (data.error) {
+                        _showError(data.error);
+                        return;
+                    }
+                    opts.onSuccess(data, overlay._targetFieldId);
+                    close(modalId);
+                })
+                .catch(() => {
+                    _showError("Грешка при чувању. Покушајте поново.");
+                });
+        }
+
+        return {
+            open: function (targetFieldId) {
+                open(modalId, targetFieldId);
+            },
+            close: function () {
+                close(modalId);
+            },
+            save: save,
+        };
+    }
+
+    // Global Esc + overlay-click handlers
+    document.addEventListener("keydown", (e) => {
+        if (e.key !== "Escape" || _openModals.size === 0) return;
+        // Close the most recently opened modal
+        const last = Array.from(_openModals).pop();
+        close(last);
+    });
+    document.addEventListener("click", (e) => {
+        if (e.target.classList && e.target.classList.contains("modal-overlay")) {
+            close(e.target.id);
+        }
+    });
+
+    window.Modal = { open: open, close: close, bindForm: bindForm };
+})();

--- a/crkva/registar/static/registar/components/modali.css
+++ b/crkva/registar/static/registar/components/modali.css
@@ -1,0 +1,120 @@
+/* ==========================================================================
+   MODAL COMPONENT
+   ==========================================================================
+   Generic modal shell used by quick-add dialogs (e.g. _modal_osoba.html).
+
+   Markup pattern:
+     <div id="my-modal" class="modal-overlay" style="display:none;">
+       <div class="modal">
+         <div class="modal__header">
+           <h3><i class="fa-solid fa-…"></i> Title</h3>
+           <button class="modal__close" onclick="Modal.close('my-modal')">&times;</button>
+         </div>
+         <div class="modal__body">
+           …fields…
+         </div>
+         <div class="modal__footer">
+           <button class="button button--neutral" onclick="Modal.close('my-modal')">Откажи</button>
+           <button class="button button--primary" onclick="myModalInstance.save()">Сачувај</button>
+         </div>
+       </div>
+     </div>
+
+   Behaviour is provided by registar/components/modal.js
+   (Modal.open / close / bindForm).
+   ========================================================================== */
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal {
+    background: var(--color-surface);
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    width: 90%;
+    max-width: 440px;
+    animation: modal-in 0.15s ease-out;
+}
+
+@keyframes modal-in {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.modal__header h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.modal__close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    line-height: 1;
+    padding: 0 4px;
+}
+
+.modal__close:hover {
+    color: var(--color-primary);
+}
+
+.modal__body {
+    padding: 20px;
+}
+
+.modal__body .form-row {
+    margin-bottom: 12px;
+}
+
+.modal__body input[type="text"] {
+    width: 100%;
+    padding: 10px 12px;
+    font-size: 16px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-sizing: border-box;
+}
+
+.modal__body input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 20px;
+    border-top: 1px solid var(--color-border);
+}
+
+.modal .error-text {
+    color: var(--color-danger, #b91c1c);
+    font-size: 13px;
+    margin-top: 8px;
+}

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -45,6 +45,7 @@
       <link rel="stylesheet" href="{% static 'registar/components/forme.css' %}">
       <link rel="stylesheet" href="{% static 'registar/components/oznake.css' %}">
       <link rel="stylesheet" href="{% static 'registar/components/tabovi.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/components/modali.css' %}">
       <!-- Dark theme overrides (loaded last for correct specificity) -->
       <link rel="stylesheet" href="{% static 'registar/themes/tamna.css' %}">
     {% endcompress %}
@@ -165,5 +166,6 @@
         io.observe(sentinel);
       })();
     </script>
+    <script src="{% static 'registar/components/modal.js' %}"></script>
   </body>
 </html>

--- a/crkva/registar/templates/registar/_modal_osoba.html
+++ b/crkva/registar/templates/registar/_modal_osoba.html
@@ -1,11 +1,12 @@
-<!-- Модал за брзо додавање особе -->
-<div id="osoba-modal" class="osoba-modal-overlay" style="display:none;">
-  <div class="osoba-modal">
-    <div class="osoba-modal__header">
+{# Quick-add Osoba modal. Uses the generic Modal component
+   (registar/components/modali.css + modal.js). #}
+<div id="osoba-modal" class="modal-overlay" style="display:none;">
+  <div class="modal">
+    <div class="modal__header">
       <h3><i class="fa-solid fa-user-plus"></i> Нова особа</h3>
-      <button type="button" class="osoba-modal__close" onclick="osobaModal.close()">&times;</button>
+      <button type="button" class="modal__close" onclick="Modal.close('osoba-modal')">&times;</button>
     </div>
-    <div class="osoba-modal__body">
+    <div class="modal__body">
       <div class="form-row">
         <div class="form-field">
           <label for="modal-ime">Име *</label>
@@ -25,10 +26,10 @@
           </div>
         </div>
       </div>
-      <div id="modal-error" class="error-text" style="display:none;"></div>
+      <div class="error-text" style="display:none;"></div>
     </div>
-    <div class="osoba-modal__footer">
-      <button type="button" class="button" onclick="osobaModal.close()" style="background:var(--color-surface-1);color:var(--color-text);border:1px solid var(--color-border);">Откажи</button>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('osoba-modal')">Откажи</button>
       <button type="button" class="button button--primary" onclick="osobaModal.save()">
         <i class="fa-solid fa-check" style="margin-right:6px;"></i>Сачувај
       </button>
@@ -36,144 +37,12 @@
   </div>
 </div>
 
-<style>
-.osoba-modal-overlay {
-  position: fixed; inset: 0; z-index: 9999;
-  background: rgba(0,0,0,0.5);
-  display: flex; align-items: center; justify-content: center;
-}
-.osoba-modal {
-  background: var(--color-surface); border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-  width: 90%; max-width: 440px;
-  animation: modalIn 0.15s ease-out;
-}
-@keyframes modalIn { from { opacity:0; transform:scale(0.95); } to { opacity:1; transform:scale(1); } }
-.osoba-modal__header {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 16px 20px; border-bottom: 1px solid var(--color-border);
-}
-.osoba-modal__header h3 { margin: 0; font-size: 16px; }
-.osoba-modal__close {
-  background: none; border: none; font-size: 24px; cursor: pointer;
-  color: var(--color-text-muted); line-height: 1; padding: 0 4px;
-}
-.osoba-modal__close:hover { color: var(--color-primary); }
-.osoba-modal__body { padding: 20px; }
-.osoba-modal__body .form-row { margin-bottom: 12px; }
-.osoba-modal__body input[type="text"] {
-  width: 100%; padding: 10px 12px; font-size: 16px;
-  border: 1px solid var(--color-border); border-radius: var(--radius-2);
-  background: var(--color-surface); color: var(--color-text);
-  box-sizing: border-box;
-}
-.osoba-modal__body input:focus {
-  outline: 2px solid var(--color-primary); outline-offset: 2px;
-}
-.osoba-modal__footer {
-  display: flex; justify-content: flex-end; gap: 8px;
-  padding: 12px 20px; border-top: 1px solid var(--color-border);
-}
-</style>
-
 <script>
-var osobaModal = (function() {
-  var overlay = document.getElementById('osoba-modal');
-  var imeInput = document.getElementById('modal-ime');
-  var prezimeInput = document.getElementById('modal-prezime');
-  var errorDiv = document.getElementById('modal-error');
-  var polToggle = document.getElementById('modal-pol-toggle');
-  var targetFieldId = null;
-  var selectedPol = '';
-
-  // Pol toggle buttons
-  polToggle.querySelectorAll('.toggle-button').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      polToggle.querySelectorAll('.toggle-button').forEach(function(b) { b.classList.remove('active'); });
-      btn.classList.add('active');
-      selectedPol = btn.dataset.value;
-    });
+  var osobaModal = Modal.bindForm("osoba-modal", {
+    url: "{% url 'brzi_unos_osobe' %}",
+    fields: ["ime", "prezime", "pol"],
+    toggleGroups: { pol: "modal-pol-toggle" },
+    requiredFields: ["ime", "prezime"],
+    requiredMessage: "Име и презиме су обавезни.",
   });
-
-  function open(fieldId) {
-    targetFieldId = fieldId;
-    imeInput.value = '';
-    prezimeInput.value = '';
-    selectedPol = '';
-    errorDiv.style.display = 'none';
-    polToggle.querySelectorAll('.toggle-button').forEach(function(b) { b.classList.remove('active'); });
-    overlay.style.display = 'flex';
-    setTimeout(function() { imeInput.focus(); }, 50);
-  }
-
-  function close() {
-    overlay.style.display = 'none';
-    targetFieldId = null;
-  }
-
-  function save() {
-    var ime = imeInput.value.trim();
-    var prezime = prezimeInput.value.trim();
-    if (!ime || !prezime) {
-      errorDiv.textContent = 'Име и презиме су обавезни.';
-      errorDiv.style.display = 'block';
-      return;
-    }
-    errorDiv.style.display = 'none';
-
-    var csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-    var formData = new FormData();
-    formData.append('ime', ime);
-    formData.append('prezime', prezime);
-    formData.append('pol', selectedPol);
-
-    fetch('{% url "brzi_unos_osobe" %}', {
-      method: 'POST',
-      headers: { 'X-CSRFToken': csrfToken },
-      body: formData
-    })
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      if (data.error) {
-        errorDiv.textContent = data.error;
-        errorDiv.style.display = 'block';
-        return;
-      }
-      // Add the new option to the select2 widget and select it
-      var select = document.getElementById(targetFieldId);
-      if (select) {
-        var option = new Option(data.text, data.id, true, true);
-        select.appendChild(option);
-        // Trigger select2 change event
-        if (window.jQuery) {
-          jQuery(select).trigger('change');
-        }
-      }
-      close();
-    })
-    .catch(function(err) {
-      errorDiv.textContent = 'Грешка при чувању. Покушајте поново.';
-      errorDiv.style.display = 'block';
-    });
-  }
-
-  // Close on ESC
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && overlay.style.display === 'flex') close();
-  });
-
-  // Close on overlay click
-  overlay.addEventListener('click', function(e) {
-    if (e.target === overlay) close();
-  });
-
-  // Enter key saves
-  [imeInput, prezimeInput].forEach(function(input) {
-    input.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') { e.preventDefault(); save(); }
-    });
-  });
-
-  return { open: open, close: close, save: save };
-})();
 </script>


### PR DESCRIPTION
The osoba quick-add modal carried 110 lines of inline CSS + 100 lines of IIFE JavaScript inside the template. Adding another quick-add modal (Hram, Slava, …) would mean copy-pasting all of it. Pulled the shell and the behaviour out so each consumer is a slim template + one Modal.bindForm call.

New shared pieces:

  components/modali.css   Generic .modal-overlay / .modal /
                          .modal__header / .modal__body / .modal__footer
                          rules + .error-text + the modal-in keyframe.
                          Added to the compressor bundle in base.html.

  components/modal.js     One global `Modal` object exposing:
                            Modal.open(modalId, targetFieldId?)
                            Modal.close(modalId)
                            Modal.bindForm(modalId, options)
                          bindForm wires up: collecting the inputs by
                          id ("modal-<field>"), toggle-group buttons,
                          Enter-to-save, validation, CSRF-protected POST,
                          response handling, and a default `onSuccess`
                          that appends the new option to a Select2 widget.
                          Esc and overlay-click handlers are global.

  templates/registar/_modal_osoba.html
                          Slim consumer: declares the markup with the
                          generic classes and calls Modal.bindForm with
                          the brzi_unos_osobe url, the field list, the
                          pol toggle group, and the validation rules.
                          From 179 lines → 36.

Adding a new modal now means:
  1. Copy _modal_osoba.html, rename the id and headline.
  2. Adjust the body fields to your inputs (use id="modal-<field>").
  3. Update the Modal.bindForm options (url, fields, etc.).

Existing osobaModal.open("id_dete") calls from the entry forms keep working — bindForm still returns an instance with open/close/save.