### PR TITLE
fix: Docker Hub workflow uses `docker compose` (no hyphen)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: docker.io
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -22,5 +22,5 @@ jobs:
 
     - name: Build and push Docker Compose app image
       run: |
-        docker-compose build app
-        docker-compose push app
+        docker compose build app
+        docker compose push app


### PR DESCRIPTION
* docker-compose v1 was removed from GitHub runners; switch to v2 subcommand
* Bump actions/checkout v2→v4 and docker/login-action v1→v3