### PR TITLE
tenants: add /tenant/switch/<id>/ endpoint

### DIFF
--- a/crkva/crkva/urls.py
+++ b/crkva/crkva/urls.py
@@ -21,6 +21,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("tenant/", include("tenants.urls")),
     path("", include("registar.urls")),
 ]
 

--- a/crkva/tenants/tests/test_switch.py
+++ b/crkva/tenants/tests/test_switch.py
@@ -1,0 +1,97 @@
+"""Tests for the tenant-switch endpoint."""
+
+# pylint: disable=missing-function-docstring  # test names already describe intent
+
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.urls import reverse
+from tenants.middleware import SESSION_TENANT_KEY
+from tenants.models import Tenant, UserMembership
+
+
+class SwitchTenantViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant_a = Tenant.objects.get(schema_name="test_tenant")
+        # bulk_create bypasses TenantMixin.save() so we don't try to provision
+        # new Postgres schemas from inside the active tenant schema.
+        Tenant.objects.bulk_create(
+            [
+                Tenant(
+                    schema_name="test_tenant_b",
+                    naziv="Test B",
+                    parohija_naziv="Test B",
+                    is_active=True,
+                ),
+                Tenant(
+                    schema_name="test_tenant_off",
+                    naziv="Test Off",
+                    parohija_naziv="Test Off",
+                    is_active=False,
+                ),
+            ]
+        )
+        cls.tenant_b = Tenant.objects.get(schema_name="test_tenant_b")
+        cls.tenant_inactive = Tenant.objects.get(schema_name="test_tenant_off")
+
+        cls.superuser = User.objects.create_superuser(
+            username="root", password="x", email="root@test"
+        )
+        cls.user = User.objects.create_user(username="alice", password="x")
+        UserMembership.objects.create(user=cls.user, tenant=cls.tenant_a)
+
+    def setUp(self):
+        # Each test starts on the default test_tenant schema; ensure that
+        # the User/session/Tenant lookups in middleware see consistent state.
+        connection.set_tenant(self.tenant_a)
+        self.client = Client()
+
+    def url(self, tenant_id):
+        return reverse("tenants:switch", kwargs={"tenant_id": tenant_id})
+
+    def test_anonymous_redirects_to_login(self):
+        r = self.client.post(self.url(self.tenant_a.pk))
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/prijava/", r["Location"])
+
+    def test_get_not_allowed(self):
+        self.client.force_login(self.superuser)
+        r = self.client.get(self.url(self.tenant_a.pk))
+        self.assertEqual(r.status_code, 405)
+
+    def test_superuser_can_switch_to_any_active(self):
+        self.client.force_login(self.superuser)
+        r = self.client.post(self.url(self.tenant_b.pk))
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(self.client.session[SESSION_TENANT_KEY], self.tenant_b.pk)
+
+    def test_member_can_switch_to_own_tenant(self):
+        self.client.force_login(self.user)
+        r = self.client.post(self.url(self.tenant_a.pk))
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(self.client.session[SESSION_TENANT_KEY], self.tenant_a.pk)
+
+    def test_non_member_forbidden(self):
+        self.client.force_login(self.user)
+        r = self.client.post(self.url(self.tenant_b.pk))
+        self.assertEqual(r.status_code, 403)
+        self.assertNotEqual(
+            self.client.session.get(SESSION_TENANT_KEY), self.tenant_b.pk
+        )
+
+    def test_inactive_tenant_is_404(self):
+        self.client.force_login(self.superuser)
+        r = self.client.post(self.url(self.tenant_inactive.pk))
+        self.assertEqual(r.status_code, 404)
+
+    def test_unknown_tenant_is_404(self):
+        self.client.force_login(self.superuser)
+        r = self.client.post(self.url(999999))
+        self.assertEqual(r.status_code, 404)
+
+    def test_redirect_to_next_when_provided(self):
+        self.client.force_login(self.superuser)
+        r = self.client.post(self.url(self.tenant_b.pk), {"next": "/krstenja/"})
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r["Location"], "/krstenja/")

--- a/crkva/tenants/urls.py
+++ b/crkva/tenants/urls.py
@@ -1,0 +1,10 @@
+"""URL patterns for the tenants app."""
+
+from django.urls import path
+from tenants import views
+
+app_name = "tenants"
+
+urlpatterns = [
+    path("switch/<int:tenant_id>/", views.switch_tenant, name="switch"),
+]

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -12,6 +12,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.decorators.http import require_POST
+from django.utils.http import url_has_allowed_host_and_scheme
 from tenants.middleware import SESSION_TENANT_KEY
 from tenants.models import Tenant, UserMembership
 
@@ -32,6 +33,11 @@ def switch_tenant(request: HttpRequest, tenant_id: int) -> HttpResponse:
     request.session[SESSION_TENANT_KEY] = tenant.pk
 
     next_url = request.POST.get("next") or request.META.get("HTTP_REFERER")
-    if not next_url:
-        next_url = reverse("pocetna")
+    fallback_url = reverse("pocetna")
+    if not next_url or not url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = fallback_url
     return HttpResponseRedirect(next_url)

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -1,0 +1,37 @@
+"""Tenant switching view.
+
+A logged-in user POSTs to /tenant/switch/<id>/ and the active tenant is
+swapped on their session. Superusers can pick any active tenant; regular
+users only the ones they have a UserMembership for.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.views.decorators.http import require_POST
+from tenants.middleware import SESSION_TENANT_KEY
+from tenants.models import Tenant, UserMembership
+
+
+@login_required
+@require_POST
+def switch_tenant(request: HttpRequest, tenant_id: int) -> HttpResponse:
+    """Set the active tenant on the session, then redirect back."""
+    tenant = get_object_or_404(Tenant, pk=tenant_id, is_active=True)
+
+    if not request.user.is_superuser:
+        allowed = UserMembership.objects.filter(
+            user=request.user, tenant=tenant
+        ).exists()
+        if not allowed:
+            return HttpResponse(status=403)
+
+    request.session[SESSION_TENANT_KEY] = tenant.pk
+
+    next_url = request.POST.get("next") or request.META.get("HTTP_REFERER")
+    if not next_url:
+        next_url = reverse("pocetna")
+    return HttpResponseRedirect(next_url)


### PR DESCRIPTION
POST /tenant/switch/<tenant_id>/ writes the chosen tenant pk into session\\[active_tenant_id\\] so the next request resolves to that schema. Superusers can target any active tenant; other users need a UserMembership row. Optional next redirect, otherwise back to the Referer, otherwise the home page.

Includes 8 tests covering anonymous, GET-not-allowed, superuser, member, non-member (403), inactive tenant (404), unknown tenant (404), and the next-redirect path.