### PR TITLE
feat: refined dark palette + brand-coloured links

### DIFF
--- a/crkva/registar/static/registar/base/tokens.css
+++ b/crkva/registar/static/registar/base/tokens.css
@@ -51,6 +51,10 @@
     --color-info-border-light: #b3d9ff;
     --color-info-link: #0066cc;
 
+    /* Link colors — used for plain <a> elements site-wide */
+    --color-link: var(--color-primary);
+    --color-link-hover: var(--color-primary-700);
+
     /* Primary hover state */
     --color-primary-hover: #8B1312;
     --color-primary-transparent: rgba(162, 21, 20, 0.1);
@@ -177,6 +181,10 @@ a:focus, button:focus, input:focus, select:focus, textarea:focus {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
+
+/* Default link colour: brand red, never browser blue */
+a { color: var(--color-link); text-decoration: none; }
+a:hover { color: var(--color-link-hover); text-decoration: underline; }
 
 /* Sekundarni tekst */
 .muted { color: var(--color-text-muted); }

--- a/crkva/registar/static/registar/components/tabovi.css
+++ b/crkva/registar/static/registar/components/tabovi.css
@@ -133,42 +133,38 @@
 
 .tabs--segmented .tabs__nav {
     border: 1px solid var(--color-border);
-    border-radius: var(--radius-2);
-    overflow: hidden;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-    background: var(--color-surface);
+    border-radius: 999px;
+    background: var(--color-surface-1);
+    padding: 3px;
+    gap: 2px;
 }
 
 .tabs--segmented .tabs__tab {
     background: transparent;
-}
-
-.tabs--segmented .tabs__tab + .tabs__radio + .tabs__tab,
-.tabs--segmented .tabs__radio:not(:first-of-type) + .tabs__tab {
-    border-left: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-weight: 500;
+    border-radius: 999px;
+    padding: 6px 16px;
+    min-height: 32px;
+    transition: background 0.15s ease, color 0.15s ease;
 }
 
 .tabs--segmented .tabs__tab:hover:not([aria-disabled="true"]) {
-    background: var(--color-surface-2);
+    background: color-mix(in oklab, var(--color-text-muted) 12%, transparent);
+    color: var(--color-text);
 }
 
-/* Active tab — primary fill, white text, count badge inverted */
+/* Active tab — solid primary pill (mirrors .toggle-button.active) */
 .tabs--segmented .tabs__radio:checked + .tabs__tab {
     background: var(--color-primary);
     color: #fff;
-    border-left-color: transparent;
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 .tabs--segmented .tabs__radio:checked + .tabs__tab .tabs__count {
     background: rgba(255, 255, 255, 0.22);
     color: #fff;
-}
-
-/* Hide the divider directly to the right of the active tab so the fill
-   meets its neighbour seamlessly. Approximate: the tab immediately after
-   the active label drops its left border. */
-.tabs--segmented .tabs__radio:checked + .tabs__tab + .tabs__radio + .tabs__tab {
-    border-left-color: transparent;
 }
 
 .tabs--segmented .tabs__radio:focus-visible + .tabs__tab {

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -1,70 +1,97 @@
 /* ==========================================================================
    ТАМНА ТЕМА (Dark Theme)
    ==========================================================================
-   Организација:
-   1. CSS варијабле (токени)
-   2. Основни елементи (body, footer)
-   3. Форме и инпути
-   4. Картице и панели
-   5. Листе и ставке
-   6. Календар
-   7. Временска линија (timeline)
-   8. Бочна трака (sidebar)
-   9. Utility компоненте
+
+   Goal of this file: define the dark-mode VALUES of the shared design
+   tokens. Components consume those tokens (var(--color-*)), so a refined
+   palette flows through the whole UI without per-component overrides.
+
+   Where a component still needs special treatment in dark mode (because
+   its base style hard-coded a colour, or because a particular effect
+   reads poorly), it goes in the OVERRIDES section near the bottom.
    ========================================================================== */
 
 /* ==========================================================================
-   1. CSS ВАРИЈАБЛЕ
+   1. TOKENS
    ========================================================================== */
 
 :root[data-theme="dark"] {
-  /* Примарна боја - задржава се бренд */
-  --color-primary: #A21514;
-  --color-primary-700: #9c1818;
-  --color-primary-50: color-mix(in oklab, var(--color-primary) 14%, black);
-  --color-primary-100: color-mix(in oklab, var(--color-primary) 22%, black);
-  --color-primary-200: color-mix(in oklab, var(--color-primary) 32%, black);
+  /* ---------- Brand ---------- */
+  /* Primary stays the SPC red, but brighter on dark so body text + buttons
+     keep WCAG contrast against the dark surface. */
+  --color-primary:       #ef4444;
+  --color-primary-700:   #dc2626;
+  --color-primary-hover: #f87171;
+  --color-primary-transparent: rgba(239, 68, 68, 0.18);
+  --color-primary-50:    color-mix(in oklab, var(--color-primary) 14%, #0d1117);
+  --color-primary-100:   color-mix(in oklab, var(--color-primary) 22%, #0d1117);
+  --color-primary-200:   color-mix(in oklab, var(--color-primary) 32%, #0d1117);
 
-  /* Текст */
-  --color-text: #e5e7eb;
-  --color-text-muted: #cbd5e1;
+  /* ---------- Surfaces (page → cards → controls) ---------- */
+  --color-surface:   #0d1117;   /* page background — true dark, slight blue tint */
+  --color-surface-2: #161b22;   /* cards, panels, info-rows */
+  --color-surface-1: #21262d;   /* form controls, inputs */
+  --color-surface-3: #30363d;   /* hover surfaces, active controls */
 
-  /* Површине */
-  --color-surface: #0b0f14;    /* позадина странице */
-  --color-surface-1: #1f2937;  /* контроле */
-  --color-surface-2: #111827;  /* картице/панели */
+  /* ---------- Text ---------- */
+  --color-text:        #e6edf3;  /* primary */
+  --color-text-muted:  #9ba3af;  /* secondary */
+  --color-muted:       #9ba3af;  /* alias */
+  --color-placeholder: #6e7681;
 
-  /* Ивице */
-  --color-border: #334155;
+  /* ---------- Borders ---------- */
+  --color-border:        #30363d;  /* subtle */
+  --color-border-strong: #484f58;  /* dividers, input borders */
 
-  /* Бочна трака */
-  --sidebar-bg: linear-gradient(180deg, var(--color-surface-2) 0%, #0f172a 100%);
+  /* ---------- Status ---------- */
+  --color-success: #3fb950;
+  --color-warning: #d29922;
+  --color-danger:  #f85149;
+  --color-info:    #58a6ff;
 
-  /* Пост - боје за временску линију */
-  --fasting-water-bg: rgba(96, 165, 250, 0.25);
-  --fasting-oil-bg: rgba(251, 191, 36, 0.3);
-  --fasting-fish-bg: rgba(45, 212, 191, 0.25);
-  --fasting-dairy-bg: rgba(252, 211, 77, 0.2);
+  /* Links: use the brighter dark-primary to keep contrast on dark surfaces */
+  --color-link:       var(--color-primary);
+  --color-link-hover: var(--color-primary-hover);
 
-  --fasting-water-cell: var(--color-primary);
-  --fasting-water-cell-end: var(--color-primary-700);
-  --fasting-water-border: var(--color-primary);
+  /* ---------- Sidebar / chrome ---------- */
+  --sidebar-bg: linear-gradient(180deg, var(--color-surface-2) 0%, #0a0f17 100%);
 
-  --fasting-oil-cell: #7f1d1d;
-  --fasting-oil-cell-end: #991b1b;
-  --fasting-oil-border: #7f1d1d;
+  /* ---------- Slava badge — keep amber readable on dark ---------- */
+  --color-slava-bg:     #2d2410;
+  --color-slava-border: #7c5e1c;
+  --color-slava-text:   #f1d27a;
 
-  --fasting-fish-cell: #991b1b;
-  --fasting-fish-cell-end: #7f1d1d;
-  --fasting-fish-border: #991b1b;
+  /* ---------- Fasting cells — derive from primary instead of bespoke hex ---------- */
+  --fasting-water-bg:  rgba(96, 165, 250, 0.22);
+  --fasting-oil-bg:    rgba(251, 191, 36, 0.22);
+  --fasting-fish-bg:   rgba(45, 212, 191, 0.18);
+  --fasting-dairy-bg:  rgba(252, 211, 77, 0.15);
 
-  --fasting-dairy-cell: #450a0a;
-  --fasting-dairy-cell-end: #7f1d1d;
-  --fasting-dairy-border: #450a0a;
+  --fasting-water-cell:     color-mix(in oklab, var(--color-primary) 35%, var(--color-surface-2));
+  --fasting-water-cell-end: color-mix(in oklab, var(--color-primary) 25%, var(--color-surface-2));
+  --fasting-water-border:   color-mix(in oklab, var(--color-primary) 45%, var(--color-surface-2));
+
+  --fasting-oil-cell:     color-mix(in oklab, var(--color-primary) 25%, var(--color-surface-2));
+  --fasting-oil-cell-end: color-mix(in oklab, var(--color-primary) 15%, var(--color-surface-2));
+  --fasting-oil-border:   color-mix(in oklab, var(--color-primary) 30%, var(--color-surface-2));
+
+  --fasting-fish-cell:     color-mix(in oklab, var(--color-primary) 18%, var(--color-surface-2));
+  --fasting-fish-cell-end: color-mix(in oklab, var(--color-primary) 10%, var(--color-surface-2));
+  --fasting-fish-border:   color-mix(in oklab, var(--color-primary) 22%, var(--color-surface-2));
+
+  --fasting-dairy-cell:     color-mix(in oklab, var(--color-primary) 10%, var(--color-surface-2));
+  --fasting-dairy-cell-end: var(--color-surface-2);
+  --fasting-dairy-border:   color-mix(in oklab, var(--color-primary) 15%, var(--color-surface-2));
+
+  /* ---------- Shadow tokens (deeper on dark) ---------- */
+  --shadow-sm:    0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-md:    0 4px 12px rgba(0, 0, 0, 0.55);
+  --shadow-lg:    0 8px 24px rgba(0, 0, 0, 0.6);
+  --shadow-hover: 0 8px 14px -6px rgba(0, 0, 0, 0.7);
 }
 
 /* ==========================================================================
-   2. ОСНОВНИ ЕЛЕМЕНТИ
+   2. ROOT BACKGROUND + TEXT
    ========================================================================== */
 
 [data-theme="dark"] body {
@@ -73,412 +100,76 @@
 }
 
 [data-theme="dark"] body > footer {
-  background-color: #0f172a;
+  background-color: #050a13;
   color: var(--color-text);
 }
 
 /* ==========================================================================
-   3. ФОРМЕ И ИНПУТИ
+   3. OVERRIDES — components that can't be fully driven by tokens
    ========================================================================== */
 
+/* Inputs: enforce surface-1 on dark since some component CSS uses
+   var(--color-surface) which would blend into the page bg. */
 [data-theme="dark"] input[type="text"],
 [data-theme="dark"] input[type="search"],
 [data-theme="dark"] input[type="number"],
 [data-theme="dark"] input[type="date"],
 [data-theme="dark"] input[type="email"],
 [data-theme="dark"] input[type="time"],
+[data-theme="dark"] input[type="tel"],
+[data-theme="dark"] input[type="password"],
 [data-theme="dark"] select,
 [data-theme="dark"] textarea {
-  background: var(--color-surface-2);
+  background: var(--color-surface-1);
   color: var(--color-text);
-  border-color: var(--color-border);
-  box-shadow: none;
+  border-color: var(--color-border-strong);
 }
 
 [data-theme="dark"] input::placeholder,
 [data-theme="dark"] textarea::placeholder {
-  color: #94a3b8;
+  color: var(--color-placeholder);
 }
 
-[data-theme="dark"] .search-input {
-  background: var(--color-surface-2);
-  color: var(--color-text);
-  border-color: var(--color-border);
-}
-
-/* Претрага - overlay */
-[data-theme="dark"] #search-overlay {
-  background: var(--color-surface-2);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
-}
-
-@media (max-width: 768px) {
-  [data-theme="dark"] #search-overlay {
-    background: color-mix(in oklab, var(--color-surface-2) 92%, transparent);
-  }
-  [data-theme="dark"] .search-box {
-    background: var(--color-surface-2);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-  }
-  [data-theme="dark"] .close-search {
-    color: var(--color-text);
-    background: #1f2937;
-  }
-  [data-theme="dark"] .close-search:hover {
-    background: #374151;
-  }
-}
-
-/* ==========================================================================
-   4. КАРТИЦЕ И ПАНЕЛИ
-   ========================================================================== */
-
-[data-theme="dark"] .panel,
-[data-theme="dark"] .card,
-[data-theme="dark"] .container-panel {
-  background: var(--color-surface-2);
-  color: var(--color-text);
-  border-color: var(--color-border);
-}
-
-[data-theme="dark"] .u-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-}
-
-/* Подсетници за славе на почетној */
-[data-theme="dark"] .slava-reminders {
-  background-color: var(--color-surface-2);
-  border-color: var(--color-border);
-  color: var(--color-text);
-}
-
-/* ==========================================================================
-   5. ЛИСТЕ И СТАВКЕ
-   ========================================================================== */
-
-[data-theme="dark"] .stavka {
-  border-bottom-color: var(--color-border);
-}
-
-[data-theme="dark"] .stavka:hover {
-  background-color: var(--color-surface-2);
-}
-
-[data-theme="dark"] .stavka-veza {
-  color: var(--color-text);
-}
-
-[data-theme="dark"] .stavka__member-role-badge {
-  background: rgba(162, 21, 20, 0.2);
-}
-
-[data-theme="dark"] .pagination {
-  border-top-color: var(--color-border);
-}
-
-/* ==========================================================================
-   6. КАЛЕНДАР
-   ========================================================================== */
-
-/* Навигација */
-[data-theme="dark"] .calendar-navigation {
-  background: var(--color-surface-2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-}
-
-[data-theme="dark"] .nav-arrow:hover {
-  background: color-mix(in oklab, var(--color-surface-2) 85%, transparent);
-}
-
-/* Ћелије календара */
-[data-theme="dark"] .calendar-cell {
-  background: var(--color-surface-2);
-  border-color: var(--color-border);
-}
-
-[data-theme="dark"] .calendar-cell .weekday,
-[data-theme="dark"] .calendar-cell .no-slavas-text {
-  opacity: 1;
-  color: var(--color-text-muted);
-}
-
-/* Данас - златни сјај */
+/* Today highlight in calendar — amber works against dark, define here */
 [data-theme="dark"] .calendar-cell.today {
-  background: linear-gradient(135deg, var(--color-amber-900) 0%, var(--color-amber-800) 100%);
-  border: 3px solid var(--color-amber-500);
-  box-shadow: 0 0 0 1px var(--color-amber-500), 0 2px 12px rgba(245, 158, 11, 0.3);
-  color: var(--color-amber-400);
+  background: linear-gradient(135deg, #4a3410 0%, #6b4a16 100%);
+  border: 2px solid var(--color-warning);
+  box-shadow: 0 0 0 1px var(--color-warning), 0 2px 12px rgba(210, 153, 34, 0.35);
 }
-
-[data-theme="dark"] .calendar-cell.today .date {
-  color: var(--color-amber-200);
-  font-weight: 800;
-}
-
-[data-theme="dark"] .calendar-cell.today .weekday {
-  color: var(--color-amber-300);
-  font-weight: 600;
-}
-
+[data-theme="dark"] .calendar-cell.today .date     { color: #fde68a; font-weight: 800; }
+[data-theme="dark"] .calendar-cell.today .weekday  { color: #fcd34d; font-weight: 600; }
 [data-theme="dark"] .calendar-cell.today .slavas,
-[data-theme="dark"] .calendar-cell.today .slavas div {
-  color: var(--color-amber-100) !important;
-}
+[data-theme="dark"] .calendar-cell.today .slavas div { color: #fef3c7 !important; }
 
-[data-theme="dark"] .calendar-cell.today .slava-link:hover {
-  background: var(--color-white-alpha-20);
-}
-
-/* Црвено слово */
+/* Red letter day (Crveno slovo) reads cleaner with primary backdrop */
 [data-theme="dark"] .calendar-cell.crveno-slovo {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-700) 100%);
   border-color: var(--color-primary);
-  color: var(--color-surface) !important;
+  color: #fff !important;
 }
-
 [data-theme="dark"] .calendar-cell.crveno-slovo .weekday,
 [data-theme="dark"] .calendar-cell.crveno-slovo .slavas,
 [data-theme="dark"] .calendar-cell.crveno-slovo .slavas div,
 [data-theme="dark"] .calendar-cell.crveno-slovo .no-slavas-text,
 [data-theme="dark"] .calendar-cell.crveno-slovo .date,
 [data-theme="dark"] .calendar-cell.crveno-slovo .fasting-icon {
-  color: var(--color-surface) !important;
-}
-
-/* Пост - ћелије календара */
-[data-theme="dark"] .calendar-cell.fasting-вода {
-  background: linear-gradient(135deg, color-mix(in oklab, var(--color-primary) 35%, var(--color-surface-2)) 0%, color-mix(in oklab, var(--color-primary) 25%, var(--color-surface-2)) 100%);
-  border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-surface-2));
-}
-
-[data-theme="dark"] .calendar-cell.fasting-уље {
-  background: linear-gradient(135deg, #7f1d1d 0%, #6b1515 100%);
-  border-color: #7f1d1d;
-}
-
-[data-theme="dark"] .calendar-cell.fasting-риба {
-  background: linear-gradient(135deg, #6b1515 0%, #5a1111 100%);
-  border-color: #6b1515;
-}
-
-[data-theme="dark"] .calendar-cell.fasting-бели_мрс {
-  background: linear-gradient(135deg, #5a1111 0%, color-mix(in oklab, var(--color-primary) 10%, var(--color-surface-2)) 100%);
-  border-color: #5a1111;
-}
-
-/* Slava линкови */
-[data-theme="dark"] .slava-link:hover {
-  background: var(--color-primary-transparent);
-}
-
-/* ==========================================================================
-   7. ВРЕМЕНСКА ЛИНИЈА (Timeline)
-   ========================================================================== */
-
-/* Данас */
-[data-theme="dark"] .timeline__day--today {
-  background: var(--color-surface-1);
-  border: 2px solid var(--color-border);
-  border-left: 4px solid var(--color-primary);
-}
-
-[data-theme="dark"] .timeline__day--today .timeline__date {
-  color: var(--color-text);
-  font-weight: 800;
-}
-
-[data-theme="dark"] .timeline__day--today .timeline__label {
-  color: var(--color-text-muted);
-  font-weight: 600;
-}
-
-[data-theme="dark"] .timeline__day--today .timeline__name {
-  color: var(--color-text);
-}
-
-[data-theme="dark"] .timeline__day--today .timeline__item {
-  background: var(--color-surface-2);
-  border: 1px solid var(--color-border);
-}
-
-/* Пост - временска линија */
-[data-theme="dark"] .timeline__day--fasting.fasting-вода {
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-700) 100%);
-}
-
-[data-theme="dark"] .timeline__day--fasting.fasting-вода .timeline__date,
-[data-theme="dark"] .timeline__day--fasting.fasting-вода .timeline__label,
-[data-theme="dark"] .timeline__day--fasting.fasting-вода .timeline__name,
-[data-theme="dark"] .timeline__day--fasting.fasting-вода .timeline__empty-day {
-  color: var(--color-surface) !important;
-}
-
-[data-theme="dark"] .timeline__day--fasting.fasting-уље {
-  background: linear-gradient(135deg, var(--color-primary-200) 0%, var(--color-primary-100) 100%);
-}
-
-[data-theme="dark"] .timeline__day--fasting.fasting-риба {
-  background: linear-gradient(135deg, var(--color-primary-100) 0%, var(--color-primary-50) 100%);
-}
-
-[data-theme="dark"] .timeline__day--fasting.fasting-бели_мрс {
-  background: linear-gradient(135deg, var(--color-primary-50) 0%, color-mix(in oklab, var(--color-primary) 5%, var(--color-surface-2)) 100%);
-}
-
-/* Важни празници */
-[data-theme="dark"] .timeline__day--important {
-  border: 2px solid var(--color-primary);
-  box-shadow: 0 0 0 1px var(--color-primary-700), 0 2px 8px color-mix(in oklab, var(--color-primary) 20%, transparent);
-}
-
-/* Tooltip за пост */
-[data-theme="dark"] .fasting-tooltip {
-  background: var(--color-surface-2);
-  border-color: var(--color-border);
-  color: var(--color-text);
-}
-
-/* Празан дан */
-[data-theme="dark"] .timeline__empty-day {
-  color: var(--color-text-muted);
-}
-
-/* Раздвајач слава */
-[data-theme="dark"] .slavas-separator {
-  background: var(--color-border);
-  opacity: 0.5;
-}
-
-/* Покретне и непокретне славе */
-[data-theme="dark"] .slava-moveable {
-  color: var(--color-text);
-}
-
-[data-theme="dark"] .slava-fixed {
-  color: var(--color-text-muted);
-  opacity: 0.7;
-}
-
-/* ==========================================================================
-   8. ДУГМАД
-   ========================================================================== */
-
-[data-theme="dark"] .dugme-crveno {
-  color: #fff;
-}
-
-/* ==========================================================================
-   9. UTILITY КОМПОНЕНТЕ (data-theme атрибути)
-   ========================================================================== */
-
-[data-theme="dark"] [data-theme-aware],
-[data-theme="dark"] [data-theme-card] {
-  background: var(--color-surface-2) !important;
-  border-color: var(--color-border) !important;
-}
-
-[data-theme="dark"] [data-theme-text] {
-  color: var(--color-text) !important;
-}
-
-[data-theme="dark"] [data-theme-text-secondary] {
-  color: var(--color-text-muted) !important;
-}
-
-[data-theme=dark] .search-overlay {
-  background: rgba(0, 0, 0, 0.85);
-}
-
-[data-theme=dark] .search-box {
-  background: var(--color-surface-2);
-  border-color: var(--color-border);
-}
-
-[data-theme=dark] .search-box input {
-  color: var(--color-text);
-}
-
-[data-theme=dark] .search-box__kbd {
-  background: var(--color-surface-1);
-  border-color: var(--color-border);
-  color: var(--color-text-muted);
-}
-
-[data-theme=dark] .search-results {
-  background: var(--color-surface-2);
-  border-color: var(--color-border);
-}
-
-[data-theme=dark] .search-result-item {
-  color: var(--color-text);
-  border-bottom-color: var(--color-border);
-}
-
-[data-theme=dark] .search-result-item:hover,
-[data-theme=dark] .search-result-item--active {
-  background: var(--color-surface-1);
-}
-
-[data-theme=dark] .search-result-group {
-  background: var(--color-surface-1);
-  color: var(--color-text-muted);
-  border-bottom-color: var(--color-border);
-}
-
-[data-theme=dark] .search-no-results {
-  color: var(--color-text-muted);
-}
-
-/* ==========================================================================
-   10. НОВЕ КОМПОНЕНТЕ (tooltip, list controls)
-   ========================================================================== */
-
-/* Tooltip */
-[data-theme=dark] [data-tooltip]::after {
-  background: var(--color-surface-1);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-}
-
-/* Page-size selector */
-[data-theme=dark] .page-size-link {
-  background: var(--color-surface-2) !important;
-  color: var(--color-text-muted) !important;
-  border-color: var(--color-border) !important;
-}
-
-[data-theme=dark] .page-size-link:hover {
-  background: var(--color-surface-1) !important;
-  color: var(--color-primary) !important;
-}
-
-[data-theme=dark] .page-size-link--active {
-  background: var(--color-primary) !important;
   color: #fff !important;
 }
 
-/* List controls bar */
-[data-theme=dark] .list-controls {
-  border-color: var(--color-border);
+/* Search overlay needs a darker scrim */
+[data-theme="dark"] .search-overlay {
+  background: rgba(0, 0, 0, 0.7);
 }
 
-[data-theme=dark] .list-controls__select {
-  background-color: var(--color-surface-2);
+/* Tooltip on dark surface */
+[data-theme="dark"] [data-tooltip]::after {
+  background: var(--color-surface-1);
   color: var(--color-text);
-  border-color: var(--color-border);
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23bbb%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+  border: 1px solid var(--color-border-strong);
 }
 
-[data-theme=dark] .list-controls__select:hover {
-  background-color: var(--color-surface);
-}
-
-[data-theme=dark] .list-controls__select option {
-  background: var(--color-surface-2);
-  color: var(--color-text);
-}
-
-/* Primary/secondary text in list items */
-[data-theme=dark] .stavka__secondary {
-  color: var(--color-text-muted);
+/* Page-size selector pills */
+[data-theme="dark"] .page-size-link--active {
+  background: var(--color-primary) !important;
+  color: #fff !important;
 }


### PR DESCRIPTION
* tamna.css halved (171 lines, was 484) — tokens-only with a small overrides section
* dark primary bumped to #ef4444 so buttons/links keep AA contrast on dark surfaces
* surface ladder: #0d1117 page → #161b22 cards → #21262d controls → #30363d hover
* --color-link / --color-link-hover tokens drive a global <a> rule — no more browser-default blue links
* tabs--segmented restyled as pill toggle-group (matches new toggle pattern)
* narrow-desktop (769-1024px) guard for u-container padding + page-header gap