### PR TITLE
feat: krštenje + венчање detail pages aligned to info-row pattern

### DIFF
--- a/crkva/registar/templates/registar/info_krstenje.html
+++ b/crkva/registar/templates/registar/info_krstenje.html
@@ -6,225 +6,186 @@
 {% load julian_dates %}
 
 {% block content %}
+<div class="info-page">
 
-<div class="u-page-header">
+  <div class="u-page-header">
     <a href="{% url 'krstenja' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
+      <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Крштење — {{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}</h1>
     {% if can_edit_krstenje %}<a href="{% url 'izmena_krstenja' uid=krstenje.uid %}" class="button button--primary button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
     <a href="{% url 'krstenje_pdf' krstenje.uid %}" target="_blank" class="button button--primary button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
     <button type="button" id="history-toggle" class="button button--primary button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
-</div>
+  </div>
 
-<div class="tabs tabs--segmented">
+  <div class="tabs tabs--segmented">
     <div class="tabs__nav">
-        <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
-        <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
-        <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
-        <label for="krst-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Крштеница</label>
+      <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
+      <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+      <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
+      <label for="krst-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Крштеница</label>
     </div>
 
-    <!-- ============ STANDARD DATA VIEW ============ -->
+    {# ============ STANDARD DATA VIEW ============ #}
     <section class="tabs__panel">
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Дете</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Име</span>
-                        <span>{% if krstenje.dete %}<a href="{% url 'parohijan_detail' uid=krstenje.dete.uid %}" class="u-link-primary">{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}</a>{% else %}{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}{% endif %}</span>
-                    </li>
-                    {% if krstenje.dete.get_pol_display %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Пол</span>
-                        <span>{{ krstenje.dete.get_pol_display }}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.datum_rodjenja %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Датум рођења</span>
-                        <span>{{ krstenje.datum_rodjenja }}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.mesto_rodjenja %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Место рођења</span>
-                        <span>{{ krstenje.mesto_rodjenja }}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.dete_po_redu_po_majci %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Дете по реду (по мајци)</span>
-                        <span>{{ krstenje.dete_po_redu_po_majci }}</span>
-                    </li>
-                    {% endif %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Брачно</span>
-                        <span>{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</span>
-                    </li>
-                    {% if krstenje.dete_blizanac %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Близанац</span>
-                        <span>Да{% if krstenje.drugo_dete_blizanac_ime %} ({{ krstenje.drugo_dete_blizanac_ime }}){% endif %}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.dete_sa_telesnom_manom %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Телесна мана</span>
-                        <span>Да</span>
-                    </li>
-                    {% endif %}
-                </ul>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-baby"></i> Дете</h2>
+        <ul class="info-rows">
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
+            <div class="info-row__value">
+              {% if krstenje.dete %}<a href="{% url 'parohijan_detail' uid=krstenje.dete.uid %}">{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}</a>{% else %}{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}{% endif %}
             </div>
-        </div>
+          </li>
+          {% if krstenje.dete.get_pol_display %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div><div class="info-row__value">{{ krstenje.dete.get_pol_display }}</div></li>
+          {% endif %}
+          {% if krstenje.datum_rodjenja %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ krstenje.datum_rodjenja }}</div></li>
+          {% endif %}
+          {% if krstenje.mesto_rodjenja %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.mesto_rodjenja }}</div></li>
+          {% endif %}
+          {% if krstenje.dete_po_redu_po_majci %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ krstenje.dete_po_redu_po_majci }}</div></li>
+          {% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div></li>
+          {% if krstenje.dete_blizanac %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value">Да{% if krstenje.drugo_dete_blizanac_ime %} ({{ krstenje.drugo_dete_blizanac_ime }}){% endif %}</div></li>
+          {% endif %}
+          {% if krstenje.dete_sa_telesnom_manom %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Телесна мана"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">Да</div></li>
+          {% endif %}
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Родитељи</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Отац</span>
-                        <span>{% if krstenje.otac %}<a href="{% url 'parohijan_detail' uid=krstenje.otac.uid %}" class="u-link-primary">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}</a>{% else %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}{% endif %}{% if krstenje.zanimanje_oca %}, {{ krstenje.zanimanje_oca|lower }}{% endif %}</span>
-                    </li>
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Мајка</span>
-                        <span>{% if krstenje.majka %}<a href="{% url 'parohijan_detail' uid=krstenje.majka.uid %}" class="u-link-primary">{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}</a>{% else %}{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}{% endif %}{% if krstenje.zanimanje_majke %}, {{ krstenje.zanimanje_majke|lower }}{% endif %}</span>
-                    </li>
-                    {% if krstenje.veroispovest_oca %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Вероисповест</span>
-                        <span>{{ krstenje.veroispovest_oca }}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.adresa_deteta %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Адреса</span>
-                        <span>{{ krstenje.adresa_deteta }}</span>
-                    </li>
-                    {% endif %}
-                </ul>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
+        <ul class="info-rows">
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div>
+            <div class="info-row__value">
+              {% if krstenje.otac %}<a href="{% url 'parohijan_detail' uid=krstenje.otac.uid %}">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}</a>{% else %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}{% endif %}{% if krstenje.zanimanje_oca %}<span class="info-row__sub">{{ krstenje.zanimanje_oca|lower }}</span>{% endif %}
             </div>
-        </div>
+          </li>
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div>
+            <div class="info-row__value">
+              {% if krstenje.majka %}<a href="{% url 'parohijan_detail' uid=krstenje.majka.uid %}">{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}</a>{% else %}{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}{% endif %}{% if krstenje.zanimanje_majke %}<span class="info-row__sub">{{ krstenje.zanimanje_majke|lower }}</span>{% endif %}
+            </div>
+          </li>
+          {% if krstenje.veroispovest_oca %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ krstenje.veroispovest_oca }}</div></li>
+          {% endif %}
+          {% if krstenje.adresa_deteta %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.adresa_deteta }}</div></li>
+          {% endif %}
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Кум</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Име</span>
-                        <span>{% if krstenje.kum %}<a href="{% url 'parohijan_detail' uid=krstenje.kum.uid %}" class="u-link-primary">{{ krstenje.ime_kuma }}</a>{% else %}{{ krstenje.ime_kuma }}{% endif %}{% if krstenje.zanimanje_kuma %}, {{ krstenje.zanimanje_kuma|lower }}{% endif %}</span>
-                    </li>
-                    {% if krstenje.adresa_kuma_mesto %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Место</span>
-                        <span>{{ krstenje.adresa_kuma_mesto }}</span>
-                    </li>
-                    {% endif %}
-                </ul>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-user-tag"></i> Кум</h2>
+        <ul class="info-rows">
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div>
+            <div class="info-row__value">
+              {% if krstenje.kum %}<a href="{% url 'parohijan_detail' uid=krstenje.kum.uid %}">{{ krstenje.ime_kuma }}</a>{% else %}{{ krstenje.ime_kuma }}{% endif %}{% if krstenje.zanimanje_kuma %}<span class="info-row__sub">{{ krstenje.zanimanje_kuma|lower }}</span>{% endif %}
             </div>
-        </div>
+          </li>
+          {% if krstenje.adresa_kuma_mesto %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Место"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.adresa_kuma_mesto }}</div></li>
+          {% endif %}
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Крштење</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    {% if krstenje.datum %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Датум</span>
-                        <span>{{ krstenje.datum }}{% if krstenje.vreme %}, {{ krstenje.vreme }} час{% endif %}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.hram %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Храм</span>
-                        <span>{{ krstenje.hram }}{% if krstenje.hram.mesto %}, {{ krstenje.hram.mesto }}{% endif %}</span>
-                    </li>
-                    {% endif %}
-                    {% if krstenje.svestenik %}
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Свештеник</span>
-                        <span><a href="{% url 'svestenik_detail' uid=krstenje.svestenik.uid %}" class="u-link-primary">{{ krstenje.svestenik }}</a></span>
-                    </li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-droplet"></i> Крштење</h2>
+        <ul class="info-rows">
+          {% if krstenje.datum %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ krstenje.datum }}{% if krstenje.vreme %} <span class="info-row__sub">у {{ krstenje.vreme }}</span>{% endif %}</div></li>
+          {% endif %}
+          {% if krstenje.hram %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ krstenje.hram }}{% if krstenje.hram.mesto %} <span class="info-row__sub">{{ krstenje.hram.mesto }}</span>{% endif %}</div></li>
+          {% endif %}
+          {% if krstenje.svestenik %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value"><a href="{% url 'svestenik_detail' uid=krstenje.svestenik.uid %}">{{ krstenje.svestenik }}</a></div></li>
+          {% endif %}
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Запис</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item"><span class="u-kv-label">Књига</span><span>{{ krstenje.knjiga }}</span></li>
-                    <li class="u-kv-item"><span class="u-kv-label">Страна</span><span>{{ krstenje.strana }}</span></li>
-                    <li class="u-kv-item"><span class="u-kv-label">Текући број</span><span>{{ krstenje.broj }}</span></li>
-                    {% if krstenje.godina_registracije %}
-                    <li class="u-kv-item"><span class="u-kv-label">Година регистрације</span><span>{{ krstenje.godina_registracije }}</span></li>
-                    {% endif %}
-                    {% if krstenje.primedba %}
-                    <li class="u-kv-item"><span class="u-kv-label">Примедба</span><span>{{ krstenje.primedba }}</span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-file-lines"></i> Запис</h2>
+        <ul class="info-rows">
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ krstenje.knjiga }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ krstenje.strana }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ krstenje.broj }}</div></li>
+          {% if krstenje.godina_registracije %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ krstenje.godina_registracije }}</div></li>
+          {% endif %}
+          {% if krstenje.primedba %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ krstenje.primedba }}</div></li>
+          {% endif %}
+        </ul>
+      </div>
 
     </section>
 
