### PR TITLE
fix: pre-populate edit form + tab height jitter

### DIFF
--- a/crkva/registar/forms/krstenje_form.py
+++ b/crkva/registar/forms/krstenje_form.py
@@ -72,9 +72,11 @@ class KrstenjeForm(forms.ModelForm):
             "primedba",
         ]
         widgets = {
-            "datum": forms.DateInput(attrs={"type": "date"}),
-            "vreme": forms.TimeInput(attrs={"type": "time"}),
-            "datum_registracije": forms.DateInput(attrs={"type": "date"}),
+            "datum": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+            "vreme": forms.TimeInput(attrs={"type": "time"}, format="%H:%M"),
+            "datum_registracije": forms.DateInput(
+                attrs={"type": "date"}, format="%Y-%m-%d"
+            ),
             "primedba": forms.Textarea(attrs={"rows": 4}),
             "dete": OsobaSelect2Widget,
             "otac": OsobaSelect2Widget,

--- a/crkva/registar/forms/lookup.py
+++ b/crkva/registar/forms/lookup.py
@@ -19,7 +19,8 @@ class TaggableLookupWidget(ModelSelect2Widget):
         attrs = super().build_attrs(base_attrs, extra_attrs)
         attrs.setdefault("data-tags", "true")
         attrs.setdefault("data-token-separators", "[]")
-        attrs.setdefault("data-minimum-input-length", 1)
+        # django-select2 sets this to 2 by default; force 1 so suggestions appear after one keystroke.
+        attrs["data-minimum-input-length"] = 1
         attrs.setdefault("data-placeholder", "Изабери или унеси ново…")
         return attrs
 

--- a/crkva/registar/forms/parohijan_form.py
+++ b/crkva/registar/forms/parohijan_form.py
@@ -51,7 +51,9 @@ class ParohijanForm(forms.ModelForm):
             "narodnost",
         ]
         widgets = {
-            "datum_rodjenja": forms.DateInput(attrs={"type": "date"}),
-            "vreme_rodjenja": forms.TimeInput(attrs={"type": "time"}),
+            "datum_rodjenja": forms.DateInput(
+                attrs={"type": "date"}, format="%Y-%m-%d"
+            ),
+            "vreme_rodjenja": forms.TimeInput(attrs={"type": "time"}, format="%H:%M"),
             "pol": forms.RadioSelect,
         }

--- a/crkva/registar/forms/svestenik_form.py
+++ b/crkva/registar/forms/svestenik_form.py
@@ -24,5 +24,7 @@ class SvestenikForm(forms.ModelForm):
                 search_fields=["naziv__icontains"],
                 attrs={"data-minimum-input-length": 0},
             ),
-            "datum_rodjenja": forms.DateInput(attrs={"type": "date"}),
+            "datum_rodjenja": forms.DateInput(
+                attrs={"type": "date"}, format="%Y-%m-%d"
+            ),
         }

--- a/crkva/registar/forms/vencanje_form.py
+++ b/crkva/registar/forms/vencanje_form.py
@@ -69,8 +69,8 @@ class VencanjeForm(forms.ModelForm):
             "primedba",
         ]
         widgets = {
-            "datum": forms.DateInput(attrs={"type": "date"}),
-            "datum_ispita": forms.DateInput(attrs={"type": "date"}),
+            "datum": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+            "datum_ispita": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
             "primedba": forms.Textarea(attrs={"rows": 3}),
             "zenik": OsobaSelect2Widget,
             "nevesta": OsobaSelect2Widget,

--- a/crkva/registar/static/registar/components/tabovi.css
+++ b/crkva/registar/static/registar/components/tabovi.css
@@ -132,19 +132,25 @@
    ========================================================================== */
 
 .tabs--segmented .tabs__nav {
+    display: inline-flex;
+    align-items: stretch;
+    vertical-align: top;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
     overflow: hidden;
     background: var(--color-surface-1);
+    line-height: 1;
 }
 
 .tabs--segmented .tabs__tab {
+    box-sizing: border-box;
     background: transparent;
     color: var(--color-text-muted);
     font-weight: 500;
     border-radius: 0;
-    padding: 8px 18px;
-    min-height: 38px;
+    padding: 0 18px;
+    min-height: 36px;
+    line-height: 1;
     transition: background 0.15s ease, color 0.15s ease;
 }
 


### PR DESCRIPTION
* DateInput / TimeInput render ISO format so HTML5 date/time pickers display the existing value
* TaggableLookupWidget force-overrides data-minimum-input-length to 1 (django-select2 was defaulting to 2)
* tabs--segmented: box-sizing, line-height 1, vertical-align top — tabs__nav and tabs__tab now share height (no more 8px phantom descender)