### PR TITLE
feat: per-tenant admin user management

### DIFF
--- a/crkva/registar/templates/registar/users_add.html
+++ b/crkva/registar/templates/registar/users_add.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <form method="post" class="form">
+    {% csrf_token %}
+    <div class="u-page-header">
+      <a href="{% url 'tenants:user_list' %}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+      </a>
+      <h1 class="u-page-title">Нови корисник — {{ tenant.naziv }}</h1>
+      <button class="button button--primary" type="submit" title="Сачувај">
+        <i class="fa-solid fa-floppy-disk" style="margin-right:6px;"></i> Сачувај
+      </button>
+    </div>
+
+    {% if form.errors %}
+      <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+        <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+        <ul style="margin:8px 0 0;padding-left:20px;">
+          {% for field, errors in form.errors.items %}
+            {% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <fieldset class="form-section">
+      <legend>Налог</legend>
+      <div class="form-row">
+        <div class="form-field">{{ form.username.label_tag }} {{ form.username }}</div>
+        <div class="form-field">{{ form.password.label_tag }} {{ form.password }}</div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">{{ form.first_name.label_tag }} {{ form.first_name }}</div>
+        <div class="form-field">{{ form.last_name.label_tag }} {{ form.last_name }}</div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">{{ form.email.label_tag }} {{ form.email }}</div>
+      </div>
+    </fieldset>
+
+    <fieldset class="form-section">
+      <legend>Приступ у парохији</legend>
+      <div class="form-row">
+        <div class="form-field">{{ form.role.label_tag }} {{ form.role }}</div>
+        <div class="form-field">
+          <label>{{ form.is_default }} {{ form.is_default.label }}</label>
+        </div>
+      </div>
+    </fieldset>
+  </form>
+{% endblock %}

--- a/crkva/registar/templates/registar/users_list.html
+++ b/crkva/registar/templates/registar/users_list.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="u-page-header">
+    <h1 class="u-page-title">Корисници — {{ tenant.naziv }}</h1>
+    <a href="{% url 'tenants:user_add' %}" class="button button--primary" title="Додај корисника">
+      <i class="fa-solid fa-user-plus" style="margin-right:6px;"></i> Додај корисника
+    </a>
+  </div>
+
+  {% if messages %}
+    <div class="form-messages" style="margin-bottom:var(--space-4);">
+      {% for message in messages %}
+        <div class="alert" style="background:#ecfdf5;border:1px solid #6ee7b7;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);color:#065f46;">
+          {{ message }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <table class="data-table" style="width:100%;border-collapse:collapse;">
+    <thead>
+      <tr style="border-bottom:2px solid var(--color-border);">
+        <th style="text-align:left;padding:var(--space-3);">Корисник</th>
+        <th style="text-align:left;padding:var(--space-3);">Име</th>
+        <th style="text-align:left;padding:var(--space-3);">Е-маил</th>
+        <th style="text-align:left;padding:var(--space-3);">Улога</th>
+        <th style="text-align:left;padding:var(--space-3);">Активан</th>
+        <th style="text-align:right;padding:var(--space-3);">Акције</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for m in memberships %}
+        <tr style="border-bottom:1px solid var(--color-border);">
+          <td style="padding:var(--space-3);">{{ m.user.username }}</td>
+          <td style="padding:var(--space-3);">{{ m.user.first_name }} {{ m.user.last_name }}</td>
+          <td style="padding:var(--space-3);">{{ m.user.email|default:"—" }}</td>
+          <td style="padding:var(--space-3);">
+            <form method="post" action="{% url 'tenants:user_edit_role' m.user.pk %}" style="display:inline-flex;gap:8px;align-items:center;">
+              {% csrf_token %}
+              <select name="role" onchange="this.form.submit()" class="list-toolbar__select">
+                {% for value, label in m.Role.choices %}{% endfor %}
+                <option value="admin" {% if m.role == "admin" %}selected{% endif %}>Администратор</option>
+                <option value="kancelarija" {% if m.role == "kancelarija" %}selected{% endif %}>Канцеларија</option>
+                <option value="svestenstvo" {% if m.role == "svestenstvo" %}selected{% endif %}>Свештенство</option>
+                <option value="pregled" {% if m.role == "pregled" %}selected{% endif %}>Преглед</option>
+              </select>
+            </form>
+          </td>
+          <td style="padding:var(--space-3);">
+            {% if m.user.is_active %}
+              <span style="color:#059669;"><i class="fa-solid fa-circle-check"></i> Да</span>
+            {% else %}
+              <span style="color:#dc2626;"><i class="fa-solid fa-circle-xmark"></i> Не</span>
+            {% endif %}
+          </td>
+          <td style="padding:var(--space-3);text-align:right;">
+            {% if m.user.pk != request.user.pk %}
+              <form method="post" action="{% url 'tenants:user_deactivate' m.user.pk %}" style="display:inline;" onsubmit="return confirm('{% if m.user.is_active %}Деактивирати{% else %}Активирати{% endif %} {{ m.user.username }}?');">
+                {% csrf_token %}
+                <button type="submit" class="button button--ghost" title="{% if m.user.is_active %}Деактивирај{% else %}Активирај{% endif %}">
+                  <i class="fa-solid {% if m.user.is_active %}fa-user-slash{% else %}fa-user-check{% endif %}"></i>
+                </button>
+              </form>
+            {% endif %}
+          </td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="6" style="padding:var(--space-4);text-align:center;color:var(--color-text-muted);">Нема корисника</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -107,6 +107,13 @@
       <span class="sidebar-text">Тема</span>
     </button>
 
+    {% if is_tenant_admin %}
+    <a href="{% url 'tenants:user_list' %}" class="sidebar-action-btn {% if request.path == '/tenant/users/' or request.path|slice:':14' == '/tenant/users/' %}active{% endif %}" title="Корисници" aria-label="Корисници">
+      <i class="fa-solid fa-users-gear"></i>
+      <span class="sidebar-text">Корисници</span>
+    </a>
+    {% endif %}
+
     {% if user.is_authenticated %}
     <a href="{% url 'tenants:profile' %}" class="sidebar-action-btn {% if request.path == '/tenant/profile/' %}active{% endif %}" title="Профил" aria-label="Профил">
       <i class="fa-solid fa-user"></i>

--- a/crkva/tenants/context_processors.py
+++ b/crkva/tenants/context_processors.py
@@ -9,15 +9,17 @@ from tenants.permissions import (
     SVESTENIK,
     VENCANJE,
     can_edit,
+    is_tenant_admin,
 )
 
 
 def current_tenant(request):
-    """Make request.tenant and a `can_edit_<resource>` flag available."""
+    """Make request.tenant, can_edit_<resource>, and is_admin available."""
     tenant = getattr(request, "tenant", None)
     user = getattr(request, "user", None)
     return {
         "tenant": tenant,
+        "is_tenant_admin": is_tenant_admin(user, tenant),
         "can_edit_osoba": can_edit(user, tenant, OSOBA),
         "can_edit_domacinstvo": can_edit(user, tenant, DOMACINSTVO),
         "can_edit_krstenje": can_edit(user, tenant, KRSTENJE),

--- a/crkva/tenants/forms.py
+++ b/crkva/tenants/forms.py
@@ -1,9 +1,12 @@
-"""Forms for the self-edit user profile page."""
+"""Forms for the self-edit user profile page and admin user management."""
 
 from __future__ import annotations
 
 from django import forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
+from tenants.models import Role
 
 User = get_user_model()
 
@@ -19,3 +22,42 @@ class ProfileForm(forms.ModelForm):
             "last_name": "Презиме",
             "email": "Е-маил",
         }
+
+
+class AddUserForm(forms.Form):
+    """Admin form: create a new user + membership for the active tenant."""
+
+    username = forms.CharField(
+        max_length=150,
+        label="Корисничко име",
+        widget=forms.TextInput(attrs={"autocomplete": "off"}),
+    )
+    first_name = forms.CharField(max_length=150, required=False, label="Име")
+    last_name = forms.CharField(max_length=150, required=False, label="Презиме")
+    email = forms.EmailField(required=False, label="Е-маил")
+    password = forms.CharField(
+        label="Лозинка", widget=forms.PasswordInput, min_length=8
+    )
+    role = forms.ChoiceField(choices=Role.choices, label="Улога")
+    is_default = forms.BooleanField(
+        required=False, initial=True, label="Подразумевани тенант"
+    )
+
+    def clean_username(self):
+        username = self.cleaned_data["username"].strip()
+        if not username:
+            raise ValidationError("Корисничко име је обавезно.")
+        if User.objects.filter(username=username).exists():
+            raise ValidationError("Корисник са овим именом већ постоји.")
+        return username
+
+    def clean_password(self):
+        password = self.cleaned_data["password"]
+        validate_password(password)
+        return password
+
+
+class EditRoleForm(forms.Form):
+    """Admin form: change a membership's role."""
+
+    role = forms.ChoiceField(choices=Role.choices, label="Улога")

--- a/crkva/tenants/permissions.py
+++ b/crkva/tenants/permissions.py
@@ -13,6 +13,8 @@ write. All authenticated users can read.
 
 Use the `tenant_role_required(resource)` decorator on write views and
 the `can_edit_*` flags exposed by the context processor in templates.
+For tenant-admin-only pages (e.g. user management), use
+`tenant_admin_required` instead.
 """
 
 from __future__ import annotations
@@ -56,6 +58,19 @@ def can_edit(user, tenant, resource: str) -> bool:
     return resource in WRITE_BY_ROLE.get(membership.role, frozenset())
 
 
+def is_tenant_admin(user, tenant) -> bool:
+    """True if `user` has Админ role in `tenant`, or is a superuser."""
+    if user is None or not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    if tenant is None:
+        return False
+    return UserMembership.objects.filter(
+        user=user, tenant=tenant, role=Role.ADMIN
+    ).exists()
+
+
 def tenant_role_required(resource: str):
     """Decorator: 403 if request.user can't write `resource` in request.tenant."""
 
@@ -70,3 +85,16 @@ def tenant_role_required(resource: str):
         return _wrapped
 
     return decorator
+
+
+def tenant_admin_required(view_func):
+    """Decorator: 403 if request.user is not Админ in request.tenant."""
+
+    @wraps(view_func)
+    @login_required
+    def _wrapped(request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        if not is_tenant_admin(request.user, getattr(request, "tenant", None)):
+            raise PermissionDenied
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped

--- a/crkva/tenants/tests/test_user_management.py
+++ b/crkva/tenants/tests/test_user_management.py
@@ -1,0 +1,179 @@
+"""Tests for admin user-management views (tenant-scoped)."""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class UserManagementViewTests(TestCase):
+    """Smoke tests for /tenant/users/ list, add, role-edit, deactivate."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        # bulk_create bypasses the django-tenants schema-check on save()
+        Tenant.objects.bulk_create(
+            [
+                Tenant(
+                    schema_name="test_tenant_other",
+                    naziv="Other",
+                    parohija_naziv="Other",
+                    is_active=True,
+                )
+            ]
+        )
+        cls.other_tenant = Tenant.objects.get(schema_name="test_tenant_other")
+        cls.admin = User.objects.create_user(username="adm", password="x")
+        UserMembership.objects.create(
+            user=cls.admin, tenant=cls.tenant, role=Role.ADMIN
+        )
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.foreign_admin = User.objects.create_user(username="other_adm", password="x")
+        UserMembership.objects.create(
+            user=cls.foreign_admin, tenant=cls.other_tenant, role=Role.ADMIN
+        )
+        cls.foreign_clerk = User.objects.create_user(
+            username="other_kanc", password="x"
+        )
+        UserMembership.objects.create(
+            user=cls.foreign_clerk, tenant=cls.other_tenant, role=Role.KANCELARIJA
+        )
+
+    def setUp(self):
+        self.client = Client()
+
+    # ----- list -----
+
+    def test_anonymous_redirects_to_login(self):
+        r = self.client.get(reverse("tenants:user_list"))
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/prijava/", r["Location"])
+
+    def test_non_admin_forbidden(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(reverse("tenants:user_list"))
+        self.assertEqual(r.status_code, 403)
+
+    def test_admin_sees_only_their_tenants_users(self):
+        self.client.force_login(self.admin)
+        r = self.client.get(reverse("tenants:user_list"))
+        self.assertEqual(r.status_code, 200)
+        usernames = [m.user.username for m in r.context["memberships"]]
+        self.assertIn("adm", usernames)
+        self.assertIn("kanc", usernames)
+        self.assertNotIn("other_adm", usernames)
+        self.assertNotIn("other_kanc", usernames)
+
+    # ----- add -----
+
+    def test_admin_can_add_user(self):
+        self.client.force_login(self.admin)
+        before = User.objects.count()
+        r = self.client.post(
+            reverse("tenants:user_add"),
+            {
+                "username": "newuser",
+                "password": "veryStrong!Pass1",
+                "first_name": "",
+                "last_name": "",
+                "email": "",
+                "role": Role.KANCELARIJA,
+                "is_default": "on",
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(User.objects.count(), before + 1)
+        new_user = User.objects.get(username="newuser")
+        m = UserMembership.objects.get(user=new_user)
+        self.assertEqual(m.tenant_id, self.tenant.pk)
+        self.assertEqual(m.role, Role.KANCELARIJA)
+
+    def test_non_admin_cannot_add_user(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            reverse("tenants:user_add"),
+            {
+                "username": "nope",
+                "password": "veryStrong!Pass1",
+                "role": Role.PREGLED,
+            },
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_duplicate_username_rejected(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse("tenants:user_add"),
+            {
+                "username": "kanc",  # already exists
+                "password": "veryStrong!Pass1",
+                "role": Role.PREGLED,
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.context["form"].errors)
+
+    # ----- edit role -----
+
+    def test_admin_can_change_role(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse("tenants:user_edit_role", kwargs={"user_id": self.clerk.pk}),
+            {"role": Role.PREGLED},
+        )
+        self.assertEqual(r.status_code, 302)
+        m = UserMembership.objects.get(user=self.clerk, tenant=self.tenant)
+        self.assertEqual(m.role, Role.PREGLED)
+
+    def test_admin_cannot_edit_other_tenants_user(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse(
+                "tenants:user_edit_role", kwargs={"user_id": self.foreign_clerk.pk}
+            ),
+            {"role": Role.PREGLED},
+        )
+        self.assertEqual(r.status_code, 404)
+        m = UserMembership.objects.get(
+            user=self.foreign_clerk, tenant=self.other_tenant
+        )
+        self.assertEqual(m.role, Role.KANCELARIJA)  # unchanged
+
+    # ----- deactivate -----
+
+    def test_admin_can_deactivate_user(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse("tenants:user_deactivate", kwargs={"user_id": self.clerk.pk}),
+        )
+        self.assertEqual(r.status_code, 302)
+        self.clerk.refresh_from_db()
+        self.assertFalse(self.clerk.is_active)
+
+    def test_admin_cannot_deactivate_self(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse("tenants:user_deactivate", kwargs={"user_id": self.admin.pk}),
+        )
+        self.assertEqual(r.status_code, 302)
+        self.admin.refresh_from_db()
+        self.assertTrue(self.admin.is_active)
+
+    def test_admin_cannot_deactivate_other_tenants_user(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse(
+                "tenants:user_deactivate", kwargs={"user_id": self.foreign_clerk.pk}
+            ),
+        )
+        self.assertEqual(r.status_code, 404)
+        self.foreign_clerk.refresh_from_db()
+        self.assertTrue(self.foreign_clerk.is_active)

--- a/crkva/tenants/urls.py
+++ b/crkva/tenants/urls.py
@@ -8,4 +8,12 @@ app_name = "tenants"
 urlpatterns = [
     path("switch/<int:tenant_id>/", views.switch_tenant, name="switch"),
     path("profile/", views.profile, name="profile"),
+    path("users/", views.user_list, name="user_list"),
+    path("users/add/", views.user_add, name="user_add"),
+    path("users/<int:user_id>/role/", views.user_edit_role, name="user_edit_role"),
+    path(
+        "users/<int:user_id>/deactivate/",
+        views.user_deactivate,
+        name="user_deactivate",
+    ),
 ]

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -1,9 +1,9 @@
-"""Tenant switching + self-edit profile views."""
+"""Tenant switching, self-profile, and admin user-management views."""
 
 from __future__ import annotations
 
 from django.contrib import messages
-from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -11,9 +11,12 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
-from tenants.forms import ProfileForm
+from tenants.forms import AddUserForm, EditRoleForm, ProfileForm
 from tenants.middleware import SESSION_TENANT_KEY
 from tenants.models import Tenant, UserMembership
+from tenants.permissions import tenant_admin_required
+
+User = get_user_model()
 
 
 @login_required
@@ -60,7 +63,6 @@ def profile(request: HttpRequest) -> HttpResponse:
             password_form = PasswordChangeForm(user=request.user, data=request.POST)
             if password_form.is_valid():
                 user = password_form.save()
-                # keep the user logged in after their password changes
                 update_session_auth_hash(request, user)
                 messages.success(request, "Лозинка промењена.")
                 return redirect("tenants:profile")
@@ -70,3 +72,75 @@ def profile(request: HttpRequest) -> HttpResponse:
         "registar/profile.html",
         {"info_form": info_form, "password_form": password_form},
     )
+
+
+@tenant_admin_required
+def user_list(request: HttpRequest) -> HttpResponse:
+    """List memberships for the active tenant."""
+    memberships = (
+        UserMembership.objects.filter(tenant=request.tenant)
+        .select_related("user")
+        .order_by("user__username")
+    )
+    return render(
+        request,
+        "registar/users_list.html",
+        {"memberships": memberships},
+    )
+
+
+@tenant_admin_required
+def user_add(request: HttpRequest) -> HttpResponse:
+    """Create a new User + UserMembership scoped to the active tenant."""
+    form = AddUserForm(request.POST or None)
+    if request.method == "POST" and form.is_valid():
+        data = form.cleaned_data
+        user = User.objects.create_user(
+            username=data["username"],
+            password=data["password"],
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+            email=data["email"],
+        )
+        UserMembership.objects.create(
+            user=user,
+            tenant=request.tenant,
+            role=data["role"],
+            is_default=data["is_default"],
+        )
+        messages.success(request, f"Корисник {user.username} креиран.")
+        return redirect("tenants:user_list")
+    return render(request, "registar/users_add.html", {"form": form})
+
+
+@tenant_admin_required
+@require_POST
+def user_edit_role(request: HttpRequest, user_id: int) -> HttpResponse:
+    """Change a membership's role inside the active tenant."""
+    membership = get_object_or_404(
+        UserMembership, user_id=user_id, tenant=request.tenant
+    )
+    form = EditRoleForm(request.POST)
+    if form.is_valid():
+        membership.role = form.cleaned_data["role"]
+        membership.save(update_fields=["role"])
+        messages.success(request, f"Улога ажурирана за {membership.user.username}.")
+    return redirect("tenants:user_list")
+
+
+@tenant_admin_required
+@require_POST
+def user_deactivate(request: HttpRequest, user_id: int) -> HttpResponse:
+    """Toggle User.is_active for a member of the active tenant."""
+    membership = get_object_or_404(
+        UserMembership, user_id=user_id, tenant=request.tenant
+    )
+    target = membership.user
+    if target.pk == request.user.pk:
+        messages.error(request, "Не можете деактивирати свој налог.")
+        return redirect("tenants:user_list")
+    target.is_active = not target.is_active
+    target.save(update_fields=["is_active"])
+    verb = "активиран" if target.is_active else "деактивиран"
+    messages.success(request, f"Корисник {target.username} {verb}.")
+    return redirect("tenants:user_list")


### PR DESCRIPTION
Tenant admins (UserMembership.role=ADMIN) can manage users for their parish from /tenant/users/. The list, add, role-edit, and deactivate views are gated by a new tenant_admin_required decorator and scoped strictly to request.tenant — an Админ of Чукарица cannot see, edit, or deactivate users that belong only to Амстердам. Superusers bypass.

Adds is_tenant_admin to the template context; sidebar shows a Корисници link that only renders for that role. Users-list page lets the admin switch a member's role inline and toggle is_active (cannot deactivate themselves). Users-add page creates the User + tenant-scoped UserMembership in one form.

11 tests cover anonymous, non-admin 403s, tenant-scoping (admin of one parish cannot edit another parish's members), self-deactivation prevented, and duplicate-username rejected.