### PR TITLE
fix: right padding on narrow-desktop / tablet widths

### DIFF
--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -213,7 +213,16 @@
    RESPONSIVE
    ========================================================================== */
 
+@media (max-width: 1024px) and (min-width: 641px) {
+    /* Sidebar still takes ~260px on tablet/narrow-desktop widths;
+       give the right edge a bit more breathing room and prevent
+       the page-header buttons from spilling off-screen. */
+    .u-container { padding: 0 var(--space-4); }
+    .u-page-header { gap: var(--space-2); }
+    .u-page-title { flex: 1 1 0; }
+}
+
 @media (max-width: 640px) {
     .u-container { padding: 0 var(--space-3); }
-    .u-page-header { gap: var(--space-3); }
+    .u-page-header { gap: var(--space-3); flex-wrap: wrap; }
 }


### PR DESCRIPTION
* sidebar still claims 260px between 641-1024px, content was hugging right edge
* bump u-container padding to space-4 and tighten page-header gap in that range
* mobile (<640px) page-header wraps onto a new row so buttons stay reachable