### PR TITLE
fix sidebar: align <button> and <a> .sidebar-action-btn elements

### DIFF
--- a/crkva/registar/static/registar/layout/bocna-traka.css
+++ b/crkva/registar/static/registar/layout/bocna-traka.css
@@ -380,7 +380,14 @@ body.sidebar-collapsed .sidebar-toggle {
 }
 
 .sidebar-action-btn {
+  /* Used by both <button> elements (Претрага, Тема, Одјава) and the
+     <a> Пријава link. Without explicit resets, those two element types
+     don't render at the same dimensions: <button> has a UA-specified
+     font-family and box-sizing: border-box, while <a> defaults to
+     content-box, text-decoration: underline, and inherits color from the
+     parent stylesheet. */
   width: 100%;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -388,10 +395,13 @@ body.sidebar-collapsed .sidebar-toggle {
   background: transparent;
   border: none;
   color: var(--sidebar-text-color);
+  text-decoration: none;
   cursor: pointer;
+  font: inherit;
   font-size: 15px;
-  transition: background 0.2s;
+  line-height: 1.4;
   text-align: left;
+  transition: background 0.2s;
 }
 
 .sidebar-action-btn:hover {


### PR DESCRIPTION
The bottom of the sidebar mixes <button> (Претрага, Тема, Одјава) and <a> (Пријава) elements, all sharing .sidebar-action-btn. Without explicit resets the two element types render at slightly different dimensions because:

  * <button> defaults to box-sizing: border-box; <a> to content-box, so the same "padding: 12px 20px" produces different total widths.
  * <button> has a UA-specified font-family; <a> inherits from parent. Mixed fonts mean slightly different text metrics and vertical alignment of the icon.
  * <a> defaults to text-decoration: underline, which appeared on hover for the login link only.

Added to .sidebar-action-btn:
  * box-sizing: border-box
  * text-decoration: none
  * font: inherit
  * line-height: 1.4

Buttons and the login link now occupy identical boxes, icons sit on the same baseline, and hovering the login link no longer underlines.