### PR TITLE
tenants: per-resource roles + permission gating for write views

### DIFF
--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -27,9 +27,11 @@
           <i class="fa-solid fa-users"></i>
           <span class="sidebar-text">Парохијани</span>
         </a>
+        {% if can_edit_osoba %}
         <a href="{{ unos_parohijana_url }}" class="sidebar-add-btn {% if request.path == unos_parohijana_url %}active{% endif %}" title="Додај парохијана" aria-label="Додај парохијана">
           <i class="fa-solid fa-circle-plus"></i>
         </a>
+        {% endif %}
       </div>
 
       <div class="sidebar-menu-item sidebar-submenu-item">
@@ -45,9 +47,11 @@
         <i class="fa-solid fa-droplet"></i>
         <span class="sidebar-text">Крштења</span>
       </a>
+      {% if can_edit_krstenje %}
       <a href="{{ unos_krstenja_url }}" class="sidebar-add-btn {% if request.path == unos_krstenja_url %}active{% endif %}" title="Додај крштење" aria-label="Додај крштење">
         <i class="fa-solid fa-circle-plus"></i>
       </a>
+      {% endif %}
     </div>
 
     <div class="sidebar-menu-item">
@@ -55,9 +59,11 @@
         <i class="icon-rings"></i>
         <span class="sidebar-text">Венчања</span>
       </a>
+      {% if can_edit_vencanje %}
       <a href="{{ unos_vencanja_url }}" class="sidebar-add-btn {% if request.path == unos_vencanja_url %}active{% endif %}" title="Додај венчање" aria-label="Додај венчање">
         <i class="fa-solid fa-circle-plus"></i>
       </a>
+      {% endif %}
     </div>
 
     <div class="sidebar-menu-item">

--- a/crkva/registar/tests/test_integration.py
+++ b/crkva/registar/tests/test_integration.py
@@ -103,6 +103,7 @@ class KrstenjeCreationIntegrationTest(TestCase):
 
     def test_krstenje_creation_page_accessible(self):
         """Тест да је страница за креирање крштења доступна"""
+        self.client.force_login(self.user)
         response = self.client.get(reverse("unos_krstenja"))
         self.assertEqual(response.status_code, 200)
 
@@ -208,6 +209,7 @@ class VencanjeCreationIntegrationTest(TestCase):
 
     def test_vencanje_creation_page_accessible(self):
         """Тест да је страница за креирање венчања доступна"""
+        self.client.force_login(self.user)
         response = self.client.get(reverse("unos_vencanja"))
         self.assertEqual(response.status_code, 200)
 

--- a/crkva/registar/tests/test_views.py
+++ b/crkva/registar/tests/test_views.py
@@ -4,6 +4,7 @@
 
 import datetime
 
