### PR TITLE
feat: self-edit user profile at /tenant/profile/

### DIFF
--- a/crkva/registar/templates/registar/profile.html
+++ b/crkva/registar/templates/registar/profile.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="u-page-header">
+    <h1 class="u-page-title">Профил корисника</h1>
+  </div>
+
+  {% if messages %}
+    <div class="form-messages" style="margin-bottom:var(--space-4);">
+      {% for message in messages %}
+        <div class="alert alert-{{ message.tags|default:'info' }}" style="background:#ecfdf5;border:1px solid #6ee7b7;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);color:#065f46;">
+          <i class="fa-solid fa-check-circle"></i> {{ message }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <form method="post" class="form" style="margin-bottom:var(--space-6);">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="info">
+    <fieldset class="form-section">
+      <legend>Подаци</legend>
+      <div class="form-row">
+        <div class="form-field">
+          <label>Корисничко име</label>
+          <input type="text" value="{{ user.username }}" disabled style="background:var(--color-surface-muted);">
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">{{ info_form.first_name.label_tag }} {{ info_form.first_name }}</div>
+        <div class="form-field">{{ info_form.last_name.label_tag }} {{ info_form.last_name }}</div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">{{ info_form.email.label_tag }} {{ info_form.email }}</div>
+      </div>
+      {% if info_form.errors %}
+        <div style="color:#991b1b;">{{ info_form.errors }}</div>
+      {% endif %}
+      <div style="margin-top:var(--space-3);">
+        <button class="button button--primary" type="submit">
+          <i class="fa-solid fa-floppy-disk" style="margin-right:6px;"></i>
+          Сачувај податке
+        </button>
+      </div>
+    </fieldset>
+  </form>
+
+  <form method="post" class="form">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="password">
+    <fieldset class="form-section">
+      <legend>Промена лозинке</legend>
+      <div class="form-row">
+        <div class="form-field">
+          <label for="id_old_password">Тренутна лозинка</label>
+          {{ password_form.old_password }}
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">
+          <label for="id_new_password1">Нова лозинка</label>
+          {{ password_form.new_password1 }}
+        </div>
+        <div class="form-field">
+          <label for="id_new_password2">Поново нова лозинка</label>
+          {{ password_form.new_password2 }}
+        </div>
+      </div>
+      {% if password_form.errors %}
+        <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin:var(--space-3) 0;color:#991b1b;">
+          <ul style="margin:0;padding-left:20px;">
+            {% for field, errors in password_form.errors.items %}
+              {% for error in errors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+      <div style="margin-top:var(--space-3);">
+        <button class="button button--primary" type="submit">
+          <i class="fa-solid fa-key" style="margin-right:6px;"></i>
+          Промени лозинку
+        </button>
+      </div>
+    </fieldset>
+  </form>
+{% endblock %}

--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -102,10 +102,10 @@
     </button>
 
     {% if user.is_authenticated %}
-    <div class="sidebar-action-btn" style="cursor: default; opacity: 0.7;">
+    <a href="{% url 'tenants:profile' %}" class="sidebar-action-btn {% if request.path == '/tenant/profile/' %}active{% endif %}" title="Профил" aria-label="Профил">
       <i class="fa-solid fa-user"></i>
       <span class="sidebar-text">{{ user.username }}</span>
-    </div>
+    </a>
 
     <!-- Logout -->
     <form method="post" action="{% url 'logout' %}" style="margin:0;padding:0;">

--- a/crkva/tenants/forms.py
+++ b/crkva/tenants/forms.py
@@ -1,0 +1,21 @@
+"""Forms for the self-edit user profile page."""
+
+from __future__ import annotations
+
+from django import forms
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class ProfileForm(forms.ModelForm):
+    """Edit first_name, last_name, email of the logged-in user."""
+
+    class Meta:
+        model = User
+        fields = ["first_name", "last_name", "email"]
+        labels = {
+            "first_name": "Име",
+            "last_name": "Презиме",
+            "email": "Е-маил",
+        }

--- a/crkva/tenants/tests/test_profile.py
+++ b/crkva/tenants/tests/test_profile.py
@@ -1,0 +1,115 @@
+"""Tests for the self-edit user profile view."""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+
+class ProfileViewTests(TestCase):
+    """Smoke tests for /tenant/profile/ info + password change."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username="alice", password="oldpass123!", email="alice@old.test"
+        )
+
+    def setUp(self):
+        self.client = Client()
+
+    def url(self):
+        return reverse("tenants:profile")
+
+    def test_anonymous_redirects_to_login(self):
+        r = self.client.get(self.url())
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/prijava/", r["Location"])
+
+    def test_get_returns_form(self):
+        self.client.force_login(self.user)
+        r = self.client.get(self.url())
+        self.assertEqual(r.status_code, 200)
+        self.assertTemplateUsed(r, "registar/profile.html")
+        self.assertIn("info_form", r.context)
+        self.assertIn("password_form", r.context)
+
+    def test_save_info_updates_user(self):
+        self.client.force_login(self.user)
+        r = self.client.post(
+            self.url(),
+            {
+                "action": "info",
+                "first_name": "Алиса",
+                "last_name": "Тест",
+                "email": "alice@new.test",
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Алиса")
+        self.assertEqual(self.user.last_name, "Тест")
+        self.assertEqual(self.user.email, "alice@new.test")
+
+    def test_change_password_with_correct_old_password(self):
+        self.client.force_login(self.user)
+        r = self.client.post(
+            self.url(),
+            {
+                "action": "password",
+                "old_password": "oldpass123!",
+                "new_password1": "newpass456!",
+                "new_password2": "newpass456!",
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("newpass456!"))
+
+    def test_change_password_with_wrong_old_rejects(self):
+        self.client.force_login(self.user)
+        r = self.client.post(
+            self.url(),
+            {
+                "action": "password",
+                "old_password": "WRONG",
+                "new_password1": "newpass456!",
+                "new_password2": "newpass456!",
+            },
+        )
+        self.assertEqual(r.status_code, 200)  # re-renders with errors
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpass123!"))
+
+    def test_change_password_mismatched_new_passwords(self):
+        self.client.force_login(self.user)
+        r = self.client.post(
+            self.url(),
+            {
+                "action": "password",
+                "old_password": "oldpass123!",
+                "new_password1": "newpass456!",
+                "new_password2": "different!",
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpass123!"))
+
+    def test_change_password_keeps_user_logged_in(self):
+        self.client.force_login(self.user)
+        self.client.post(
+            self.url(),
+            {
+                "action": "password",
+                "old_password": "oldpass123!",
+                "new_password1": "newpass456!",
+                "new_password2": "newpass456!",
+            },
+        )
+        # subsequent GET to a login_required view should still work
+        r = self.client.get(self.url())
+        self.assertEqual(r.status_code, 200)

--- a/crkva/tenants/urls.py
+++ b/crkva/tenants/urls.py
@@ -7,4 +7,5 @@ app_name = "tenants"
 
 urlpatterns = [
     path("switch/<int:tenant_id>/", views.switch_tenant, name="switch"),
+    path("profile/", views.profile, name="profile"),
 ]

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -1,18 +1,17 @@
-"""Tenant switching view.
-
-A logged-in user POSTs to /tenant/switch/<id>/ and the active tenant is
-swapped on their session. Superusers can pick any active tenant; regular
-users only the ones they have a UserMembership for.
-"""
+"""Tenant switching + self-edit profile views."""
 
 from __future__ import annotations
 
+from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.forms import PasswordChangeForm
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.views.decorators.http import require_POST
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.http import require_POST
+from tenants.forms import ProfileForm
 from tenants.middleware import SESSION_TENANT_KEY
 from tenants.models import Tenant, UserMembership
 
@@ -41,3 +40,33 @@ def switch_tenant(request: HttpRequest, tenant_id: int) -> HttpResponse:
     ):
         next_url = fallback_url
     return HttpResponseRedirect(next_url)
+
+
+@login_required
+def profile(request: HttpRequest) -> HttpResponse:
+    """Self-edit profile. Two forms in one page: info + password."""
+    info_form = ProfileForm(instance=request.user)
+    password_form = PasswordChangeForm(user=request.user)
+
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "info":
+            info_form = ProfileForm(request.POST, instance=request.user)
+            if info_form.is_valid():
+                info_form.save()
+                messages.success(request, "Подаци сачувани.")
+                return redirect("tenants:profile")
+        elif action == "password":
+            password_form = PasswordChangeForm(user=request.user, data=request.POST)
+            if password_form.is_valid():
+                user = password_form.save()
+                # keep the user logged in after their password changes
+                update_session_auth_hash(request, user)
+                messages.success(request, "Лозинка промењена.")
+                return redirect("tenants:profile")
+
+    return render(
+        request,
+        "registar/profile.html",
+        {"info_form": info_form, "password_form": password_form},
+    )


### PR DESCRIPTION
Logged-in user can update first_name, last_name, email and change their password (verifies current password via PasswordChangeForm, keeps the session alive via update_session_auth_hash). The page has two forms in one template; \`action=info\` saves profile fields, \`action=password\` runs the password change.

Sidebar username badge becomes a link to the profile page.

7 tests cover anonymous redirect, GET, info save, correct password change, wrong old password rejected, mismatched new passwords, and session survives a successful password change.