### PR TITLE
fix: serve static files via whitenoise under gunicorn

### DIFF
--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -73,6 +73,7 @@ DATABASE_ROUTERS = ("django_tenants.routers.TenantSyncRouter",)
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,6 @@ uWSGI>=2.0.19.1,<2.1
 
 # PDF Generation
 WeasyPrint~=62.3
+
+# Static file serving
+whitenoise~=6.12


### PR DESCRIPTION
The site moved from \`runserver 0.0.0.0:9000\` to gunicorn, which does not serve STATIC_URL on its own. Pages rendered without CSS/JS because every /static/static/... request returned 404. Add whitenoise as the first middleware after SecurityMiddleware so collected static files \(including django-compressor output\) are served alongside the WSGI responses.