-    <!-- ============ CERTIFICATE PREVIEW ============ -->
+    {# ============ CERTIFICATE PREVIEW ============ #}
     <section class="tabs__panel">
 
-<div class="krstenica">
-    <div class="krstenica-frame">
-        <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>
-        <div class="krst-field-strana">{{ krstenje.strana }}</div>
-        <div class="krst-field-broj">{{ krstenje.broj }}</div>
-        <div class="krst-field-eparhija">БЕОГРАДСКО - КАРЛОВАЧКЕ</div>
-        <div class="krst-field-hram">{{ krstenje.hram }}</div>
-        <div class="krst-field-mesto">{{ krstenje.hram.mesto }}у</div>
-        <div class="krst-field-godina">{{ krstenje.datum|date:"y" }}</div>
-        <div class="krst-table-field krst-field-rodjenje_datum">
+      <div class="krstenica">
+        <div class="krstenica-frame">
+          <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>
+          <div class="krst-field-strana">{{ krstenje.strana }}</div>
+          <div class="krst-field-broj">{{ krstenje.broj }}</div>
+          <div class="krst-field-eparhija">БЕОГРАДСКО - КАРЛОВАЧКЕ</div>
+          <div class="krst-field-hram">{{ krstenje.hram }}</div>
+          <div class="krst-field-mesto">{{ krstenje.hram.mesto }}у</div>
+          <div class="krst-field-godina">{{ krstenje.datum|date:"y" }}</div>
+          <div class="krst-table-field krst-field-rodjenje_datum">
             {{ krstenje.datum_rodjenja|julian_date }}, {{ krstenje.vreme_rodjenja }} часова
-        </div>
-        <div class="krst-table-field krst-field-rodjenje_mesto">
+          </div>
+          <div class="krst-table-field krst-field-rodjenje_mesto">
             {{ krstenje.mesto_rodjenja }}
-        </div>
-        <div class="krst-table-field krst-field-krstenje_datum">
+          </div>
+          <div class="krst-table-field krst-field-krstenje_datum">
             {{ krstenje.datum|julian_date|default_if_none:"" }}{% if krstenje.vreme is not none %}, {{ krstenje.vreme }} часова{% endif %}
-        </div>
-        <div class="krst-table-field krst-field-krstenje_mesto">
+          </div>
+          <div class="krst-table-field krst-field-krstenje_mesto">
             {{ krstenje.hram.mesto }}, {{ krstenje.hram }}
-        </div>
-        <div class="krst-table-field krst-field-ime_pol">
+          </div>
+          <div class="krst-table-field krst-field-ime_pol">
             {{ krstenje.ime_deteta }}{{ krstenje.gradjansko_ime_deteta }}, {{ krstenje.get_pol_deteta_display }}
-        </div>
-        <div class="krst-table-field krst-field-roditelji">
+          </div>
+          <div class="krst-table-field krst-field-roditelji">
             {{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}, {{ krstenje.zanimanje_oca|lower }} и<br>
             {{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}, {{ krstenje.zanimanje_majke|lower }}<br>
             {{ krstenje.hram.mesto }}, {{ krstenje.adresa_deteta }}<br>
             {{ krstenje.veroispovest_oca }}
-        </div>
-        <div class="krst-table-field krst-field-dete_po_redu">{{ krstenje.dete_po_redu_po_majci }}</div>
-        <div class="krst-table-field krst-field-bracno">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div>
-        <div class="krst-table-field krst-field-blizanac">{{ krstenje.dete_blizanac|yesno:"јесте,није" }}</div>
-        <div class="krst-table-field krst-field-telesna_mana">{{ krstenje.dete_sa_telesnom_manom|yesno:"јесте,није,непознато" }}</div>
-        <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|default_if_none:"" }}</div>
-        <div class="krst-table-field krst-field-kum">
+          </div>
+          <div class="krst-table-field krst-field-dete_po_redu">{{ krstenje.dete_po_redu_po_majci }}</div>
+          <div class="krst-table-field krst-field-bracno">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div>
+          <div class="krst-table-field krst-field-blizanac">{{ krstenje.dete_blizanac|yesno:"јесте,није" }}</div>
+          <div class="krst-table-field krst-field-telesna_mana">{{ krstenje.dete_sa_telesnom_manom|yesno:"јесте,није,непознато" }}</div>
+          <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|default_if_none:"" }}</div>
+          <div class="krst-table-field krst-field-kum">
             {{ krstenje.ime_kuma }}, {{ krstenje.zanimanje_kuma }}<br>
             {{ krstenje.adresa_kuma_mesto }}
