### PR TITLE
feat: redesign /unos/ forms — single-column card layout

### DIFF
--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -265,3 +265,40 @@ input[name="vreme_rodjenja"]:focus {
   min-height: 38px;
   white-space: nowrap;
 }
+
+/* Single-column card layout used by the redesigned unos forms. */
+.form--single-column {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.form--single-column .form-row {
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.form--single-column .form-row--pair {
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+@media (max-width: 640px) {
+  .form--single-column .form-row--pair {
+    grid-template-columns: 1fr;
+  }
+}
+.form--single-column fieldset.form-section {
+  padding: 20px 22px;
+  margin-bottom: 18px;
+  background: var(--color-surface);
+}
+.form--single-column fieldset.form-section legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+}
+.form--single-column .form-field label {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}

--- a/crkva/registar/templates/registar/unos_krstenja.html
+++ b/crkva/registar/templates/registar/unos_krstenja.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-  <form method="post" class="form">
+  <form method="post" class="form form--single-column">
     {% csrf_token %}
 
 <div class="u-page-header">
@@ -38,7 +38,7 @@
 {% endif %}
 
     <fieldset class="form-section">
-      <legend>Регистар</legend>
+      <legend><i class="fa-solid fa-list-ol"></i> Регистар</legend>
       <div class="form-row">
         <div class="form-field">{{ form.redni_broj.label_tag }} {{ form.redni_broj }}</div>
         <div class="form-field">{{ form.godina_registracije.label_tag }} {{ form.godina_registracije }}</div>
@@ -51,7 +51,7 @@
     </fieldset>
 
     <fieldset class="form-section">
-      <legend>Детаљи крштења</legend>
+      <legend><i class="fa-solid fa-droplet"></i> Детаљи крштења</legend>
       <div class="form-row">
         <div class="form-field">{{ form.datum.label_tag }} {{ form.datum }}</div>
         <div class="form-field">{{ form.vreme.label_tag }} {{ form.vreme }}</div>
@@ -69,7 +69,7 @@
     </fieldset>
 
     <fieldset class="form-section">
-      <legend>Дете</legend>
+      <legend><i class="fa-solid fa-baby"></i> Дете</legend>
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.dete.label_tag }}
@@ -118,7 +118,7 @@
     </fieldset>
 
     <fieldset class="form-section">
-      <legend>Кум</legend>
+      <legend><i class="fa-solid fa-user-tag"></i> Кум</legend>
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.kum.label_tag }}

