### PR TITLE
fix: tighten pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 default_stages: [pre-commit, manual]
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -60,7 +61,15 @@ repos:
     hooks:
       - id: django-tests
         name: django tests
-        entry: python crkva/manage.py test registar.tests --keepdb --verbosity=1
+        entry: python crkva/manage.py test registar.tests tenants.tests --keepdb --parallel auto --verbosity=1
         language: system
         pass_filenames: false
-        always_run: true
+        files: '\.py$'
+
+  # Validate commit message subject (feat: / fix: / refactor: / ...)
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, refactor, docs, test, chore, ci, perf, style, build, revert]


### PR DESCRIPTION
* django-tests: skip when only non-py files changed, run with --parallel auto
* django-tests: also cover tenants.tests (was registar-only)
* add conventional-pre-commit on commit-msg stage (feat:/fix:/refactor:/...)