+          </div>
+          <div class="krst-table-field krst-field-domovnik"></div>
+          <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|default_if_none:"" }}</div>
+          <div class="krst-field-footer_br">{% now "d.m" %}</div>
+          <div class="krst-field-footer_godina">{% now "y" %}</div>
+          <div class="krst-field-footer_u">Београду</div>
+          <div class="krst-field-footer_parohija">{% if krstenje.svestenik %}{{ krstenje.svestenik.parohija }}{% endif %}</div>
+          <div class="krst-field-footer_paroh">{% if krstenje.svestenik %}{{ krstenje.svestenik }}{% endif %}</div>
         </div>
-        <div class="krst-table-field krst-field-domovnik"></div>
-        <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|default_if_none:"" }}</div>
-        <div class="krst-field-footer_br">{% now "d.m" %}</div>
-        <div class="krst-field-footer_godina">{% now "y" %}</div>
-        <div class="krst-field-footer_u">Београду</div>
-        <div class="krst-field-footer_parohija">{% if krstenje.svestenik %}{{ krstenje.svestenik.parohija }}{% endif %}</div>
-        <div class="krst-field-footer_paroh">{% if krstenje.svestenik %}{{ krstenje.svestenik }}{% endif %}</div>
-    </div>
-</div>
+      </div>
 
     </section>
