### PR TITLE
fix: toggle-group component rework

### DIFF
--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -129,28 +129,76 @@ fieldset.form-section legend {
   font-weight: 700;
 }
 
-/* Toggle group for 'pol' selection */
+/* ==========================================================================
+   TOGGLE GROUP — segmented control (pill buttons)
+   Used as a replacement for <select> when there are 2-5 discrete options.
+   Visual: pills inside a rounded container. Active pill has solid primary
+   background and contrasting text. Inactive pills are transparent / muted.
+   ========================================================================== */
 .toggle-group {
   display: inline-flex;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
-  overflow: hidden;
+  border-radius: 999px;
   background: var(--color-surface-1);
+  padding: 3px;
+  gap: 2px;
+  flex-wrap: wrap;
 }
 .toggle-button {
-  padding: 8px 14px;
+  padding: 6px 14px;
   cursor: pointer;
   user-select: none;
   font-weight: 500;
+  font-size: 14px;
+  line-height: 1.4;
   color: var(--color-text-muted);
   background: transparent;
   border: none;
+  border-radius: 999px;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
-.toggle-button + .toggle-button { border-left: 1px solid var(--color-border); }
-.toggle-button.active {
+.toggle-button:hover:not(.active):not(:disabled) {
+  background: color-mix(in oklab, var(--color-text-muted) 12%, transparent);
   color: var(--color-text);
-  background: var(--color-surface-2);
 }
+.toggle-button:focus-visible,
+.toggle-button:focus-within {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.toggle-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.toggle-button.active,
+.toggle-button:has(input:checked) {
+  color: #fff;
+  background: var(--color-primary);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+.toggle-button:has(input:checked):hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+/* Hide the underlying radio/checkbox inside a label-style toggle */
+.toggle-button > input[type="radio"],
+.toggle-button > input[type="checkbox"] {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+/* Compact variant for dense lists / toolbars */
+.toggle-group--sm {
+  padding: 2px;
+}
+.toggle-group--sm .toggle-button {
+  padding: 4px 10px;
+  font-size: 13px;
+}
+
 .toggle-wrapper { display: flex; align-items: center; gap: 10px; }
 .toggle-label { font-weight: 600; color: var(--color-text-muted); }
 /* NOTE: .visually-hidden је дефинисан у utilities/pomocno.css */

--- a/crkva/registar/templates/registar/_list_toolbar.html
+++ b/crkva/registar/templates/registar/_list_toolbar.html
@@ -4,11 +4,14 @@
         <input type="search" name="search" value="{{ upit }}" placeholder="Претражи..." class="list-toolbar__search-input" autocomplete="off" aria-label="Претрага">
     </div>
     {% if sort_options %}
-    <select name="sort" class="list-toolbar__select" onchange="this.form.submit()" data-tooltip="Сортирање">
+    <div class="toggle-group toggle-group--sm" role="radiogroup" aria-label="Сортирање">
         {% for value, label in sort_options %}
-        <option value="{{ value }}"{% if current_sort == value %} selected{% endif %}>{{ label }}</option>
+        <label class="toggle-button">
+            <input type="radio" name="sort" value="{{ value }}"{% if current_sort == value %} checked{% endif %} onchange="this.form.submit()">
+            <span>{{ label }}</span>
+        </label>
         {% endfor %}
-    </select>
+    </div>
     {% endif %}
 
 </form>

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -49,14 +49,14 @@
     <li class="info-row info-row--editable">
       <div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div>
       <div class="info-row__value">
-        <div class="toggle-wrapper">
-          <div class="toggle-group" id="pol-toggle">
-            {% for value, label in form.pol.field.choices %}
-              <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
-            {% endfor %}
-          </div>
+        <div class="toggle-group" role="radiogroup" aria-label="Пол">
+          {% for value, label in form.pol.field.choices %}{% if value %}
+            <label class="toggle-button">
+              <input type="radio" name="pol" value="{{ value }}"{% if form.pol.value == value %} checked{% endif %}>
+              <span>{{ label }}</span>
+            </label>
+          {% endif %}{% endfor %}
         </div>
-        <div class="visually-hidden">{{ form.pol }}</div>
       </div>
     </li>
     {% elif parohijan.pol %}

--- a/crkva/registar/templates/registar/unos_parohijana.html
+++ b/crkva/registar/templates/registar/unos_parohijana.html
@@ -29,14 +29,14 @@
     <li class="info-row info-row--editable">
       <div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div>
       <div class="info-row__value">
-        <div class="toggle-wrapper">
-          <div class="toggle-group" id="pol-toggle">
-            {% for value, label in form.pol.field.choices %}
-              <button type="button" class="toggle-button{% if form.pol.value == value %} active{% endif %}" data-value="{{ value }}">{{ label }}</button>
-            {% endfor %}
-          </div>
+        <div class="toggle-group" role="radiogroup" aria-label="Пол">
+          {% for value, label in form.pol.field.choices %}{% if value %}
+            <label class="toggle-button">
+              <input type="radio" name="pol" value="{{ value }}"{% if form.pol.value == value %} checked{% endif %}>
+              <span>{{ label }}</span>
+            </label>
+          {% endif %}{% endfor %}
         </div>
-        <div class="visually-hidden">{{ form.pol }}</div>
       </div>
     </li>
     <li class="info-row info-row--editable">


### PR DESCRIPTION
* strong active state — solid primary pill, white text, shadow
* hover/focus/disabled states
* pol toggle now wraps a real radio input (no JS, no doubled DOM)
* list-toolbar sort select replaced with toggle-group