### PR TITLE
fix: load select2 JS in unified edit templates + hide maiden name for…

### DIFF
--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -168,5 +168,6 @@
       })();
     </script>
     <script src="{% static 'registar/components/modal.js' %}"></script>
+    {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block extra_css %}{% if is_edit %}{{ form.media.css }}{% endif %}{% endblock %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
 {% load phone_filters %}
 
 {% block content %}

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block extra_css %}{% if is_edit %}{{ form.media.css }}{% endif %}{% endblock %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
 {% load phone_filters %}
 
 {% comment %}
@@ -23,7 +26,7 @@
     <h1 class="u-page-title">
       {% if is_edit and not parohijan %}Додавање парохијана
       {% elif is_edit %}Измена: {{ parohijan.ime }} {{ parohijan.prezime }}
-      {% else %}{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime %} <span style="color:var(--color-text-muted);font-weight:400;">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}{% endif %}
+      {% else %}{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime and parohijan.pol == "Ж" %} <span style="color:var(--color-text-muted);font-weight:400;">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}{% endif %}
     </h1>
     {% if is_edit %}
       <button class="button button--primary button--icon" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
@@ -66,7 +69,7 @@
     {% if is_edit %}
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.ime }}</div></li>
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Презиме"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{{ form.prezime }}</div></li>
-    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Девојачко презиме"><i class="fa-solid fa-id-card"></i></div><div class="info-row__value">{{ form.devojacko_prezime }}</div></li>
+    <li class="info-row info-row--editable" id="row-devojacko-prezime"{% if parohijan and parohijan.pol == "М" %} style="display:none;"{% endif %}><div class="info-row__icon" data-tooltip="Девојачко презиме"><i class="fa-solid fa-id-card"></i></div><div class="info-row__value">{{ form.devojacko_prezime }}</div></li>
     {% endif %}
 
     {% if is_edit %}
@@ -147,6 +150,22 @@
     {% endif %}
   {% endif %}
 
-{% if is_edit %}</form>{% else %}</div>{% endif %}
+{% if is_edit %}
+<script>
+  (function () {
+    var row = document.getElementById("row-devojacko-prezime");
+    if (!row) return;
+    function sync() {
+      var checked = document.querySelector('input[name="pol"]:checked');
+      var val = checked ? checked.value : "";
+      row.style.display = (val === "М") ? "none" : "";
+    }
+    document.querySelectorAll('input[name="pol"]').forEach(function (r) {
+      r.addEventListener("change", sync);
+    });
+    sync();
+  })();
+</script>
+</form>{% else %}</div>{% endif %}
 {% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
+{% block extra_css %}{% if is_edit %}{{ form.media.css }}{% endif %}{% endblock %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
+
 {% block content %}
 {% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
 


### PR DESCRIPTION
… men

* unified parohijan/svestenik/domacinstvo templates were rendering bare <select> dropdowns because form.media wasn't included — added extra_css/extra_js blocks
* base.html now has {% block extra_js %} before </body>
* parohijan title suffix "(рођ. ...)" and the edit-mode "Девојачко презиме" row are now hidden for pol=М
* small inline JS toggles the row live when the pol radio changes