-</div>
+  </div>
 
+</div>
 {% include "registar/_history_panel.html" %}
 {% endblock %}

--- a/crkva/registar/templates/registar/info_vencanje.html
+++ b/crkva/registar/templates/registar/info_vencanje.html
@@ -6,230 +6,166 @@
 {% load julian_dates %}
 
 {% block content %}
+<div class="info-page">
 
-<div class="u-page-header">
+  <div class="u-page-header">
     <a href="{% url 'vencanja' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
+      <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Венчање — {{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</h1>
     {% if can_edit_vencanje %}<a href="{% url 'izmena_vencanja' uid=vencanje.uid %}" class="button button--primary button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
     <a href="{% url 'vencanje_pdf' vencanje.uid %}" target="_blank" class="button button--primary button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
     <button type="button" id="history-toggle" class="button button--primary button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
-</div>
+  </div>
 
-<div class="tabs tabs--segmented">
+  <div class="tabs tabs--segmented">
     <div class="tabs__nav">
-        <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
-        <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
-        <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
-        <label for="venc-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Венчаница</label>
+      <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
+      <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+      <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
+      <label for="venc-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Венчаница</label>
     </div>
 
-    <!-- ============ STANDARD DATA VIEW ============ -->
+    {# ============ STANDARD DATA VIEW ============ #}
     <section class="tabs__panel">
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Женик</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Име</span>
-                        <span>{% if vencanje.zenik %}<a href="{% url 'parohijan_detail' uid=vencanje.zenik.uid %}" class="u-link-primary">{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}</a>{% else %}{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}{% endif %}</span>
-                    </li>
-                    {% if vencanje.zanimanje_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Занимање</span><span>{{ vencanje.zanimanje_zenika|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.adresa_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Адреса</span><span>{{ vencanje.adresa_zenika }}</span></li>
-                    {% endif %}
-                    {% if vencanje.datum_rodjenja_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Датум рођења</span><span>{{ vencanje.datum_rodjenja_zenika }}</span></li>
-                    {% endif %}
-                    {% if vencanje.mesto_rodjenja_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Место рођења</span><span>{{ vencanje.mesto_rodjenja_zenika }}</span></li>
-                    {% endif %}
-                    {% if vencanje.veroispovest_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Вероисповест</span><span>{{ vencanje.veroispovest_zenika|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.narodnost_zenika %}
-                    <li class="u-kv-item"><span class="u-kv-label">Народност</span><span>{{ vencanje.narodnost_zenika|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.zenik_rb_brak %}
-                    <li class="u-kv-item"><span class="u-kv-label">Редни брак</span><span>{{ vencanje.zenik_rb_brak }}</span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-person"></i> Женик</h2>
+        <ul class="info-rows">
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
+            <div class="info-row__value">{% if vencanje.zenik %}<a href="{% url 'parohijan_detail' uid=vencanje.zenik.uid %}">{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}</a>{% else %}{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}{% endif %}</div>
+          </li>
+          {% if vencanje.zanimanje_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ vencanje.zanimanje_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.adresa_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.adresa_zenika }}</div></li>{% endif %}
+          {% if vencanje.datum_rodjenja_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ vencanje.datum_rodjenja_zenika }}{% if vencanje.mesto_rodjenja_zenika %} <span class="info-row__sub">{{ vencanje.mesto_rodjenja_zenika }}</span>{% endif %}</div></li>{% elif vencanje.mesto_rodjenja_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.mesto_rodjenja_zenika }}</div></li>{% endif %}
+          {% if vencanje.veroispovest_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ vencanje.veroispovest_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.narodnost_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ vencanje.narodnost_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.zenik_rb_brak %}<li class="info-row"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ vencanje.zenik_rb_brak }}</div></li>{% endif %}
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Невеста</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item">
-                        <span class="u-kv-label">Име</span>
-                        <span>{% if vencanje.nevesta %}<a href="{% url 'parohijan_detail' uid=vencanje.nevesta.uid %}" class="u-link-primary">{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}</a>{% else %}{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}{% endif %}</span>
-                    </li>
-                    {% if vencanje.zanimanje_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Занимање</span><span>{{ vencanje.zanimanje_neveste|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.adresa_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Адреса</span><span>{{ vencanje.adresa_neveste }}</span></li>
-                    {% endif %}
-                    {% if vencanje.datum_rodjenja_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Датум рођења</span><span>{{ vencanje.datum_rodjenja_neveste }}</span></li>
-                    {% endif %}
-                    {% if vencanje.mesto_rodjenja_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Место рођења</span><span>{{ vencanje.mesto_rodjenja_neveste }}</span></li>
-                    {% endif %}
-                    {% if vencanje.veroispovest_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Вероисповест</span><span>{{ vencanje.veroispovest_neveste|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.narodnost_neveste %}
-                    <li class="u-kv-item"><span class="u-kv-label">Народност</span><span>{{ vencanje.narodnost_neveste|lower }}</span></li>
-                    {% endif %}
-                    {% if vencanje.nevesta_rb_brak %}
-                    <li class="u-kv-item"><span class="u-kv-label">Редни брак</span><span>{{ vencanje.nevesta_rb_brak }}</span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-person-dress"></i> Невеста</h2>
+        <ul class="info-rows">
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
+            <div class="info-row__value">{% if vencanje.nevesta %}<a href="{% url 'parohijan_detail' uid=vencanje.nevesta.uid %}">{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}</a>{% else %}{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}{% endif %}</div>
+          </li>
+          {% if vencanje.zanimanje_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ vencanje.zanimanje_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.adresa_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.adresa_neveste }}</div></li>{% endif %}
+          {% if vencanje.datum_rodjenja_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ vencanje.datum_rodjenja_neveste }}{% if vencanje.mesto_rodjenja_neveste %} <span class="info-row__sub">{{ vencanje.mesto_rodjenja_neveste }}</span>{% endif %}</div></li>{% elif vencanje.mesto_rodjenja_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.mesto_rodjenja_neveste }}</div></li>{% endif %}
+          {% if vencanje.veroispovest_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ vencanje.veroispovest_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.narodnost_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ vencanje.narodnost_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.nevesta_rb_brak %}<li class="info-row"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ vencanje.nevesta_rb_brak }}</div></li>{% endif %}
+        </ul>
+      </div>
 
-        {% if vencanje.svekar or vencanje.svekrva or vencanje.tast or vencanje.tasta %}
-        <div class="detail-section">
-            <h2 class="detail-section__title">Родитељи</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    {% if vencanje.svekar %}
-                    <li class="u-kv-item"><span class="u-kv-label">Свекар</span><span><a href="{% url 'parohijan_detail' uid=vencanje.svekar.uid %}" class="u-link-primary">{{ vencanje.svekar }}</a></span></li>
-                    {% endif %}
-                    {% if vencanje.svekrva %}
-                    <li class="u-kv-item"><span class="u-kv-label">Свекрва</span><span><a href="{% url 'parohijan_detail' uid=vencanje.svekrva.uid %}" class="u-link-primary">{{ vencanje.svekrva }}</a></span></li>
-                    {% endif %}
-                    {% if vencanje.tast %}
-                    <li class="u-kv-item"><span class="u-kv-label">Таст</span><span><a href="{% url 'parohijan_detail' uid=vencanje.tast.uid %}" class="u-link-primary">{{ vencanje.tast }}</a></span></li>
-                    {% endif %}
-                    {% if vencanje.tasta %}
-                    <li class="u-kv-item"><span class="u-kv-label">Ташта</span><span><a href="{% url 'parohijan_detail' uid=vencanje.tasta.uid %}" class="u-link-primary">{{ vencanje.tasta }}</a></span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
-        {% endif %}
+      {% if vencanje.svekar or vencanje.svekrva or vencanje.tast or vencanje.tasta %}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
+        <ul class="info-rows">
+          {% if vencanje.svekar %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekar.uid %}">{{ vencanje.svekar }}</a></div></li>{% endif %}
+          {% if vencanje.svekrva %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekrva.uid %}">{{ vencanje.svekrva }}</a></div></li>{% endif %}
+          {% if vencanje.tast %}<li class="info-row"><div class="info-row__icon" data-tooltip="Таст"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.tast.uid %}">{{ vencanje.tast }}</a></div></li>{% endif %}
+          {% if vencanje.tasta %}<li class="info-row"><div class="info-row__icon" data-tooltip="Ташта"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.tasta.uid %}">{{ vencanje.tasta }}</a></div></li>{% endif %}
+        </ul>
+      </div>
+      {% endif %}
 
-        {% if vencanje.kum or vencanje.stari_svat %}
-        <div class="detail-section">
-            <h2 class="detail-section__title">Сведоци</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    {% if vencanje.kum %}
-                    <li class="u-kv-item"><span class="u-kv-label">Кум</span><span><a href="{% url 'parohijan_detail' uid=vencanje.kum.uid %}" class="u-link-primary">{{ vencanje.kum }}</a></span></li>
-                    {% endif %}
-                    {% if vencanje.stari_svat %}
-                    <li class="u-kv-item"><span class="u-kv-label">Стари сват</span><span><a href="{% url 'parohijan_detail' uid=vencanje.stari_svat.uid %}" class="u-link-primary">{{ vencanje.stari_svat }}</a></span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
-        {% endif %}
+      {% if vencanje.kum or vencanje.stari_svat %}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-user-check"></i> Сведоци</h2>
+        <ul class="info-rows">
+          {% if vencanje.kum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.kum.uid %}">{{ vencanje.kum }}</a></div></li>{% endif %}
+          {% if vencanje.stari_svat %}<li class="info-row"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.stari_svat.uid %}">{{ vencanje.stari_svat }}</a></div></li>{% endif %}
+        </ul>
+      </div>
+      {% endif %}
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Венчање</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    {% if vencanje.datum %}
-                    <li class="u-kv-item"><span class="u-kv-label">Датум</span><span>{{ vencanje.datum }}</span></li>
-                    {% endif %}
-                    {% if vencanje.datum_ispita %}
-                    <li class="u-kv-item"><span class="u-kv-label">Датум испита</span><span>{{ vencanje.datum_ispita }}</span></li>
-                    {% endif %}
-                    {% if vencanje.hram %}
-                    <li class="u-kv-item"><span class="u-kv-label">Храм</span><span>{{ vencanje.hram }}{% if vencanje.hram.mesto %}, {{ vencanje.hram.mesto }}{% endif %}</span></li>
-                    {% endif %}
-                    {% if vencanje.svestenik %}
-                    <li class="u-kv-item"><span class="u-kv-label">Свештеник</span><span><a href="{% url 'svestenik_detail' uid=vencanje.svestenik.uid %}" class="u-link-primary">{{ vencanje.svestenik }}</a></span></li>
-                    {% endif %}
-                    <li class="u-kv-item"><span class="u-kv-label">Разрешење</span><span>{{ vencanje.razresenje|yesno:"Да,Не" }}</span></li>
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-ring"></i> Венчање</h2>
+        <ul class="info-rows">
+          {% if vencanje.datum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ vencanje.datum }}</div></li>{% endif %}
+          {% if vencanje.datum_ispita %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум испита"><i class="fa-solid fa-clipboard-check"></i></div><div class="info-row__value">{{ vencanje.datum_ispita }}</div></li>{% endif %}
+          {% if vencanje.hram %}<li class="info-row"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ vencanje.hram }}{% if vencanje.hram.mesto %} <span class="info-row__sub">{{ vencanje.hram.mesto }}</span>{% endif %}</div></li>{% endif %}
+          {% if vencanje.svestenik %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value"><a href="{% url 'svestenik_detail' uid=vencanje.svestenik.uid %}">{{ vencanje.svestenik }}</a></div></li>{% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Разрешење"><i class="fa-solid fa-file-signature"></i></div><div class="info-row__value">{{ vencanje.razresenje|yesno:"Да,Не" }}</div></li>
+        </ul>
+      </div>
 
-        <div class="detail-section">
-            <h2 class="detail-section__title">Запис</h2>
-            <div class="card">
-                <ul class="u-kv-list">
-                    <li class="u-kv-item"><span class="u-kv-label">Књига</span><span>{{ vencanje.knjiga }}</span></li>
-                    <li class="u-kv-item"><span class="u-kv-label">Страна</span><span>{{ vencanje.strana }}</span></li>
-                    <li class="u-kv-item"><span class="u-kv-label">Текући број</span><span>{{ vencanje.broj }}</span></li>
-                    {% if vencanje.godina_registracije %}
-                    <li class="u-kv-item"><span class="u-kv-label">Година регистрације</span><span>{{ vencanje.godina_registracije }}</span></li>
-                    {% endif %}
-                    {% if vencanje.primedba %}
-                    <li class="u-kv-item"><span class="u-kv-label">Примедба</span><span>{{ vencanje.primedba }}</span></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-file-lines"></i> Запис</h2>
+        <ul class="info-rows">
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ vencanje.knjiga }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ vencanje.strana }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ vencanje.broj }}</div></li>
+          {% if vencanje.godina_registracije %}<li class="info-row"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ vencanje.godina_registracije }}</div></li>{% endif %}
+          {% if vencanje.primedba %}<li class="info-row"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ vencanje.primedba }}</div></li>{% endif %}
+        </ul>
+      </div>
 
     </section>
 
