### PR TITLE
feat: taggable lookups — suggest + create new entry inline

### DIFF
--- a/crkva/registar/forms/domacinstvo_form.py
+++ b/crkva/registar/forms/domacinstvo_form.py
@@ -24,12 +24,12 @@ class DomacinstvoForm(forms.ModelForm):
             "domacin": ModelSelect2Widget(
                 model=Osoba,
                 search_fields=["ime__icontains", "prezime__icontains"],
-                attrs={"data-minimum-input-length": 2},
+                attrs={"data-minimum-input-length": 1},
             ),
             "adresa": ModelSelect2Widget(
                 model=Adresa,
                 search_fields=["ulica__icontains", "mesto__icontains"],
-                attrs={"data-minimum-input-length": 2},
+                attrs={"data-minimum-input-length": 1},
             ),
             "slava": ModelSelect2Widget(
                 model=Slava,

--- a/crkva/registar/forms/krstenje_form.py
+++ b/crkva/registar/forms/krstenje_form.py
@@ -11,7 +11,7 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     model = Osoba
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class SvestenikSelect2Widget(ModelSelect2Widget):
@@ -19,7 +19,7 @@ class SvestenikSelect2Widget(ModelSelect2Widget):
 
     model = Svestenik
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class HramSelect2Widget(ModelSelect2Widget):
@@ -27,7 +27,7 @@ class HramSelect2Widget(ModelSelect2Widget):
 
     model = Hram
     search_fields = ["naziv__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class KrstenjeForm(forms.ModelForm):

--- a/crkva/registar/forms/lookup.py
+++ b/crkva/registar/forms/lookup.py
@@ -1,0 +1,52 @@
+"""Select2-style fields with on-the-fly creation of simple lookup rows.
+
+Used for занимање / вероисповест / народност — single-field models where a
+clerk legitimately wants to add a new value without leaving the form.
+"""
+
+from __future__ import annotations
+
+from django import forms
+from django.core.exceptions import ValidationError
+from django_select2.forms import ModelSelect2Widget
+
+
+class TaggableLookupWidget(ModelSelect2Widget):
+    """ModelSelect2Widget with select2 `tags: true` enabled so the user
+    can pick an existing row OR create a new one from the typed text."""
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs.setdefault("data-tags", "true")
+        attrs.setdefault("data-token-separators", "[]")
+        attrs.setdefault("data-minimum-input-length", 1)
+        attrs.setdefault("data-placeholder", "Изабери или унеси ново…")
+        return attrs
+
+
+class TaggableLookupField(forms.ModelChoiceField):
+    """ModelChoiceField that creates a new row from a typed string
+    when the submitted value isn't a numeric pk. The new row is
+    populated via `get_or_create(**{create_field: value})`."""
+
+    create_field = "naziv"
+
+    def to_python(self, value):
+        if value in self.empty_values:
+            return None
+        # First try as a pk (handles both integer and UUID primary keys).
+        try:
+            return self.queryset.get(pk=value)
+        except (
+            ValueError,
+            TypeError,
+            ValidationError,
+            self.queryset.model.DoesNotExist,
+        ):
+            value = str(value).strip()
+            if not value:
+                return None
+            obj, _ = self.queryset.model.objects.get_or_create(
+                **{self.create_field: value}
+            )
+            return obj

--- a/crkva/registar/forms/parohijan_form.py
+++ b/crkva/registar/forms/parohijan_form.py
@@ -1,12 +1,40 @@
 """Django форма за унос парохијана."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
+from registar.forms.lookup import TaggableLookupField, TaggableLookupWidget
 from registar.models import Narodnost, Parohijan, Veroispovest, Zanimanje
 
 
 class ParohijanForm(forms.ModelForm):
     """Формулар за унос и измену парохијана."""
+
+    zanimanje = TaggableLookupField(
+        queryset=Zanimanje.objects.all(),
+        required=False,
+        label="Занимање",
+        widget=TaggableLookupWidget(
+            model=Zanimanje,
+            search_fields=["naziv__icontains"],
+        ),
+    )
+    veroispovest = TaggableLookupField(
+        queryset=Veroispovest.objects.all(),
+        required=False,
+        label="Вероисповест",
+        widget=TaggableLookupWidget(
+            model=Veroispovest,
+            search_fields=["naziv__icontains"],
+        ),
+    )
+    narodnost = TaggableLookupField(
+        queryset=Narodnost.objects.all(),
+        required=False,
+        label="Народност",
+        widget=TaggableLookupWidget(
+            model=Narodnost,
+            search_fields=["naziv__icontains"],
+        ),
+    )
 
     class Meta:
         model = Parohijan
@@ -23,21 +51,6 @@ class ParohijanForm(forms.ModelForm):
             "narodnost",
         ]
         widgets = {
-            "zanimanje": ModelSelect2Widget(
-                model=Zanimanje,
-                search_fields=["naziv__icontains"],
-                attrs={"data-minimum-input-length": 3},
-            ),
-            "veroispovest": ModelSelect2Widget(
-                model=Veroispovest,
-                search_fields=["naziv__icontains"],
-                attrs={"data-minimum-input-length": 0},
-            ),
-            "narodnost": ModelSelect2Widget(
-                model=Narodnost,
-                search_fields=["naziv__icontains"],
-                attrs={"data-minimum-input-length": 0},
-            ),
             "datum_rodjenja": forms.DateInput(attrs={"type": "date"}),
             "vreme_rodjenja": forms.TimeInput(attrs={"type": "time"}),
             "pol": forms.RadioSelect,

--- a/crkva/registar/forms/vencanje_form.py
+++ b/crkva/registar/forms/vencanje_form.py
@@ -11,7 +11,7 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     model = Osoba
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class SvestenikSelect2Widget(ModelSelect2Widget):
@@ -19,7 +19,7 @@ class SvestenikSelect2Widget(ModelSelect2Widget):
 
     model = Svestenik
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class HramSelect2Widget(ModelSelect2Widget):
@@ -27,7 +27,7 @@ class HramSelect2Widget(ModelSelect2Widget):
 
     model = Hram
     search_fields = ["naziv__icontains"]
-    attrs = {"data-minimum-input-length": 2}
+    attrs = {"data-minimum-input-length": 1}
 
 
 class VencanjeForm(forms.ModelForm):

--- a/crkva/registar/tests/test_taggable_lookup.py
+++ b/crkva/registar/tests/test_taggable_lookup.py
@@ -1,0 +1,77 @@
+"""Tests for the taggable lookup pattern."""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Parohijan, Zanimanje
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class TaggableLookupTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.user = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.user, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.existing_zanimanje = Zanimanje.objects.create(naziv="Учитељ")
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_select_existing_lookup_by_pk(self):
+        r = self.client.post(
+            reverse("unos_parohijana"),
+            {
+                "ime": "Тест",
+                "prezime": "Иван",
+                "pol": "М",
+                "zanimanje": str(self.existing_zanimanje.pk),
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        p = Parohijan.objects.get(ime="Тест", prezime="Иван")
+        self.assertEqual(p.zanimanje, self.existing_zanimanje)
+
+    def test_create_new_lookup_from_typed_string(self):
+        before = Zanimanje.objects.count()
+        r = self.client.post(
+            reverse("unos_parohijana"),
+            {
+                "ime": "Нови",
+                "prezime": "Иван",
+                "pol": "М",
+                "zanimanje": "Програмер",
+                "veroispovest": "Православна",
+                "narodnost": "Српска",
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(Zanimanje.objects.count(), before + 1)
+        new = Zanimanje.objects.get(naziv="Програмер")
+        p = Parohijan.objects.get(ime="Нови", prezime="Иван")
+        self.assertEqual(p.zanimanje, new)
+        self.assertEqual(p.veroispovest.naziv, "Православна")
+        self.assertEqual(p.narodnost.naziv, "Српска")
+
+    def test_typed_string_matches_existing_creates_no_duplicate(self):
+        before = Zanimanje.objects.count()
+        r = self.client.post(
+            reverse("unos_parohijana"),
+            {
+                "ime": "Дупликат",
+                "prezime": "Тест",
+                "pol": "М",
+                "zanimanje": "Учитељ",
+            },
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(Zanimanje.objects.count(), before)
+        p = Parohijan.objects.get(ime="Дупликат")
+        self.assertEqual(p.zanimanje, self.existing_zanimanje)


### PR DESCRIPTION
* TaggableLookupField + TaggableLookupWidget: select2 with tags=true
* ParohijanForm: занимање / вероисповест / народност — type to search, pick existing or create new from typed text
* drop data-minimum-input-length from 3 → 1 across all forms so suggestions appear after one keystroke
* 3 tests covering pk-select, new-create, and existing-naziv reuse