### PR TITLE
fix: drop invalid select_related("adresa__ulica") in slava view

### DIFF
--- a/crkva/registar/tests/test_slava.py
+++ b/crkva/registar/tests/test_slava.py
@@ -1,0 +1,30 @@
+"""Regression test: /slava/<id>/ rendered after dropping adresa.ulica FK."""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from registar.models import Domacinstvo, Osoba, Slava
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class SlavaDomacinstvaViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.user = User.objects.create_user(username="view", password="x")
+        UserMembership.objects.create(
+            user=cls.user, tenant=cls.tenant, role=Role.PREGLED
+        )
+        cls.slava = Slava.objects.create(naziv="Тест Слава", dan=1, mesec=1)
+        osoba = Osoba.objects.create(ime="Тест", prezime="Домаћин", pol="М")
+        Domacinstvo.objects.create(domacin=osoba, slava=cls.slava)
+
+    def test_slava_detail_renders(self):
+        self.client.force_login(self.user)
+        r = self.client.get(f"/slava/{self.slava.uid}/")
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Тест Слава")
+        self.assertEqual(r.context["count"], 1)

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -12,7 +12,7 @@ def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
     # Get all households celebrating this slava
     domacinstva = (
         Domacinstvo.objects.filter(slava=slava)
-        .select_related("domacin", "adresa", "adresa__ulica")
+        .select_related("domacin", "adresa")
         .prefetch_related("ukucani", "ukucani__osoba")
         .order_by("domacin__prezime", "domacin__ime")
     )


### PR DESCRIPTION
* Adresa.ulica is a CharField, not a FK — caused FieldError at /slava/<id>/
* Add regression test exercising the view end-to-end