-    <!-- ============ CERTIFICATE PREVIEW ============ -->
+    {# ============ CERTIFICATE PREVIEW ============ #}
     <section class="tabs__panel">
 
-<div class="vencanica">
-    <div class="vencanica-frame">
-        <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>
-        <div class="venc-field-strana">{{ vencanje.strana }}</div>
-        <div class="venc-field-tekuci">{{ vencanje.broj }}</div>
-        <div class="venc-field-hram">{{ vencanje.hram }}</div>
-        <div class="venc-field-eparhija">Београдско-Карловачке</div>
-        <div class="venc-field-mesto">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}</div>
-        <div class="venc-field-godina">{{ vencanje.datum|date:"y" }}</div>
-        <div class="venc-table-field venc-field-ime_zenika">
+      <div class="vencanica">
+        <div class="vencanica-frame">
+          <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>
+          <div class="venc-field-strana">{{ vencanje.strana }}</div>
+          <div class="venc-field-tekuci">{{ vencanje.broj }}</div>
+          <div class="venc-field-hram">{{ vencanje.hram }}</div>
+          <div class="venc-field-eparhija">Београдско-Карловачке</div>
+          <div class="venc-field-mesto">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}</div>
+          <div class="venc-field-godina">{{ vencanje.datum|date:"y" }}</div>
+          <div class="venc-table-field venc-field-ime_zenika">
             <span>{{ vencanje.ime_zenika }} | {{ vencanje.zanimanje_zenika|lower }} | {{ vencanje.adresa_zenika }} | {{ vencanje.veroispovest_zenika|lower }}, {{ vencanje.narodnost_zenika|lower }}</span>
