### PR TITLE
fix: history panel renders for krstenje/venčanje

### DIFF
--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -86,6 +86,9 @@ class KrstenjePDF(DetailView):
     def get_context_data(self, **kwargs):
         """Додаје историјске снимке особа у контекст."""
         context = super().get_context_data(**kwargs)
+        from registar.history import history_for
+
+        context["history_entries"] = history_for(self.object)
         krstenje = context["krstenje"]
         event_date = krstenje.datum or krstenje.created
 
@@ -138,13 +141,6 @@ class PrikazKrstenja(DetailView):
 def calibrate_krstenje(request):
     """Калибрациона страница за подешавање позиција поља на крштеници."""
     return render(request, "registar/calibrate_krstenje.html")
-
-    def get_context_data(self, **kwargs):
-        from registar.history import history_for
-
-        context = super().get_context_data(**kwargs)
-        context["history_entries"] = history_for(self.object)
-        return context
 
 
 @tenant_role_required("krstenje")

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -73,6 +73,9 @@ class VencanjePDF(DetailView):
     def get_context_data(self, **kwargs):
         """Додаје историјске снимке особа у контекст."""
         context = super().get_context_data(**kwargs)
+        from registar.history import history_for
+
+        context["history_entries"] = history_for(self.object)
         vencanje = context["vencanje"]
         event_date = vencanje.datum or vencanje.created
 
@@ -148,13 +151,6 @@ def unos_vencanja(request):
 def calibrate_vencanje(request):
     """Приказује страницу за калибрацију позиција поља на венчаници."""
     return render(request, "registar/calibrate_vencanje.html")
-
-    def get_context_data(self, **kwargs):
-        from registar.history import history_for
-
-        context = super().get_context_data(**kwargs)
-        context["history_entries"] = history_for(self.object)
-        return context
 
 
 @tenant_role_required("vencanje")


### PR DESCRIPTION
* history_for() was injected as dead code after `return` inside calibrate_*
* moved into PrikazKrstenja and PrikazVencanja get_context_data — now reaches the template