### PR TITLE
feat: unified view+edit template per resource

### DIFF
--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -101,3 +101,45 @@
     margin-top: 12px;
     white-space: pre-line;
 }
+
+/* ==========================================================================
+   INFO + EDIT shared row form fields
+   When .info-row contains an <input>, <select>, or <textarea>, swap layout
+   so the input occupies the value column at full width.
+   ========================================================================== */
+
+.info-row--editable .info-row__value > input[type="text"],
+.info-row--editable .info-row__value > input[type="search"],
+.info-row--editable .info-row__value > input[type="number"],
+.info-row--editable .info-row__value > input[type="date"],
+.info-row--editable .info-row__value > input[type="email"],
+.info-row--editable .info-row__value > input[type="time"],
+.info-row--editable .info-row__value > input[type="tel"],
+.info-row--editable .info-row__value > input[type="password"],
+.info-row--editable .info-row__value > select,
+.info-row--editable .info-row__value > textarea,
+.info-row--editable .info-row__value > .select2,
+.info-row--editable .info-row__value > .select2-selection {
+    width: 100%;
+}
+
+.info-row--editable {
+    padding: 6px 0;
+    align-items: center;
+}
+
+.info-row--editable .info-row__value > .visually-hidden + .toggle-group,
+.info-row--editable .info-row__value > .toggle-wrapper {
+    margin: 0;
+}
+
+.info-row--placeholder {
+    color: var(--color-text-muted);
+}
+
+/* When no rows actually rendered, show a placeholder */
+.info-empty {
+    padding: 24px 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+}

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% load phone_filters %}
+
+{% block content %}
+{% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
+
+  <div class="u-page-header">
+    <a href="{% if is_edit and domacinstvo %}{% url 'domacinstvo_detail' uid=domacinstvo.uid %}{% else %}{% url 'domacinstva' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
+    <h1 class="u-page-title">
+      {% if is_edit and not domacinstvo %}Додавање домаћинства
+      {% elif is_edit %}Измена домаћинства{% if domacinstvo.domacin %} · {{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}{% endif %}
+      {% else %}Домаћинство · {{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}{% endif %}
+    </h1>
+    {% if is_edit %}
+      <button class="button button--primary" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% else %}
+      {% if can_edit_domacinstvo %}<a href="{% url 'izmena_domacinstva' uid=domacinstvo.uid %}" class="button button--primary" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
+      <button type="button" id="history-toggle" class="button button--primary" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
+    {% endif %}
+  </div>
+
+  {% if is_edit and form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">{% for field, errors in form.errors.items %}{% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}{% endfor %}</ul>
+    </div>
+  {% endif %}
+
+  <ul class="info-rows">
+    {% if is_edit %}
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Домаћин"><i class="fa-solid fa-house"></i></div><div class="info-row__value">{{ form.domacin }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ form.adresa }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Слава"><i class="fa-solid fa-gift"></i></div><div class="info-row__value">{{ form.slava }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Мобилни телефон"><i class="fa-solid fa-mobile-screen"></i></div><div class="info-row__value">{{ form.tel_mobilni }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Фиксни телефон"><i class="fa-solid fa-phone"></i></div><div class="info-row__value">{{ form.tel_fiksni }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Славска водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value"><label>{{ form.slavska_vodica }} Славска водица</label></div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Васкршња водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value"><label>{{ form.vaskrsnja_vodica }} Васкршња водица</label></div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Напомена"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ form.napomena }}</div></li>
+    {% else %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Домаћин"><i class="fa-solid fa-house"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=domacinstvo.domacin.uid %}">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</a></div></li>
+    {% if domacinstvo.adresa %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value"><a href="https://www.openstreetmap.org/search?query={{ domacinstvo.adresa|urlencode }}" target="_blank" rel="noopener noreferrer" data-tooltip="Отвори у OpenStreetMap">{{ domacinstvo.adresa }} <i class="fa-solid fa-arrow-up-right-from-square" style="font-size:0.75em;opacity:0.55;margin-left:4px;"></i></a></div></li>{% endif %}
+    {% if domacinstvo.tel_mobilni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Мобилни"><i class="fa-solid {{ domacinstvo.tel_mobilni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ domacinstvo.tel_mobilni|tel_link }}">{{ domacinstvo.tel_mobilni|format_phone }}</a></div></li>{% endif %}
+    {% if domacinstvo.tel_fiksni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Фиксни"><i class="fa-solid {{ domacinstvo.tel_fiksni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ domacinstvo.tel_fiksni|tel_link }}">{{ domacinstvo.tel_fiksni|format_phone }}</a></div></li>{% endif %}
+    {% if domacinstvo.slava %}<li class="info-row"><div class="info-row__icon" data-tooltip="Слава"><i class="fa-solid fa-gift"></i></div><div class="info-row__value"><a href="{% url 'slava_detail' uid=domacinstvo.slava.uid %}">{{ domacinstvo.slava }}</a></div></li>{% endif %}
+    {% if domacinstvo.slavska_vodica or domacinstvo.vaskrsnja_vodica %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Водице"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">{% if domacinstvo.slavska_vodica %}Славска{% endif %}{% if domacinstvo.slavska_vodica and domacinstvo.vaskrsnja_vodica %} · {% endif %}{% if domacinstvo.vaskrsnja_vodica %}Васкршња{% endif %}</div></li>
+    {% endif %}
+    {% endif %}
+  </ul>
+
+  {% if not is_edit and domacinstvo.napomena %}<div class="info-note">{{ domacinstvo.napomena }}</div>{% endif %}
+
+  {% if not is_edit %}
+    {% if ukucani_zivi %}
+    <div class="info-section">
+      <h2 class="info-section__title">Чланови ({{ ukucani_zivi|length }})</h2>
+      <ul class="info-list">{% for u in ukucani_zivi %}<li class="info-list__item"><span>{% if u.osoba %}<a href="{% url 'parohijan_detail' uid=u.osoba.uid %}">{{ u.osoba.ime }} {{ u.osoba.prezime }}</a>{% else %}{{ u.ime_ukucana }}{% endif %}</span><span class="info-list__role">{{ u.get_uloga_display }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if ukucani_preminuli %}
+    <div class="info-section">
+      <h2 class="info-section__title">Преминули ({{ ukucani_preminuli|length }})</h2>
+      <ul class="info-list">{% for u in ukucani_preminuli %}<li class="info-list__item info-list__item--muted"><span>{% if u.osoba %}{{ u.osoba.ime }} {{ u.osoba.prezime }}{% else %}{{ u.ime_ukucana }}{% endif %} <i class="fa-solid fa-cross" style="opacity:0.5;margin-left:6px;"></i></span><span class="info-list__role">{{ u.get_uloga_display }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+  {% endif %}
+
+{% if is_edit %}</form>{% else %}</div>{% endif %}
+{% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
+{% endblock %}

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -1,0 +1,152 @@
+{% extends "base.html" %}
+{% load phone_filters %}
+
+{% comment %}
+  Single template for /parohijan/<id>/ (view), /unos/parohijan/ (create),
+  /izmena/parohijan/<id>/ (edit).
+
+  Context:
+    parohijan  — instance (view + edit), absent on create
+    form       — bound form, present on create + edit
+    is_edit    — True for create + edit, False for view
+
+  Each row chooses input vs. text based on `is_edit`.
+{% endcomment %}
+
+{% block content %}
+{% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
+
+  <div class="u-page-header">
+    <a href="{% if is_edit and parohijan %}{% url 'parohijan_detail' uid=parohijan.uid %}{% else %}{% url 'parohijani' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад">
+      <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">
+      {% if is_edit and not parohijan %}Додавање парохијана
+      {% elif is_edit %}Измена: {{ parohijan.ime }} {{ parohijan.prezime }}
+      {% else %}{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime %} <span style="color:var(--color-text-muted);font-weight:400;">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}{% endif %}
+    </h1>
+    {% if is_edit %}
+      <button class="button button--primary" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% else %}
+      {% if can_edit_osoba %}<a href="{% url 'izmena_parohijana' uid=parohijan.uid %}" class="button button--primary" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
+      <a href="{% url 'parohijan_pdf' parohijan.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+      <button type="button" id="history-toggle" class="button button--primary" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
+    {% endif %}
+  </div>
+
+  {% if is_edit and form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">
+        {% for field, errors in form.errors.items %}{% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <ul class="info-rows">
+
+    {% if is_edit %}
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div>
+      <div class="info-row__value">
+        <div class="toggle-wrapper">
+          <div class="toggle-group" id="pol-toggle">
+            {% for value, label in form.pol.field.choices %}
+              <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="visually-hidden">{{ form.pol }}</div>
+      </div>
+    </li>
+    {% elif parohijan.pol %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div><div class="info-row__value">{{ parohijan.get_pol_display }}</div></li>
+    {% endif %}
+
+    {% if is_edit %}
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.ime }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Презиме"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{{ form.prezime }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Девојачко презиме"><i class="fa-solid fa-id-card"></i></div><div class="info-row__value">{{ form.devojacko_prezime }}</div></li>
+    {% endif %}
+
+    {% if is_edit %}
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ form.datum_rodjenja }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Време рођења"><i class="fa-solid fa-clock"></i></div><div class="info-row__value">{{ form.vreme_rodjenja }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ form.mesto_rodjenja }}</div></li>
+    {% else %}
+    {% if parohijan.datum_rodjenja %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ parohijan.datum_rodjenja }}{% if parohijan.mesto_rodjenja %} <span class="info-row__sub">{{ parohijan.mesto_rodjenja }}</span>{% endif %}</div></li>
+    {% elif parohijan.mesto_rodjenja %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ parohijan.mesto_rodjenja }}</div></li>
+    {% endif %}
+    {% endif %}
+
+    {% if is_edit %}
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ form.zanimanje }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ form.veroispovest }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ form.narodnost }}</div></li>
+    {% else %}
+    {% if parohijan.zanimanje %}<li class="info-row"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ parohijan.zanimanje }}</div></li>{% endif %}
+    {% if parohijan.veroispovest %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ parohijan.veroispovest }}</div></li>{% endif %}
+    {% if parohijan.narodnost %}<li class="info-row"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ parohijan.narodnost }}</div></li>{% endif %}
+    {% if parohijan.adresa %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value"><a href="https://www.openstreetmap.org/search?query={{ parohijan.adresa|urlencode }}" target="_blank" rel="noopener noreferrer" data-tooltip="Отвори у OpenStreetMap">{{ parohijan.adresa }} <i class="fa-solid fa-arrow-up-right-from-square" style="font-size:0.75em;opacity:0.55;margin-left:4px;"></i></a></div></li>{% endif %}
+    {% if parohijan.tel_mobilni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Мобилни"><i class="fa-solid {{ parohijan.tel_mobilni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ parohijan.tel_mobilni|tel_link }}">{{ parohijan.tel_mobilni|format_phone }}</a></div></li>{% endif %}
+    {% if parohijan.tel_fiksni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Фиксни"><i class="fa-solid {{ parohijan.tel_fiksni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ parohijan.tel_fiksni|tel_link }}">{{ parohijan.tel_fiksni|format_phone }}</a></div></li>{% endif %}
+    {% if parohijan.domacinstvo %}<li class="info-row"><div class="info-row__icon" data-tooltip="Домаћин домаћинства"><i class="fa-solid fa-house"></i></div><div class="info-row__value"><a href="{% url 'domacinstvo_detail' uid=parohijan.domacinstvo.uid %}">Прикажи домаћинство <i class="fa-solid fa-arrow-right" style="font-size:0.85em;"></i></a></div></li>{% endif %}
+    {% endif %}
+  </ul>
+
+  {% if not is_edit %}
+    {% if otac or majka %}
+    <div class="info-section">
+      <h2 class="info-section__title">Родитељи</h2>
+      <ul class="info-list">
+        {% if otac %}<li class="info-list__item"><span><a href="{% url 'parohijan_detail' uid=otac.uid %}">{{ otac.ime }} {{ otac.prezime }}</a></span><span class="info-list__role">отац</span></li>{% endif %}
+        {% if majka %}<li class="info-list__item"><span><a href="{% url 'parohijan_detail' uid=majka.uid %}">{{ majka.ime }} {{ majka.prezime }}</a></span><span class="info-list__role">мајка{% if majka.devojacko_prezime %} · рођ. {{ majka.devojacko_prezime }}{% endif %}</span></li>{% endif %}
+      </ul>
+    </div>
+    {% endif %}
+    {% if deca %}
+    <div class="info-section">
+      <h2 class="info-section__title">Деца ({{ deca|length }})</h2>
+      <ul class="info-list">{% for d in deca %}<li class="info-list__item"><span><a href="{% url 'parohijan_detail' uid=d.uid %}">{{ d.ime }} {{ d.prezime }}</a></span><span class="info-list__role">{{ d.datum_rodjenja|default:"—" }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if krstenja_dete %}
+    <div class="info-section">
+      <h2 class="info-section__title">Крштење</h2>
+      <ul class="info-list">{% for k in krstenja_dete %}<li class="info-list__item"><span><a href="{% url 'krstenje_detail' uid=k.uid %}">{{ k.datum }}</a>{% if k.kum %} <span class="info-row__sub" style="display:inline;">кум: {{ k.kum.ime }} {{ k.kum.prezime }}</span>{% endif %}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if vencanja_zenik or vencanja_nevesta %}
+    <div class="info-section">
+      <h2 class="info-section__title">Венчање</h2>
+      <ul class="info-list">
+        {% for v in vencanja_zenik %}<li class="info-list__item"><span><a href="{% url 'vencanje_detail' uid=v.uid %}">са {{ v.nevesta.ime }} {{ v.nevesta.prezime }}</a></span><span class="info-list__role">{{ v.datum }}</span></li>{% endfor %}
+        {% for v in vencanja_nevesta %}<li class="info-list__item"><span><a href="{% url 'vencanje_detail' uid=v.uid %}">са {{ v.zenik.ime }} {{ v.zenik.prezime }}</a></span><span class="info-list__role">{{ v.datum }}</span></li>{% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+    {% if krstenja_kum %}
+    <div class="info-section">
+      <h2 class="info-section__title">Кумовања — крштења</h2>
+      <ul class="info-list">{% for k in krstenja_kum %}<li class="info-list__item"><span><a href="{% url 'krstenje_detail' uid=k.uid %}">{{ k.dete }}</a></span><span class="info-list__role">{{ k.datum }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if vencanja_kum %}
+    <div class="info-section">
+      <h2 class="info-section__title">Кумовања — венчања</h2>
+      <ul class="info-list">{% for v in vencanja_kum %}<li class="info-list__item"><span><a href="{% url 'vencanje_detail' uid=v.uid %}">{{ v.zenik }} и {{ v.nevesta }}</a></span><span class="info-list__role">{{ v.datum }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if ukucanstva %}
+    <div class="info-section">
+      <h2 class="info-section__title">Домаћинства</h2>
+      <ul class="info-list">{% for u in ukucanstva %}<li class="info-list__item"><span><a href="{% url 'domacinstvo_detail' uid=u.domacinstvo.uid %}">{{ u.domacinstvo.domacin.ime }} {{ u.domacinstvo.domacin.prezime }}</a></span><span class="info-list__role">{{ u.get_uloga_display }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+  {% endif %}
+
+{% if is_edit %}</form>{% else %}</div>{% endif %}
+{% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
+{% endblock %}

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
+
+  <div class="u-page-header">
+    <a href="{% if is_edit and svestenik %}{% url 'svestenik_detail' uid=svestenik.uid %}{% else %}{% url 'svestenici' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад">
+      <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">
+      {% if is_edit and not svestenik %}Додавање свештеника
+      {% elif is_edit %}Измена: {{ svestenik.ime }} {{ svestenik.prezime }}
+      {% else %}{{ svestenik.ime }} {{ svestenik.prezime }}{% endif %}
+    </h1>
+    {% if is_edit %}
+      <button class="button button--primary" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% else %}
+      {% if can_edit_svestenik %}<a href="{% url 'izmena_svestenika' uid=svestenik.uid %}" class="button button--primary" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
+      <a href="{% url 'svestenik_pdf' svestenik.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+      <button type="button" id="history-toggle" class="button button--primary" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
+    {% endif %}
+  </div>
+
+  {% if is_edit and form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">
+        {% for field, errors in form.errors.items %}{% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <ul class="info-rows">
+    {% if is_edit %}
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Звање"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value">{{ form.zvanje }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.ime }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Презиме"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{{ form.prezime }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Парохија"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ form.parohija }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ form.datum_rodjenja }}</div></li>
+    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ form.mesto_rodjenja }}</div></li>
+    {% else %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Звање"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value">{{ svestenik.zvanje }}</div></li>
+    {% if svestenik.parohija %}<li class="info-row"><div class="info-row__icon" data-tooltip="Парохија"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ svestenik.parohija }}</div></li>{% endif %}
+    {% if svestenik.datum_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ svestenik.datum_rodjenja }}</div></li>{% endif %}
+    {% if svestenik.mesto_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ svestenik.mesto_rodjenja }}</div></li>{% endif %}
+    {% endif %}
+  </ul>
+
+  {% if not is_edit %}
+    {% if krstenja %}
+    <div class="info-section">
+      <h2 class="info-section__title">Крштења ({{ krstenja_count }})</h2>
+      <ul class="info-list">{% for k in krstenja %}<li class="info-list__item"><span><a href="{% url 'krstenje_detail' uid=k.uid %}">{{ k.dete }}</a></span><span class="info-list__role">{{ k.datum|default:"—" }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+    {% if vencanja %}
+    <div class="info-section">
+      <h2 class="info-section__title">Венчања ({{ vencanja_count }})</h2>
+      <ul class="info-list">{% for v in vencanja %}<li class="info-list__item"><span><a href="{% url 'vencanje_detail' uid=v.uid %}">{{ v.zenik }} и {{ v.nevesta }}</a></span><span class="info-list__role">{{ v.datum|default:"—" }}</span></li>{% endfor %}</ul>
+    </div>
+    {% endif %}
+  {% endif %}
+
+{% if is_edit %}</form>{% else %}</div>{% endif %}
+{% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
+{% endblock %}

--- a/crkva/registar/templates/registar/unos_parohijana.html
+++ b/crkva/registar/templates/registar/unos_parohijana.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
 {% block content %}
-<form method="post" class="form form--single-column">
+<form method="post" class="info-page">
   {% csrf_token %}
 
   <div class="u-page-header">
     <a href="{% if back_url %}{{ back_url }}{% else %}{% url 'parohijani' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад">
       <i class="fa-solid fa-arrow-left"></i>
     </a>
-    <h1 class="u-page-title">{{ title|default:"Додавање новог парохијана" }}</h1>
-    <button class="button button--primary" type="submit" title="Сачувај">
-      <i class="fa-solid fa-floppy-disk" style="margin-right: 6px;"></i> Сачувај
+    <h1 class="u-page-title">{{ title|default:"Додавање парохијана" }}</h1>
+    <button class="button button--primary" type="submit" data-tooltip="Сачувај">
+      <i class="fa-solid fa-floppy-disk"></i>
     </button>
   </div>
 
@@ -25,13 +25,11 @@
     </div>
   {% endif %}
 
-  <fieldset class="form-section">
-    <legend><i class="fa-solid fa-user"></i> Основни подаци</legend>
-
-    <div class="form-row">
-      <div class="form-field">
+  <ul class="info-rows">
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div>
+      <div class="info-row__value">
         <div class="toggle-wrapper">
-          <span class="toggle-label">{{ form.pol.label }}</span>
           <div class="toggle-group" id="pol-toggle">
             {% for value, label in form.pol.field.choices %}
               <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
@@ -40,25 +38,43 @@
         </div>
         <div class="visually-hidden">{{ form.pol }}</div>
       </div>
-    </div>
-
-    <div class="form-row"><div class="form-field">{{ form.ime.label_tag }} {{ form.ime }}</div></div>
-    <div class="form-row"><div class="form-field">{{ form.prezime.label_tag }} {{ form.prezime }}</div></div>
-    <div class="form-row"><div class="form-field">{{ form.devojacko_prezime.label_tag }} {{ form.devojacko_prezime }}</div></div>
-
-    <div class="form-row form-row--pair">
-      <div class="form-field">{{ form.datum_rodjenja.label_tag }} {{ form.datum_rodjenja }}</div>
-      <div class="form-field">{{ form.vreme_rodjenja.label_tag }} {{ form.vreme_rodjenja }}</div>
-    </div>
-
-    <div class="form-row"><div class="form-field">{{ form.mesto_rodjenja.label_tag }} {{ form.mesto_rodjenja }}</div></div>
-  </fieldset>
-
-  <fieldset class="form-section">
-    <legend><i class="fa-solid fa-id-card"></i> Детаљи</legend>
-    <div class="form-row"><div class="form-field">{{ form.zanimanje.label_tag }} {{ form.zanimanje }}</div></div>
-    <div class="form-row"><div class="form-field">{{ form.veroispovest.label_tag }} {{ form.veroispovest }}</div></div>
-    <div class="form-row"><div class="form-field">{{ form.narodnost.label_tag }} {{ form.narodnost }}</div></div>
-  </fieldset>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
+      <div class="info-row__value">{{ form.ime }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Презиме"><i class="fa-solid fa-user-tag"></i></div>
+      <div class="info-row__value">{{ form.prezime }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Девојачко презиме"><i class="fa-solid fa-id-card"></i></div>
+      <div class="info-row__value">{{ form.devojacko_prezime }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div>
+      <div class="info-row__value">{{ form.datum_rodjenja }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Време рођења"><i class="fa-solid fa-clock"></i></div>
+      <div class="info-row__value">{{ form.vreme_rodjenja }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div>
+      <div class="info-row__value">{{ form.mesto_rodjenja }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div>
+      <div class="info-row__value">{{ form.zanimanje }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div>
+      <div class="info-row__value">{{ form.veroispovest }}</div>
+    </li>
+    <li class="info-row info-row--editable">
+      <div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div>
+      <div class="info-row__value">{{ form.narodnost }}</div>
+    </li>
+  </ul>
 </form>
 {% endblock %}

--- a/crkva/registar/tests/test_unos_domacinstva.py
+++ b/crkva/registar/tests/test_unos_domacinstva.py
@@ -38,7 +38,7 @@ class UnosDomacinstvaViewTests(TestCase):
         self.client.force_login(self.clerk)
         r = self.client.get(reverse("unos_domacinstva"))
         self.assertEqual(r.status_code, 200)
-        self.assertTemplateUsed(r, "registar/unos_domacinstva.html")
+        self.assertTemplateUsed(r, "registar/domacinstvo.html")
 
     def test_priest_cannot_open_form(self):
         self.client.force_login(self.priest)

--- a/crkva/registar/tests/test_unos_svestenika.py
+++ b/crkva/registar/tests/test_unos_svestenika.py
@@ -37,7 +37,7 @@ class UnosSvestenikaViewTests(TestCase):
         self.client.force_login(self.priest)
         r = self.client.get(reverse("unos_svestenika"))
         self.assertEqual(r.status_code, 200)
-        self.assertTemplateUsed(r, "registar/unos_svestenika.html")
+        self.assertTemplateUsed(r, "registar/svestenik.html")
         self.assertIn("form", r.context)
 
     def test_clerk_cannot_open_form(self):

--- a/crkva/registar/views/domacinstvo_view.py
+++ b/crkva/registar/views/domacinstvo_view.py
@@ -21,7 +21,11 @@ def unos_domacinstva(request):
             return redirect("domacinstva")
     else:
         form = DomacinstvoForm()
-    return render(request, "registar/unos_domacinstva.html", {"form": form})
+    return render(
+        request,
+        "registar/domacinstvo.html",
+        {"form": form, "is_edit": True, "domacinstvo": None},
+    )
 
 
 class SpisakDomacinsta(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
@@ -51,7 +55,7 @@ class PrikazDomacinstva(DetailView):
     """Приказује детаљне информације о одређеном домаћинству."""
 
     model = Domacinstvo
-    template_name = "registar/info_domacinstvo.html"
+    template_name = "registar/domacinstvo.html"
     context_object_name = "domacinstvo"
     pk_url_kwarg = "uid"
 
@@ -71,6 +75,8 @@ class PrikazDomacinstva(DetailView):
 
         context = super().get_context_data(**kwargs)
         context["history_entries"] = history_for(self.object)
+        context["domacinstvo"] = self.object
+        context["is_edit"] = False
         domacinstvo = self.object
         ukucani = domacinstvo.ukucani.all()
         context["ukucani_zivi"] = [u for u in ukucani if not u.preminuo]
@@ -91,11 +97,12 @@ def izmena_domacinstva(request, uid):
         form = DomacinstvoForm(instance=instance)
     return render(
         request,
-        "registar/unos_domacinstva.html",
+        "registar/domacinstvo.html",
         {
             "form": form,
             "title": "Измена",
             "back_url": reverse("domacinstvo_detail", kwargs={"uid": instance.uid}),
             "is_edit": True,
+            "domacinstvo": instance,
         },
     )

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -27,7 +27,11 @@ def unos_parohijana(request):
             return redirect("parohijani")
     else:
         form = ParohijanForm()
-    return render(request, "registar/unos_parohijana.html", {"form": form})
+    return render(
+        request,
+        "registar/parohijan.html",
+        {"form": form, "is_edit": True, "parohijan": None},
+    )
 
 
 class SpisakParohijana(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
@@ -86,7 +90,7 @@ class PrikazParohijana(DetailView):
     """Приказује детаљне информације о одређеном парохијану."""
 
     model = Parohijan
-    template_name = "registar/info_parohijan.html"
+    template_name = "registar/parohijan.html"
     context_object_name = "parohijan"
     pk_url_kwarg = "uid"
 
@@ -157,11 +161,12 @@ def izmena_parohijana(request, uid):
         form = ParohijanForm(instance=instance)
     return render(
         request,
-        "registar/unos_parohijana.html",
+        "registar/parohijan.html",
         {
             "form": form,
             "title": "Измена",
             "back_url": reverse("parohijan_detail", kwargs={"uid": instance.uid}),
             "is_edit": True,
+            "parohijan": instance,
         },
     )

--- a/crkva/registar/views/svestenik_view.py
+++ b/crkva/registar/views/svestenik_view.py
@@ -23,7 +23,11 @@ def unos_svestenika(request):
             return redirect("svestenici")
     else:
         form = SvestenikForm()
-    return render(request, "registar/unos_svestenika.html", {"form": form})
+    return render(
+        request,
+        "registar/svestenik.html",
+        {"form": form, "is_edit": True, "svestenik": None},
+    )
 
 
 class SpisakSvestenika(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
@@ -79,7 +83,7 @@ class PrikazSvestenika(DetailView):
     """Приказује детаљне информације о одређеном свештенику."""
 
     model = Svestenik
-    template_name = "registar/info_svestenik.html"
+    template_name = "registar/svestenik.html"
     context_object_name = "svestenik"
 
     def get_object(self):
@@ -117,11 +121,12 @@ def izmena_svestenika(request, uid):
         form = SvestenikForm(instance=instance)
     return render(
         request,
-        "registar/unos_svestenika.html",
+        "registar/svestenik.html",
         {
             "form": form,
             "title": "Измена",
             "back_url": reverse("svestenik_detail", kwargs={"uid": instance.uid}),
             "is_edit": True,
+            "svestenik": instance,
         },
     )


### PR DESCRIPTION
* parohijan, svestenik, domacinstvo: one template handles /info, /unos, /izmena via is_edit flag
* same info-row spec-sheet layout in both modes — inputs replace text
* tests updated for new template names
* krstenje + vencanje will follow in next PR (tabs + many fields)