-        </div>
-        <div class="venc-table-field venc-field-ime_neveste">
+          </div>
+          <div class="venc-table-field venc-field-ime_neveste">
             <span>{{ vencanje.ime_neveste }} | {{ vencanje.zanimanje_neveste|lower }} | {{ vencanje.adresa_neveste }} | {{ vencanje.veroispovest_neveste|lower }}, {{ vencanje.narodnost_neveste|lower }}</span>
-        </div>
-        <div class="venc-table-field venc-field-roditelji_zenika">
+          </div>
+          <div class="venc-table-field venc-field-roditelji_zenika">
             <span>{{ vencanje.svekar|default_if_none:"" }}</span>
             <span>{{ vencanje.svekrva|default_if_none:"" }}</span>
-        </div>
-        <div class="venc-table-field venc-field-roditelji_neveste">
+          </div>
+          <div class="venc-table-field venc-field-roditelji_neveste">
             <span>{{ vencanje.tast|default_if_none:"" }}</span>
             <span>{{ vencanje.tasta|default_if_none:"" }}</span>
-        </div>
-        <div class="venc-table-field venc-field-rodjenje_zenika">
+          </div>
+          <div class="venc-table-field venc-field-rodjenje_zenika">
             <span>{{ vencanje.datum_rodjenja_zenika|julian_date }}</span>
             <span class="venc-text-sm">{{ vencanje.mesto_rodjenja_zenika }}</span>
