### PR TITLE
feat: unify krštenje + венчање view/edit + align fieldset to info-sec…

### DIFF
--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -32,17 +32,29 @@ input:focus, select:focus, textarea:focus {
 }
 
 /* Organizacija i raspored za UNOSI */
+/* Match the boxed .info-section look so edit fieldsets and view sections share style */
 fieldset.form-section {
+  margin: 0 0 24px;
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
-  background: var(--color-surface-2);
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 16px;
+  border-radius: var(--radius-2);
+  padding: 16px 20px 10px;
 }
 fieldset.form-section legend {
-  padding: 0 8px;
-  font-weight: 600;
-  color: var(--color-text);
+  margin: 0 0 8px;
+  padding: 0;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  width: 100%;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 8px;
+}
+fieldset.form-section legend i {
+  margin-right: 6px;
+  opacity: 0.75;
 }
 
 .form-row {

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -1,0 +1,190 @@
+{% extends "base.html" %}
+{% load static %}
+{% load julian_dates %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'registar/print/krstenica.css' %}">
+  {% if is_edit %}{{ form.media.css }}{% endif %}
+{% endblock %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
+
+{% block content %}
+{% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
+
+  <div class="u-page-header">
+    <a href="{% if is_edit and krstenje %}{% url 'krstenje_detail' uid=krstenje.uid %}{% else %}{% url 'krstenja' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
+    <h1 class="u-page-title">
+      {% if is_edit and not krstenje %}Унос крштења
+      {% elif is_edit %}Измена крштења{% if krstenje %} — {{ krstenje.ime_deteta }}{% endif %}
+      {% else %}Крштење — {{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}{% endif %}
+    </h1>
+    {% if is_edit %}
+      <button class="button button--primary button--icon" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% else %}
+      {% if can_edit_krstenje %}<a href="{% url 'izmena_krstenja' uid=krstenje.uid %}" class="button button--primary button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
+      <a href="{% url 'krstenje_pdf' krstenje.uid %}" target="_blank" class="button button--primary button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+      <button type="button" id="history-toggle" class="button button--primary button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
+    {% endif %}
+  </div>
+
+  {% if is_edit and form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">
+        {% for field, errors in form.errors.items %}{% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  {% if not is_edit %}
+  <div class="tabs tabs--segmented">
+    <div class="tabs__nav">
+      <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
+      <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+      <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
+      <label for="krst-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Крштеница</label>
+    </div>
+    <section class="tabs__panel">
+  {% endif %}
+
+      {# ============ ДЕТЕ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-baby"></i> Дете</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.dete }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_dete')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.dete_po_redu_po_majci }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value"><label>{{ form.dete_vanbracno }} ванбрачно</label></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value"><label>{{ form.dete_blizanac }} близанац</label></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Друго дете близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value">{{ form.drugo_dete_blizanac_ime }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Телесна мана"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value"><label>{{ form.dete_sa_telesnom_manom }} са телесном маном</label></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Рођено живо"><i class="fa-solid fa-heart-pulse"></i></div><div class="info-row__value"><label>{{ form.dete_rodjeno_zivo }} рођено живо</label></div></li>
+          {% else %}
+          <li class="info-row">
+            <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
+            <div class="info-row__value">{% if krstenje.dete %}<a href="{% url 'parohijan_detail' uid=krstenje.dete.uid %}">{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}</a>{% else %}{{ krstenje.ime_deteta }}{% if krstenje.gradjansko_ime_deteta %} ({{ krstenje.gradjansko_ime_deteta }}){% endif %}{% endif %}</div>
+          </li>
+          {% if krstenje.dete.get_pol_display %}<li class="info-row"><div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div><div class="info-row__value">{{ krstenje.dete.get_pol_display }}</div></li>{% endif %}
+          {% if krstenje.datum_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ krstenje.datum_rodjenja }}</div></li>{% endif %}
+          {% if krstenje.mesto_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.mesto_rodjenja }}</div></li>{% endif %}
+          {% if krstenje.dete_po_redu_po_majci %}<li class="info-row"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ krstenje.dete_po_redu_po_majci }}</div></li>{% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div></li>
+          {% if krstenje.dete_blizanac %}<li class="info-row"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value">Да{% if krstenje.drugo_dete_blizanac_ime %} ({{ krstenje.drugo_dete_blizanac_ime }}){% endif %}</div></li>{% endif %}
+          {% if krstenje.dete_sa_telesnom_manom %}<li class="info-row"><div class="info-row__icon" data-tooltip="Телесна мана"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">Да</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ РОДИТЕЉИ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.otac }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_otac')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.majka }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_majka')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div><div class="info-row__value">{% if krstenje.otac %}<a href="{% url 'parohijan_detail' uid=krstenje.otac.uid %}">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}</a>{% else %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}{% endif %}{% if krstenje.zanimanje_oca %}<span class="info-row__sub">{{ krstenje.zanimanje_oca|lower }}</span>{% endif %}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value">{% if krstenje.majka %}<a href="{% url 'parohijan_detail' uid=krstenje.majka.uid %}">{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}</a>{% else %}{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}{% endif %}{% if krstenje.zanimanje_majke %}<span class="info-row__sub">{{ krstenje.zanimanje_majke|lower }}</span>{% endif %}</div></li>
+          {% if krstenje.veroispovest_oca %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ krstenje.veroispovest_oca }}</div></li>{% endif %}
+          {% if krstenje.adresa_deteta %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.adresa_deteta }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ КУМ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-user-tag"></i> Кум</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.kum }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{% if krstenje.kum %}<a href="{% url 'parohijan_detail' uid=krstenje.kum.uid %}">{{ krstenje.ime_kuma }}</a>{% else %}{{ krstenje.ime_kuma }}{% endif %}{% if krstenje.zanimanje_kuma %}<span class="info-row__sub">{{ krstenje.zanimanje_kuma|lower }}</span>{% endif %}</div></li>
+          {% if krstenje.adresa_kuma_mesto %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.adresa_kuma_mesto }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ КРШТЕЊЕ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-droplet"></i> Крштење</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ form.datum }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Време"><i class="fa-solid fa-clock"></i></div><div class="info-row__value">{{ form.vreme }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ form.hram }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value">{{ form.svestenik }}</div></li>
+          {% else %}
+          {% if krstenje.datum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ krstenje.datum }}{% if krstenje.vreme %} <span class="info-row__sub">у {{ krstenje.vreme }}</span>{% endif %}</div></li>{% endif %}
+          {% if krstenje.hram %}<li class="info-row"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ krstenje.hram }}{% if krstenje.hram.mesto %} <span class="info-row__sub">{{ krstenje.hram.mesto }}</span>{% endif %}</div></li>{% endif %}
+          {% if krstenje.svestenik %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value"><a href="{% url 'svestenik_detail' uid=krstenje.svestenik.uid %}">{{ krstenje.svestenik }}</a></div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ ЗАПИС ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-file-lines"></i> Запис</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ form.knjiga }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ form.strana }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ form.broj }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ form.redni_broj }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ form.godina_registracije }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Место регистрације"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ form.mesto_registracije }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ form.datum_registracije }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Матични број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ form.maticni_broj }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Страна регистрације"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ form.strana_registracije }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ form.primedba }}</div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ krstenje.knjiga }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ krstenje.strana }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ krstenje.broj }}</div></li>
+          {% if krstenje.godina_registracije %}<li class="info-row"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ krstenje.godina_registracije }}</div></li>{% endif %}
+          {% if krstenje.primedba %}<li class="info-row"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ krstenje.primedba }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+  {% if not is_edit %}
+    </section>
+
+    {# ============ CERTIFICATE PREVIEW ============ #}
+    <section class="tabs__panel">
+      <div class="krstenica">
+        <div class="krstenica-frame">
+          <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>
+          <div class="krst-field-strana">{{ krstenje.strana }}</div>
+          <div class="krst-field-broj">{{ krstenje.broj }}</div>
+          <div class="krst-field-eparhija">БЕОГРАДСКО - КАРЛОВАЧКЕ</div>
+          <div class="krst-field-hram">{{ krstenje.hram }}</div>
+          <div class="krst-field-mesto">{{ krstenje.hram.mesto }}у</div>
+          <div class="krst-field-godina">{{ krstenje.datum|date:"y" }}</div>
+          <div class="krst-table-field krst-field-rodjenje_datum">{{ krstenje.datum_rodjenja|julian_date }}, {{ krstenje.vreme_rodjenja }} часова</div>
+          <div class="krst-table-field krst-field-rodjenje_mesto">{{ krstenje.mesto_rodjenja }}</div>
+          <div class="krst-table-field krst-field-krstenje_datum">{{ krstenje.datum|julian_date|default_if_none:"" }}{% if krstenje.vreme is not none %}, {{ krstenje.vreme }} часова{% endif %}</div>
+          <div class="krst-table-field krst-field-krstenje_mesto">{{ krstenje.hram.mesto }}, {{ krstenje.hram }}</div>
+          <div class="krst-table-field krst-field-ime_pol">{{ krstenje.ime_deteta }}{{ krstenje.gradjansko_ime_deteta }}, {{ krstenje.get_pol_deteta_display }}</div>
+          <div class="krst-table-field krst-field-roditelji">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}, {{ krstenje.zanimanje_oca|lower }} и<br>{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}, {{ krstenje.zanimanje_majke|lower }}<br>{{ krstenje.hram.mesto }}, {{ krstenje.adresa_deteta }}<br>{{ krstenje.veroispovest_oca }}</div>
+          <div class="krst-table-field krst-field-dete_po_redu">{{ krstenje.dete_po_redu_po_majci }}</div>
+          <div class="krst-table-field krst-field-bracno">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div>
+          <div class="krst-table-field krst-field-blizanac">{{ krstenje.dete_blizanac|yesno:"јесте,није" }}</div>
+          <div class="krst-table-field krst-field-telesna_mana">{{ krstenje.dete_sa_telesnom_manom|yesno:"јесте,није,непознато" }}</div>
+          <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|default_if_none:"" }}</div>
+          <div class="krst-table-field krst-field-kum">{{ krstenje.ime_kuma }}, {{ krstenje.zanimanje_kuma }}<br>{{ krstenje.adresa_kuma_mesto }}</div>
+          <div class="krst-table-field krst-field-domovnik"></div>
+          <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|default_if_none:"" }}</div>
+          <div class="krst-field-footer_br">{% now "d.m" %}</div>
+          <div class="krst-field-footer_godina">{% now "y" %}</div>
+          <div class="krst-field-footer_u">Београду</div>
+          <div class="krst-field-footer_parohija">{% if krstenje.svestenik %}{{ krstenje.svestenik.parohija }}{% endif %}</div>
+          <div class="krst-field-footer_paroh">{% if krstenje.svestenik %}{{ krstenje.svestenik }}{% endif %}</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  {% endif %}
+
+{% if is_edit %}{% include "registar/_modal_osoba.html" %}</form>{% else %}</div>{% endif %}
+{% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
+{% endblock %}

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %}
+{% load static %}
+{% load julian_dates %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'registar/print/vencanica.css' %}">
+  {% if is_edit %}{{ form.media.css }}{% endif %}
+{% endblock %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
+
+{% block content %}
+{% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
+
+  <div class="u-page-header">
+    <a href="{% if is_edit and vencanje %}{% url 'vencanje_detail' uid=vencanje.uid %}{% else %}{% url 'vencanja' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
+    <h1 class="u-page-title">
+      {% if is_edit and not vencanje %}Унос венчања
+      {% elif is_edit %}Измена венчања
+      {% else %}Венчање — {{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}{% endif %}
+    </h1>
+    {% if is_edit %}
+      <button class="button button--primary button--icon" type="submit" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% else %}
+      {% if can_edit_vencanje %}<a href="{% url 'izmena_vencanja' uid=vencanje.uid %}" class="button button--primary button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
+      <a href="{% url 'vencanje_pdf' vencanje.uid %}" target="_blank" class="button button--primary button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+      <button type="button" id="history-toggle" class="button button--primary button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
+    {% endif %}
+  </div>
+
+  {% if is_edit and form.errors %}
+    <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
+      <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
+      <ul style="margin:8px 0 0;padding-left:20px;">{% for field, errors in form.errors.items %}{% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}{% endfor %}</ul>
+    </div>
+  {% endif %}
+
+  {% if not is_edit %}
+  <div class="tabs tabs--segmented">
+    <div class="tabs__nav">
+      <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
+      <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
+      <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
+      <label for="venc-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Венчаница</label>
+    </div>
+    <section class="tabs__panel">
+  {% endif %}
+
+      {# ============ ЖЕНИК ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-person"></i> Женик</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.zenik }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_zenik')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.zenik_rb_brak }}</div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{% if vencanje.zenik %}<a href="{% url 'parohijan_detail' uid=vencanje.zenik.uid %}">{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}</a>{% else %}{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}{% endif %}</div></li>
+          {% if vencanje.zanimanje_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ vencanje.zanimanje_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.adresa_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.adresa_zenika }}</div></li>{% endif %}
+          {% if vencanje.datum_rodjenja_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ vencanje.datum_rodjenja_zenika }}{% if vencanje.mesto_rodjenja_zenika %} <span class="info-row__sub">{{ vencanje.mesto_rodjenja_zenika }}</span>{% endif %}</div></li>{% endif %}
+          {% if vencanje.veroispovest_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ vencanje.veroispovest_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.narodnost_zenika %}<li class="info-row"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ vencanje.narodnost_zenika|lower }}</div></li>{% endif %}
+          {% if vencanje.zenik_rb_brak %}<li class="info-row"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ vencanje.zenik_rb_brak }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ НЕВЕСТА ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-person-dress"></i> Невеста</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.nevesta }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_nevesta')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.nevesta_rb_brak }}</div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{% if vencanje.nevesta %}<a href="{% url 'parohijan_detail' uid=vencanje.nevesta.uid %}">{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}</a>{% else %}{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}{% endif %}</div></li>
+          {% if vencanje.zanimanje_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Занимање"><i class="fa-solid fa-briefcase"></i></div><div class="info-row__value">{{ vencanje.zanimanje_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.adresa_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Адреса"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ vencanje.adresa_neveste }}</div></li>{% endif %}
+          {% if vencanje.datum_rodjenja_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ vencanje.datum_rodjenja_neveste }}{% if vencanje.mesto_rodjenja_neveste %} <span class="info-row__sub">{{ vencanje.mesto_rodjenja_neveste }}</span>{% endif %}</div></li>{% endif %}
+          {% if vencanje.veroispovest_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Вероисповест"><i class="fa-solid fa-cross"></i></div><div class="info-row__value">{{ vencanje.veroispovest_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.narodnost_neveste %}<li class="info-row"><div class="info-row__icon" data-tooltip="Народност"><i class="fa-solid fa-flag"></i></div><div class="info-row__value">{{ vencanje.narodnost_neveste|lower }}</div></li>{% endif %}
+          {% if vencanje.nevesta_rb_brak %}<li class="info-row"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ vencanje.nevesta_rb_brak }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ РОДИТЕЉИ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.svekar }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekar')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.svekrva }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekrva')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Таст"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.tast }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tast')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Ташта"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.tasta }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tasta')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          {% else %}
+          {% if vencanje.svekar %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekar.uid %}">{{ vencanje.svekar }}</a></div></li>{% endif %}
+          {% if vencanje.svekrva %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekrva.uid %}">{{ vencanje.svekrva }}</a></div></li>{% endif %}
+          {% if vencanje.tast %}<li class="info-row"><div class="info-row__icon" data-tooltip="Таст"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.tast.uid %}">{{ vencanje.tast }}</a></div></li>{% endif %}
+          {% if vencanje.tasta %}<li class="info-row"><div class="info-row__icon" data-tooltip="Ташта"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.tasta.uid %}">{{ vencanje.tasta }}</a></div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ СВЕДОЦИ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-user-check"></i> Сведоци</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.kum }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.stari_svat }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_stari_svat')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          {% else %}
+          {% if vencanje.kum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.kum.uid %}">{{ vencanje.kum }}</a></div></li>{% endif %}
+          {% if vencanje.stari_svat %}<li class="info-row"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.stari_svat.uid %}">{{ vencanje.stari_svat }}</a></div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ ВЕНЧАЊЕ ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-ring"></i> Венчање</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ form.datum }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Датум испита"><i class="fa-solid fa-clipboard-check"></i></div><div class="info-row__value">{{ form.datum_ispita }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ form.hram }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value">{{ form.svestenik }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Разрешење"><i class="fa-solid fa-file-signature"></i></div><div class="info-row__value"><label>{{ form.razresenje }} разрешење</label></div></li>
+          {% else %}
+          {% if vencanje.datum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум"><i class="fa-solid fa-calendar-day"></i></div><div class="info-row__value">{{ vencanje.datum }}</div></li>{% endif %}
+          {% if vencanje.datum_ispita %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум испита"><i class="fa-solid fa-clipboard-check"></i></div><div class="info-row__value">{{ vencanje.datum_ispita }}</div></li>{% endif %}
+          {% if vencanje.hram %}<li class="info-row"><div class="info-row__icon" data-tooltip="Храм"><i class="fa-solid fa-church"></i></div><div class="info-row__value">{{ vencanje.hram }}{% if vencanje.hram.mesto %} <span class="info-row__sub">{{ vencanje.hram.mesto }}</span>{% endif %}</div></li>{% endif %}
+          {% if vencanje.svestenik %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свештеник"><i class="fa-solid fa-id-badge"></i></div><div class="info-row__value"><a href="{% url 'svestenik_detail' uid=vencanje.svestenik.uid %}">{{ vencanje.svestenik }}</a></div></li>{% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Разрешење"><i class="fa-solid fa-file-signature"></i></div><div class="info-row__value">{{ vencanje.razresenje|yesno:"Да,Не" }}</div></li>
+          {% endif %}
+        </ul>
+      </div>
+
+      {# ============ ЗАПИС ============ #}
+      <div class="info-section">
+        <h2 class="info-section__title"><i class="fa-solid fa-file-lines"></i> Запис</h2>
+        <ul class="info-rows">
+          {% if is_edit %}
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ form.knjiga }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ form.strana }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ form.broj }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ form.redni_broj }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ form.godina_registracije }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ form.primedba }}</div></li>
+          {% else %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Књига"><i class="fa-solid fa-book"></i></div><div class="info-row__value">{{ vencanje.knjiga }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Страна"><i class="fa-solid fa-file"></i></div><div class="info-row__value">{{ vencanje.strana }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Текући број"><i class="fa-solid fa-hashtag"></i></div><div class="info-row__value">{{ vencanje.broj }}</div></li>
+          {% if vencanje.godina_registracije %}<li class="info-row"><div class="info-row__icon" data-tooltip="Година регистрације"><i class="fa-solid fa-calendar"></i></div><div class="info-row__value">{{ vencanje.godina_registracije }}</div></li>{% endif %}
+          {% if vencanje.primedba %}<li class="info-row"><div class="info-row__icon" data-tooltip="Примедба"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ vencanje.primedba }}</div></li>{% endif %}
+          {% endif %}
+        </ul>
+      </div>
+
+  {% if not is_edit %}
+    </section>
+
+    {# ============ CERTIFICATE PREVIEW ============ #}
+    <section class="tabs__panel">
+      <div class="vencanica">
+        <div class="vencanica-frame">
+          <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>
+          <div class="venc-field-strana">{{ vencanje.strana }}</div>
+          <div class="venc-field-tekuci">{{ vencanje.broj }}</div>
+          <div class="venc-field-hram">{{ vencanje.hram }}</div>
+          <div class="venc-field-eparhija">Београдско-Карловачке</div>
+          <div class="venc-field-mesto">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}</div>
+          <div class="venc-field-godina">{{ vencanje.datum|date:"y" }}</div>
+          <div class="venc-table-field venc-field-ime_zenika"><span>{{ vencanje.ime_zenika }} | {{ vencanje.zanimanje_zenika|lower }} | {{ vencanje.adresa_zenika }} | {{ vencanje.veroispovest_zenika|lower }}, {{ vencanje.narodnost_zenika|lower }}</span></div>
+          <div class="venc-table-field venc-field-ime_neveste"><span>{{ vencanje.ime_neveste }} | {{ vencanje.zanimanje_neveste|lower }} | {{ vencanje.adresa_neveste }} | {{ vencanje.veroispovest_neveste|lower }}, {{ vencanje.narodnost_neveste|lower }}</span></div>
+          <div class="venc-table-field venc-field-roditelji_zenika"><span>{{ vencanje.svekar|default_if_none:"" }}</span><span>{{ vencanje.svekrva|default_if_none:"" }}</span></div>
+          <div class="venc-table-field venc-field-roditelji_neveste"><span>{{ vencanje.tast|default_if_none:"" }}</span><span>{{ vencanje.tasta|default_if_none:"" }}</span></div>
+          <div class="venc-table-field venc-field-rodjenje_zenika"><span>{{ vencanje.datum_rodjenja_zenika|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_zenika }}</span></div>
+          <div class="venc-table-field venc-field-rodjenje_neveste"><span>{{ vencanje.datum_rodjenja_neveste|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_neveste }}</span></div>
+          <div class="venc-table-field venc-field-brak_zenika">{{ vencanje.zenik_rb_brak }}</div>
+          <div class="venc-table-field venc-field-brak_neveste">{{ vencanje.nevesta_rb_brak }}</div>
+          <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date }}</div>
+          <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date }}</div>
+          <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}, {{ vencanje.hram }}</div>
+          <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|default_if_none:"" }}</div>
+          <div class="venc-table-field venc-field-svedoci"><span>{{ vencanje.kum|default_if_none:"" }}</span><span>{{ vencanje.stari_svat|default_if_none:"" }}</span></div>
+          <div class="venc-table-field venc-field-razresenje">{% if vencanje.razresenje %}Да{% else %}Не{% endif %}</div>
+          <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|default_if_none:"" }}</div>
+          <div class="venc-field-footer_hram">{{ vencanje.hram }}</div>
+          <div class="venc-field-footer_eparhija">Београдске</div>
+          <div class="venc-field-footer_mesto">Београду</div>
+          <div class="venc-field-footer_datum">{% now "j. F" %}</div>
+          <div class="venc-field-footer_godina">{% now "y" %}</div>
+          <div class="venc-field-footer_paroh">{% if vencanje.svestenik %}{{ vencanje.svestenik }}{% endif %}</div>
+          <div class="venc-field-footer_parohija">{% if vencanje.svestenik %}{{ vencanje.svestenik.parohija }}{% endif %}</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  {% endif %}
+
+{% if is_edit %}{% include "registar/_modal_osoba.html" %}</form>{% else %}</div>{% endif %}
+{% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
+{% endblock %}

--- a/crkva/registar/tests/test_views.py
+++ b/crkva/registar/tests/test_views.py
@@ -111,7 +111,7 @@ class PrikazKrstenjaViewTestCase(TestCase):
         response = self.client.get(
             reverse("krstenje_detail", kwargs={"uid": self.krstenje.uid})
         )
-        self.assertTemplateUsed(response, "registar/info_krstenje.html")
+        self.assertTemplateUsed(response, "registar/krstenje.html")
 
     def test_prikaz_krstenja_contains_krstenje_data(self):
         """Приказ крштења садржи податке о крштењу."""

--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -125,7 +125,7 @@ class PrikazKrstenja(DetailView):
     """Приказује детаљне информације о појединачном крштењу."""
 
     model = Krstenje
-    template_name = "registar/info_krstenje.html"
+    template_name = "registar/krstenje.html"
     context_object_name = "krstenje"
 
     def get_object(self) -> Krstenje:
@@ -162,5 +162,6 @@ def izmena_krstenja(request, uid):
             "title": "Измена",
             "back_url": reverse("krstenje_detail", kwargs={"uid": instance.uid}),
             "is_edit": True,
+            "krstenje": instance,
         },
     )

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -121,7 +121,7 @@ class PrikazVencanja(DetailView):
     """Приказује детаљне информације о појединачном венчању."""
 
     model = Vencanje
-    template_name = "registar/info_vencanje.html"
+    template_name = "registar/vencanje.html"
     context_object_name = "vencanje"
 
     def get_object(self) -> Vencanje:
@@ -172,5 +172,6 @@ def izmena_vencanja(request, uid):
             "title": "Измена",
             "back_url": reverse("vencanje_detail", kwargs={"uid": instance.uid}),
             "is_edit": True,
+            "vencanje": instance,
         },
     )


### PR DESCRIPTION
…tion

* one krstenje.html / vencanje.html per resource — handles view, /unos and /izmena via is_edit
* same info-row/info-section layout in both modes (view shows text, edit shows form fields)
* certificate tab (kršteница / венчаница) hidden in edit
* fieldset.form-section restyled to match .info-section so the older unos_*.html (until cleanup) shares the same boxed look