### PR TITLE
fix: section frames + tooltip

### DIFF
--- a/crkva/registar/static/registar/components/dugmad.css
+++ b/crkva/registar/static/registar/components/dugmad.css
@@ -217,18 +217,23 @@
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    padding: 4px 8px;
-    background: var(--color-text, #333);
-    color: var(--color-surface, #fff);
+    padding: 6px 10px;
+    background: #1f2937;   /* fixed dark — readable on both themes */
+    color: #fff;
     font-size: 12px;
     font-weight: 400;
-    white-space: nowrap;
+    line-height: 1.4;
+    text-align: center;
     border-radius: 4px;
     pointer-events: none;
     opacity: 0;
     transition: opacity 0.15s;
     margin-bottom: 6px;
     z-index: 5;
+    max-width: 240px;
+    width: max-content;
+    white-space: normal;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 [data-tooltip]:hover::after {
     opacity: 1;

--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -32,29 +32,26 @@ input:focus, select:focus, textarea:focus {
 }
 
 /* Organizacija i raspored za UNOSI */
-/* Match the boxed .info-section look so edit fieldsets and view sections share style */
+/* Classic framed fieldset — legend floats on the top border (native fieldset behaviour). */
 fieldset.form-section {
-  margin: 0 0 24px;
-  background: var(--color-surface);
+  margin: 24px 0 16px;
+  background: var(--color-surface-2);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  padding: 16px 20px 10px;
+  border-radius: 12px;
+  padding: 14px 18px 14px;
 }
 fieldset.form-section legend {
-  margin: 0 0 8px;
-  padding: 0;
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-muted);
-  width: 100%;
-  border-bottom: 1px solid var(--color-border);
-  padding-bottom: 8px;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+  text-transform: none;
+  letter-spacing: normal;
+  line-height: 1.4;
 }
 fieldset.form-section legend i {
   margin-right: 6px;
-  opacity: 0.75;
+  color: var(--color-text-muted);
 }
 
 .form-row {

--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -56,25 +56,31 @@
 }
 
 .info-section {
-    margin-top: 24px;
-    background: var(--color-surface);
+    position: relative;
+    margin: 24px 0 16px;
+    background: var(--color-surface-2);
     border: 1px solid var(--color-border);
-    border-radius: var(--radius-2);
-    padding: 16px 20px 10px;
+    border-radius: 12px;
+    padding: 22px 18px 14px;
 }
 .info-section__title {
-    font-size: 12px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
-    margin: -8px -4px 8px;
-    padding: 0 0 8px;
-    border-bottom: 1px solid var(--color-border);
+    position: absolute;
+    top: -11px;
+    left: 14px;
+    margin: 0;
+    padding: 0 8px;
+    background: var(--color-surface);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+    text-transform: none;
+    letter-spacing: normal;
+    border: none;
+    line-height: 1.4;
 }
 .info-section__title i {
     margin-right: 6px;
-    opacity: 0.75;
+    color: var(--color-text-muted);
 }
 
 .info-list {

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -161,13 +161,6 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
-/* Tooltip on dark surface */
-[data-theme="dark"] [data-tooltip]::after {
-  background: var(--color-surface-1);
-  color: var(--color-text);
-  border: 1px solid var(--color-border-strong);
-}
-
 /* Page-size selector pills */
 [data-theme="dark"] .page-size-link--active {
   background: var(--color-primary) !important;


### PR DESCRIPTION
* restored the classic fieldset look: surface-2 bg, 12px radius, title floats on top border (legend-style)
* same look for .info-section (view) and fieldset.form-section (edit) — they were drifting apart
* tooltip: fixed dark bg (#1f2937 + white) works on both themes; multi-line wraps up to 240px
* dropped the now-conflicting [data-theme=dark] tooltip override