-        </div>
-        <div class="venc-table-field venc-field-rodjenje_neveste">
+          </div>
+          <div class="venc-table-field venc-field-rodjenje_neveste">
             <span>{{ vencanje.datum_rodjenja_neveste|julian_date }}</span>
             <span class="venc-text-sm">{{ vencanje.mesto_rodjenja_neveste }}</span>
-        </div>
-        <div class="venc-table-field venc-field-brak_zenika">{{ vencanje.zenik_rb_brak }}</div>
-        <div class="venc-table-field venc-field-brak_neveste">{{ vencanje.nevesta_rb_brak }}</div>
-        <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date }}</div>
-        <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date }}</div>
-        <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}, {{ vencanje.hram }}</div>
-        <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|default_if_none:"" }}</div>
-        <div class="venc-table-field venc-field-svedoci">
+          </div>
+          <div class="venc-table-field venc-field-brak_zenika">{{ vencanje.zenik_rb_brak }}</div>
+          <div class="venc-table-field venc-field-brak_neveste">{{ vencanje.nevesta_rb_brak }}</div>
+          <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date }}</div>
+          <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date }}</div>
+          <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}, {{ vencanje.hram }}</div>
+          <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|default_if_none:"" }}</div>
+          <div class="venc-table-field venc-field-svedoci">
             <span>{{ vencanje.kum|default_if_none:"" }}</span>
             <span>{{ vencanje.stari_svat|default_if_none:"" }}</span>