--- a/crkva/registar/templates/registar/unos_parohijana.html
+++ b/crkva/registar/templates/registar/unos_parohijana.html
@@ -1,89 +1,64 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <form method="post" class="form">
-    {% csrf_token %}
-<div class="u-page-header">
-      <a href="{% url 'parohijani' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-      </a>
-<h1 class="u-page-title">Додавање новог парохијана</h1>
-<button class="button button--primary" type="submit" title="Сачувај">
-        <i class="fa-solid fa-floppy-disk" style="margin-right: 6px;"></i> Сачувај
-      </button>
+<form method="post" class="form form--single-column">
+  {% csrf_token %}
+
+  <div class="u-page-header">
+    <a href="{% if back_url %}{{ back_url }}{% else %}{% url 'parohijani' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад">
+      <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">{{ title|default:"Додавање новог парохијана" }}</h1>
+    <button class="button button--primary" type="submit" title="Сачувај">
+      <i class="fa-solid fa-floppy-disk" style="margin-right: 6px;"></i> Сачувај
+    </button>
+  </div>
+
+  {% if form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">
+        {% for field, errors in form.errors.items %}
+          {% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <fieldset class="form-section">
+    <legend><i class="fa-solid fa-user"></i> Основни подаци</legend>
+
+    <div class="form-row">
+      <div class="form-field">
+        <div class="toggle-wrapper">
+          <span class="toggle-label">{{ form.pol.label }}</span>
+          <div class="toggle-group" id="pol-toggle">
+            {% for value, label in form.pol.field.choices %}
+              <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="visually-hidden">{{ form.pol }}</div>
+      </div>
     </div>
 
-{% if form.errors %}
-  <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
-    <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
-    <ul style="margin:8px 0 0;padding-left:20px;">
-      {% for field, errors in form.errors.items %}
-        {% for error in errors %}
-          <li>{{ field }}: {{ error }}</li>
-        {% endfor %}
-      {% endfor %}
-    </ul>
-  </div>
-{% endif %}
+    <div class="form-row"><div class="form-field">{{ form.ime.label_tag }} {{ form.ime }}</div></div>
+    <div class="form-row"><div class="form-field">{{ form.prezime.label_tag }} {{ form.prezime }}</div></div>
+    <div class="form-row"><div class="form-field">{{ form.devojacko_prezime.label_tag }} {{ form.devojacko_prezime }}</div></div>
 
-    <fieldset class="form-section">
-      <legend>Основни подаци</legend>
-      <div class="form-row">
-        <div class="form-field">
-          <div class="toggle-wrapper">
-            <span class="toggle-label">{{ form.pol.label }}</span>
-            <div class="toggle-group" id="pol-toggle">
-              {% for value, label in form.pol.field.choices %}
-                <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="visually-hidden">{{ form.pol }}</div>
-        </div>
-        <div class="form-field">{{ form.ime.label_tag }} {{ form.ime }}</div>
-        <div class="form-field">{{ form.prezime.label_tag }} {{ form.prezime }}</div>
-        <div class="form-field">{{ form.devojacko_prezime.label_tag }} {{ form.devojacko_prezime }}</div>
-      </div>
-      <div class="form-row">
-        <div class="form-field">{{ form.datum_rodjenja.label_tag }} {{ form.datum_rodjenja }}</div>
-        <div class="form-field">{{ form.vreme_rodjenja.label_tag }} {{ form.vreme_rodjenja }}</div>
-      </div>
-    </fieldset>
+    <div class="form-row form-row--pair">
+      <div class="form-field">{{ form.datum_rodjenja.label_tag }} {{ form.datum_rodjenja }}</div>
+      <div class="form-field">{{ form.vreme_rodjenja.label_tag }} {{ form.vreme_rodjenja }}</div>
+    </div>
 
-    <fieldset class="form-section">
-      <legend>Детаљи</legend>
-      <div class="form-row">
-        <div class="form-field">{{ form.zanimanje.label_tag }} {{ form.zanimanje }}</div>
-        <div class="form-field">{{ form.veroispovest.label_tag }} {{ form.veroispovest }}</div>
-        <div class="form-field">{{ form.narodnost.label_tag }} {{ form.narodnost }}</div>
-      </div>
-      <div class="form-row">
-        <div class="form-field" style="grid-column: 1 / -1;">{{ form.adresa.label_tag }} {{ form.adresa }}</div>
-      </div>
-    </fieldset>
-    <!-- Bottom save removed as per request: action button is now at the top -->
-    <script>
-      (function() {
-        var toggle = document.getElementById('pol-toggle');
-        if (toggle) {
-          var buttons = toggle.querySelectorAll('.toggle-button');
-          var select = document.querySelector('[name="{{ form.pol.name }}"]');
-          function setActive(val) {
-            buttons.forEach(function(btn){ btn.classList.toggle('active', btn.dataset.value == val); });
-            if (select) select.value = val;
-          }
-          buttons.forEach(function(btn){
-            btn.addEventListener('click', function(){ setActive(btn.dataset.value); });
-          });
-          if (select) setActive(select.value || (buttons[0] && buttons[0].dataset.value));
-        }
+    <div class="form-row"><div class="form-field">{{ form.mesto_rodjenja.label_tag }} {{ form.mesto_rodjenja }}</div></div>
+  </fieldset>
 
-        // Enhance date/time inputs if possible
-        var dateInput = document.querySelector('[name="{{ form.datum_rodjenja.name }}"]');
-        var timeInput = document.querySelector('[name="{{ form.vreme_rodjenja.name }}"]');
-        try { if (dateInput) dateInput.type = 'date'; } catch(e) {}
-        try { if (timeInput) timeInput.type = 'time'; } catch(e) {}
-      })();
-    </script>
-  </form>
+  <fieldset class="form-section">
+    <legend><i class="fa-solid fa-id-card"></i> Детаљи</legend>
+    <div class="form-row"><div class="form-field">{{ form.zanimanje.label_tag }} {{ form.zanimanje }}</div></div>
+    <div class="form-row"><div class="form-field">{{ form.veroispovest.label_tag }} {{ form.veroispovest }}</div></div>
+    <div class="form-row"><div class="form-field">{{ form.narodnost.label_tag }} {{ form.narodnost }}</div></div>
+  </fieldset>
+</form>
 {% endblock %}

--- a/crkva/registar/templates/registar/unos_svestenika.html
+++ b/crkva/registar/templates/registar/unos_svestenika.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <form method="post" class="form">
+  <form method="post" class="form form--single-column">
     {% csrf_token %}
     <div class="u-page-header">
       <a href="{% url 'svestenici' %}" class="back-button" aria-label="Назад" title="Назад">
@@ -27,7 +27,7 @@
     {% endif %}
 
     <fieldset class="form-section">
-      <legend>Основни подаци</legend>
+      <legend><i class="fa-solid fa-user"></i> Основни подаци</legend>
       <div class="form-row">
         <div class="form-field">{{ form.zvanje.label_tag }} {{ form.zvanje }}</div>
         <div class="form-field">{{ form.ime.label_tag }} {{ form.ime }}</div>
@@ -40,7 +40,7 @@
     </fieldset>
 
     <fieldset class="form-section">
-      <legend>Парохија</legend>
+      <legend><i class="fa-solid fa-church"></i> Парохија</legend>
       <div class="form-row">
         <div class="form-field">{{ form.parohija.label_tag }} {{ form.parohija }}</div>
       </div>

--- a/crkva/registar/templates/registar/unos_vencanja.html
+++ b/crkva/registar/templates/registar/unos_vencanja.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-  <form method="post" class="form">
+  <form method="post" class="form form--single-column">
     {% csrf_token %}
 
 <div class="u-page-header">
@@ -36,7 +36,7 @@
 {% endif %}
 
     <fieldset class="form-section">
-      <legend>Регистар</legend>
+      <legend><i class="fa-solid fa-list-ol"></i> Регистар</legend>
       <div class="form-row">
         <div class="form-field">{{ form.redni_broj.label_tag }} {{ form.redni_broj }}</div>
         <div class="form-field">{{ form.godina_registracije.label_tag }} {{ form.godina_registracije }}</div>
@@ -49,7 +49,7 @@
     </fieldset>
 
     <fieldset class="form-section">
-      <legend>Детаљи венчања</legend>
+      <legend><i class="fa-solid fa-ring"></i> Детаљи венчања</legend>
       <div class="form-row">
         <div class="form-field">{{ form.datum.label_tag }} {{ form.datum }}</div>
         <div class="form-field">


### PR DESCRIPTION
* form--single-column CSS: one field per row, narrow centered card
* unos_parohijana rewritten; krstenje/vencanje/svestenik patched with the new class + section icons
* form-row--pair modifier for natural pairings (datum + vreme)