### PR TITLE
fix: tighter responsive grid on /slava-kalendar/

### DIFF
--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -300,7 +300,7 @@
 
 @media (max-width: 768px) {
   .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
   .calendar-cell {
     height: auto;
@@ -343,15 +343,24 @@
 
 @media (max-width: 600px) {
   .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 6px;
   }
+  .calendar-cell {
+    min-height: 90px;
+    padding: 8px;
+  }
+  .calendar-cell .date { font-size: 1rem; }
+  .calendar-cell .weekday { font-size: 0.7rem; }
+  .calendar-cell .slavas { font-size: 0.78rem; line-height: 1.25; margin-top: 6px; }
+  .slava-link__count { font-size: 10px; padding: 0 4px; }
 }
 
 /* Small mobile - single column for better readability */
 @media (max-width: 480px) {
   .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 6px;
   }
   .calendar-cell {
     height: auto;


### PR DESCRIPTION
* breakpoints no longer force 1-cell-wide rows
* <=600px: 110px min (was 160) — 4–5 cols on tablets
* <=480px: 140px min (was 280) — 2 cols on small phones
* scale down date/weekday/slava font + count badge to keep cells readable