+          </div>
+          <div class="venc-table-field venc-field-razresenje">{% if vencanje.razresenje %}Да{% else %}Не{% endif %}</div>
+          <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|default_if_none:"" }}</div>
+          <div class="venc-field-footer_hram">{{ vencanje.hram }}</div>
+          <div class="venc-field-footer_eparhija">Београдске</div>
+          <div class="venc-field-footer_mesto">Београду</div>
+          <div class="venc-field-footer_datum">{% now "j. F" %}</div>
+          <div class="venc-field-footer_godina">{% now "y" %}</div>
+          <div class="venc-field-footer_paroh">{% if vencanje.svestenik %}{{ vencanje.svestenik }}{% endif %}</div>
+          <div class="venc-field-footer_parohija">{% if vencanje.svestenik %}{{ vencanje.svestenik.parohija }}{% endif %}</div>
         </div>
-        <div class="venc-table-field venc-field-razresenje">{% if vencanje.razresenje %}Да{% else %}Не{% endif %}</div>
-        <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|default_if_none:"" }}</div>
-        <div class="venc-field-footer_hram">{{ vencanje.hram }}</div>
-        <div class="venc-field-footer_eparhija">Београдске</div>
-        <div class="venc-field-footer_mesto">Београду</div>
-        <div class="venc-field-footer_datum">{% now "j. F" %}</div>
-        <div class="venc-field-footer_godina">{% now "y" %}</div>
-        <div class="venc-field-footer_paroh">{% if vencanje.svestenik %}{{ vencanje.svestenik }}{% endif %}</div>
-        <div class="venc-field-footer_parohija">{% if vencanje.svestenik %}{{ vencanje.svestenik.parohija }}{% endif %}</div>
-    </div>
-</div>
+      </div>
 
     </section>
-</div>
+  </div>
 
+</div>
 {% include "registar/_history_panel.html" %}
 {% endblock %}


### PR DESCRIPTION
* full rewrite of info_krstenje.html and info_vencanje.html: u-kv-item / card / detail-section → info-section / info-rows / info-row
* every field row gets a tooltip icon — labels live as data-tooltip, drops the redundant label text
* Подаци tab matches the rest of the app; Крштеница / Венчаница certificate tab untouched
* the boxed-card section style from the previous PR carries over automatically