### PR TITLE
fix: set LOGIN_URL / LOGIN_REDIRECT_URL / LOGOUT_REDIRECT_URL

### DIFF
--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -144,6 +144,12 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 
+# Authentication redirects
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "pocetna"
+LOGOUT_REDIRECT_URL = "login"
+
+
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/
 


### PR DESCRIPTION
Django defaults assume /accounts/login/ and /accounts/profile/, which do not exist in this app — login succeeded but post-login redirect 404\x27d. Point auth at the named URL routes the app actually exposes.