+from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 from registar.models import Hram, Krstenje, Osoba
@@ -224,6 +225,10 @@ class UnosKrstenjaViewTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_superuser(
+            username="krst-tester", email="t@x.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_unos_krstenja_get_returns_200(self):
         """GET захтев за унос крштења враћа статус 200."""

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from registar.models import Domacinstvo, Krstenje, Parohijan, Slava, Svestenik, Vencanje
 from registar.utils import get_query_variants
 from registar.utils_fasting import get_fasting_type
+from tenants.permissions import tenant_role_required
 
 from .domacinstvo_view import PrikazDomacinstva, SpisakDomacinsta
 from .kalendar_view import kalendar
@@ -413,6 +414,7 @@ def search_autocomplete(request):
     return JsonResponse({"groups": groups})
 
 
+@tenant_role_required("osoba")
 def brzi_unos_osobe(request):
     """AJAX endpoint за брзо креирање особе из модалног дијалога."""
     if request.method != "POST":

--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -8,6 +8,7 @@ from django.views.generic import DetailView, ListView
 from registar.forms import KrstenjeForm
 from registar.models import Krstenje
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from tenants.permissions import tenant_role_required
 from weasyprint import HTML
 
 KRSTENJE_RELATED = (
@@ -20,7 +21,7 @@ KRSTENJE_RELATED = (
 )
 
 
-# @login_required
+@tenant_role_required("krstenje")
 def unos_krstenja(request):
     """
     Обрађује захтеве за унос новог крштења. Ако је захтев POST,

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -9,10 +9,11 @@ from registar.forms import ParohijanForm
 from registar.models import Krstenje
 from registar.models.parohijan import Parohijan
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from tenants.permissions import tenant_role_required
 from weasyprint import HTML
 
 
-# @login_required
+@tenant_role_required("osoba")
 def unos_parohijana(request):
     """
     Обрађује захтев за додавање новог парохијана. Ако је метод POST,

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -8,6 +8,7 @@ from django.views.generic import DetailView, ListView
 from registar.forms import VencanjeForm
 from registar.models.vencanje import Vencanje
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from tenants.permissions import tenant_role_required
 from weasyprint import HTML
 
 VENCANJE_RELATED = (
@@ -129,6 +130,7 @@ class PrikazVencanja(DetailView):
 
 
 # @login_required
+@tenant_role_required("vencanje")
 def unos_vencanja(request):
     """Обрада уноса новог венчања."""
     if request.method == "POST":

--- a/crkva/tenants/context_processors.py
+++ b/crkva/tenants/context_processors.py
@@ -1,7 +1,26 @@
-"""Expose `tenant` to every template."""
+"""Expose tenant + per-resource write flags to every template."""
 
 from __future__ import annotations
 
+from tenants.permissions import (
+    DOMACINSTVO,
+    KRSTENJE,
+    OSOBA,
+    SVESTENIK,
+    VENCANJE,
+    can_edit,
+)
+
 
 def current_tenant(request):
-    return {"tenant": getattr(request, "tenant", None)}
+    """Make request.tenant and a `can_edit_<resource>` flag available."""
+    tenant = getattr(request, "tenant", None)
+    user = getattr(request, "user", None)
+    return {
+        "tenant": tenant,
+        "can_edit_osoba": can_edit(user, tenant, OSOBA),
+        "can_edit_domacinstvo": can_edit(user, tenant, DOMACINSTVO),
+        "can_edit_krstenje": can_edit(user, tenant, KRSTENJE),
+        "can_edit_vencanje": can_edit(user, tenant, VENCANJE),
+        "can_edit_svestenik": can_edit(user, tenant, SVESTENIK),
+    }

--- a/crkva/tenants/migrations/0003_remap_roles.py
+++ b/crkva/tenants/migrations/0003_remap_roles.py
@@ -1,0 +1,44 @@
+"""Remap UserMembership.role: member→kancelarija, viewer→pregled.
+
+Replaces the old admin/member/viewer choices with
+admin/kancelarija/svestenstvo/pregled. Existing 'admin' rows stay.
+"""
+
+from django.db import migrations, models
+
+
+def forward(apps, schema_editor):
+    Membership = apps.get_model("tenants", "UserMembership")
+    Membership.objects.filter(role="member").update(role="kancelarija")
+    Membership.objects.filter(role="viewer").update(role="pregled")
+
+
+def backward(apps, schema_editor):
+    Membership = apps.get_model("tenants", "UserMembership")
+    Membership.objects.filter(role="kancelarija").update(role="member")
+    Membership.objects.filter(role="svestenstvo").update(role="member")
+    Membership.objects.filter(role="pregled").update(role="viewer")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenants", "0002_create_default_tenant"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+        migrations.AlterField(
+            model_name="usermembership",
+            name="role",
+            field=models.CharField(
+                choices=[
+                    ("admin", "Администратор"),
+                    ("kancelarija", "Канцеларија"),
+                    ("svestenstvo", "Свештенство"),
+                    ("pregled", "Преглед"),
+                ],
+                default="pregled",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/crkva/tenants/models.py
+++ b/crkva/tenants/models.py
@@ -89,9 +89,12 @@ class Domain(DomainMixin):
 
 
 class Role(models.TextChoices):
-    ADMIN = "admin", "Администратор парохије"
-    MEMBER = "member", "Члан парохије"
-    VIEWER = "viewer", "Преглед без измена"
+    # Канцеларија editirá parohijane/domaćinstva/krštenja/venčanja.
+    # Свештенство editirá svestenike. Преглед је read-only за све.
+    ADMIN = "admin", "Администратор"
+    KANCELARIJA = "kancelarija", "Канцеларија"
+    SVESTENSTVO = "svestenstvo", "Свештенство"
+    PREGLED = "pregled", "Преглед"
 
 
 class UserMembership(models.Model):
@@ -110,7 +113,7 @@ class UserMembership(models.Model):
     role = models.CharField(
         max_length=20,
         choices=Role.choices,
-        default=Role.MEMBER,
+        default=Role.PREGLED,
     )
     is_default = models.BooleanField(
         default=False,

--- a/crkva/tenants/permissions.py
+++ b/crkva/tenants/permissions.py
@@ -1,0 +1,72 @@
+"""Role-based permission helpers.
+
+Resource buckets — each constant matches one of the editable domains in
+the registar app. Roles map to the set of resources they can write to:
+
+    Админ        → all five
+    Канцеларија  → osoba, domacinstvo, krstenje, vencanje
+    Свештенство  → svestenik
+    Преглед      → none
+
+Superusers bypass the role check entirely. Anonymous users can never
+write. All authenticated users can read.
+
+Use the `tenant_role_required(resource)` decorator on write views and
+the `can_edit_*` flags exposed by the context processor in templates.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse
+from tenants.models import Role, UserMembership
+
+OSOBA = "osoba"
+DOMACINSTVO = "domacinstvo"
+KRSTENJE = "krstenje"
+VENCANJE = "vencanje"
+SVESTENIK = "svestenik"
+
+ALL_RESOURCES = frozenset({OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK})
+KANCELARIJA_RESOURCES = frozenset({OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE})
+SVESTENSTVO_RESOURCES = frozenset({SVESTENIK})
+
+WRITE_BY_ROLE: dict[str, frozenset[str]] = {
+    Role.ADMIN: ALL_RESOURCES,
+    Role.KANCELARIJA: KANCELARIJA_RESOURCES,
+    Role.SVESTENSTVO: SVESTENSTVO_RESOURCES,
+    Role.PREGLED: frozenset(),
+}
+
+
+def can_edit(user, tenant, resource: str) -> bool:
+    """True if `user` may write `resource` inside `tenant`."""
+    if user is None or not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    if tenant is None:
+        return False
+    membership = UserMembership.objects.filter(user=user, tenant=tenant).first()
+    if membership is None:
+        return False
+    return resource in WRITE_BY_ROLE.get(membership.role, frozenset())
+
+
+def tenant_role_required(resource: str):
+    """Decorator: 403 if request.user can't write `resource` in request.tenant."""
+
+    def decorator(view_func):
+        @wraps(view_func)
+        @login_required
+        def _wrapped(request: HttpRequest, *args, **kwargs) -> HttpResponse:
+            if not can_edit(request.user, getattr(request, "tenant", None), resource):
+                raise PermissionDenied
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped
+
+    return decorator

--- a/crkva/tenants/tests/test_permissions.py
+++ b/crkva/tenants/tests/test_permissions.py
@@ -1,0 +1,150 @@
+"""Tests for tenants.permissions: role-based write gating."""
+
+# pylint: disable=missing-function-docstring  # test names describe intent
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import RequestFactory, TestCase
+from tenants.models import Role, Tenant, UserMembership
+from tenants.permissions import (
+    DOMACINSTVO,
+    KRSTENJE,
+    OSOBA,
+    SVESTENIK,
+    VENCANJE,
+    can_edit,
+)
+
+
+class CanEditTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.superuser = User.objects.create_superuser(
+            username="root", password="x", email="root@test"
+        )
+        cls.admin = User.objects.create_user(username="adm", password="x")
+        UserMembership.objects.create(
+            user=cls.admin, tenant=cls.tenant, role=Role.ADMIN
+        )
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.priest = User.objects.create_user(username="svest", password="x")
+        UserMembership.objects.create(
+            user=cls.priest, tenant=cls.tenant, role=Role.SVESTENSTVO
+        )
+        cls.viewer = User.objects.create_user(username="view", password="x")
+        UserMembership.objects.create(
+            user=cls.viewer, tenant=cls.tenant, role=Role.PREGLED
+        )
+        cls.stranger = User.objects.create_user(username="nope", password="x")
+
+    def test_anonymous_cannot_edit_anything(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK]:
+            self.assertFalse(can_edit(AnonymousUser(), self.tenant, resource))
+
+    def test_superuser_can_edit_everything(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK]:
+            self.assertTrue(can_edit(self.superuser, self.tenant, resource))
+
+    def test_admin_role_can_edit_everything(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK]:
+            self.assertTrue(can_edit(self.admin, self.tenant, resource))
+
+    def test_kancelarija_edits_data_but_not_svestenik(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE]:
+            self.assertTrue(
+                can_edit(self.clerk, self.tenant, resource),
+                f"clerk should edit {resource}",
+            )
+        self.assertFalse(can_edit(self.clerk, self.tenant, SVESTENIK))
+
+    def test_svestenstvo_edits_only_svestenik(self):
+        self.assertTrue(can_edit(self.priest, self.tenant, SVESTENIK))
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE]:
+            self.assertFalse(
+                can_edit(self.priest, self.tenant, resource),
+                f"priest should NOT edit {resource}",
+            )
+
+    def test_pregled_cannot_edit_anything(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK]:
+            self.assertFalse(can_edit(self.viewer, self.tenant, resource))
+
+    def test_user_without_membership_cannot_edit(self):
+        for resource in [OSOBA, DOMACINSTVO, KRSTENJE, VENCANJE, SVESTENIK]:
+            self.assertFalse(can_edit(self.stranger, self.tenant, resource))
+
+    def test_no_tenant_means_no_edit(self):
+        self.assertFalse(can_edit(self.admin, None, OSOBA))
+
+
+class GatedViewTests(TestCase):
+    """End-to-end: GET /unos/parohijan/ returns 403 for non-permitted roles."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.priest = User.objects.create_user(username="svest", password="x")
+        UserMembership.objects.create(
+            user=cls.priest, tenant=cls.tenant, role=Role.SVESTENSTVO
+        )
+
+    def test_clerk_can_open_parohijan_form(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get("/unos/parohijan/")
+        self.assertEqual(r.status_code, 200)
+
+    def test_priest_cannot_open_parohijan_form(self):
+        self.client.force_login(self.priest)
+        r = self.client.get("/unos/parohijan/")
+        self.assertEqual(r.status_code, 403)
+
+    def test_clerk_cannot_quick_add_osoba_via_priest_role_fail(self):
+        # priest role isn't allowed to create osoba via brzi_unos_osobe
+        self.client.force_login(self.priest)
+        r = self.client.post(
+            "/api/brzi-unos-osobe/",
+            {"ime": "Иван", "prezime": "Тест", "pol": "M"},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_clerk_can_quick_add_osoba(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            "/api/brzi-unos-osobe/",
+            {"ime": "Иван", "prezime": "Тест", "pol": "M"},
+        )
+        self.assertEqual(r.status_code, 200)
+
+    def test_anonymous_redirects_to_login(self):
+        r = self.client.get("/unos/parohijan/")
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/prijava/", r["Location"])
+
+
+class ContextProcessorTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+
+    def test_template_sees_can_edit_flags(self):
+        from tenants.context_processors import current_tenant
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = self.clerk
+        request.tenant = self.tenant
+        ctx = current_tenant(request)
+        self.assertTrue(ctx["can_edit_osoba"])
+        self.assertTrue(ctx["can_edit_krstenje"])
+        self.assertFalse(ctx["can_edit_svestenik"])


### PR DESCRIPTION
Replace placeholder admin/member/viewer with four roles reflecting how a parish actually divides labor: Админ, Канцеларија (parohijani, domaćinstva, krštenja, venčanja), Свештенство (svestenici), Преглед (read-only). Data migration remaps any existing member/viewer rows.

tenants.permissions adds can_edit(user, tenant, resource) and a @tenant_role_required(resource) decorator. Decorator applied to unos_parohijana, unos_krstenja, unos_vencanja, and brzi_unos_osobe. Context processor exposes can_edit_<resource> flags; sidebar + buttons render only for users who can use the linked form.

Existing tests that hit unos_* anonymously are updated to force_login first now that those views require write permission.

Includes 14 new permission tests covering each role × each resource plus the gated endpoints. Superusers bypass the role check.