### PR TITLE
fix sidebar: align submenu item icon with parent menu column

### DIFF
--- a/crkva/registar/static/registar/layout/bocna-traka.css
+++ b/crkva/registar/static/registar/layout/bocna-traka.css
@@ -283,7 +283,7 @@ body.sidebar-collapsed .sidebar-toggle {
 }
 
 .sidebar-menu-group .sidebar-menu-item.sidebar-submenu-item > a:first-child {
-  padding-left: 56px;
+  padding-left: 20px;
   font-size: 14px;
   opacity: 0.85;
 }


### PR DESCRIPTION
The submenu rule was overriding the base 20px left-padding with 56px, which pushed the submenu icon \(Домаћинства fa-house\) ~36px right of the parent icon column \(Парохијани fa-users\) and broke the visual alignment of the icon strip down the sidebar.