### PR TITLE
fix: inline + Додај нову особу inside Osoba select2 dropdowns

### DIFF
--- a/crkva/registar/forms/krstenje_form.py
+++ b/crkva/registar/forms/krstenje_form.py
@@ -11,7 +11,12 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     model = Osoba
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-minimum-input-length"] = 1
+        attrs["data-osoba-create"] = "1"
+        return attrs
 
 
 class SvestenikSelect2Widget(ModelSelect2Widget):

--- a/crkva/registar/forms/vencanje_form.py
+++ b/crkva/registar/forms/vencanje_form.py
@@ -11,7 +11,12 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     model = Osoba
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-minimum-input-length"] = 1
+        attrs["data-osoba-create"] = "1"
+        return attrs
 
 
 class SvestenikSelect2Widget(ModelSelect2Widget):

--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -314,19 +314,6 @@ input[name="vreme_rodjenja"]:focus {
 
 
 /* FK поље са акцијским дугметом (+ за додавање) */
-.form-field-with-action {
-  display: flex;
-  gap: 8px;
-  align-items: start;
-}
-.form-field-with-action__input {
-  flex: 1;
-}
-.form-field-with-action__btn {
-  min-height: 38px;
-  white-space: nowrap;
-}
-
 /* Single-column card layout used by the redesigned unos forms. */
 .form--single-column {
   max-width: 720px;

--- a/crkva/registar/static/registar/components/modali.css
+++ b/crkva/registar/static/registar/components/modali.css
@@ -118,3 +118,29 @@
     font-size: 13px;
     margin-top: 8px;
 }
+
+
+/* Inline create row injected into select2 dropdowns for Osoba autocompletes. */
+.select2-create-new {
+    padding: 10px 14px;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-surface-2);
+    color: var(--color-primary, #a21514);
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    user-select: none;
+}
+.select2-create-new:hover,
+.select2-create-new:focus {
+    background: var(--color-surface-3, var(--color-surface));
+    outline: none;
+}
+.select2-create-new__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/crkva/registar/static/registar/components/osoba_create.js
+++ b/crkva/registar/static/registar/components/osoba_create.js
@@ -1,0 +1,86 @@
+/* ==========================================================================
+   OSOBA-CREATE — inline "+ Додај нову особу" footer for Osoba select2s
+   ==========================================================================
+   Adds a sticky create-new row at the bottom of any select2 dropdown whose
+   underlying <select> carries `data-osoba-create`. Clicking it opens the
+   shared #osoba-modal pre-filled by splitting the typed query on the first
+   space (Име vs Презиме).
+   ========================================================================== */
+
+(function ($) {
+    "use strict";
+    if (!$) return;
+
+    function parseName(q) {
+        var trimmed = (q || "").trim();
+        if (!trimmed) return { ime: "", prezime: "" };
+        var idx = trimmed.indexOf(" ");
+        if (idx < 0) return { ime: trimmed, prezime: "" };
+        return {
+            ime: trimmed.slice(0, idx).trim(),
+            prezime: trimmed.slice(idx + 1).trim(),
+        };
+    }
+
+    function attach($select) {
+        if ($select.data("osobaCreateBound")) return;
+        $select.data("osobaCreateBound", true);
+
+        $select.on("select2:open.osobaCreate", function () {
+            requestAnimationFrame(function () {
+                var $dropdown = $(".select2-container--open .select2-dropdown");
+                if (!$dropdown.length) return;
+                if ($dropdown.find(".select2-create-new").length) return;
+
+                var $footer = $(
+                    '<div class="select2-create-new" role="button" tabindex="0">' +
+                        '<i class="fa-solid fa-plus" aria-hidden="true"></i> ' +
+                        '<span class="select2-create-new__label"></span>' +
+                    "</div>"
+                );
+                $dropdown.append($footer);
+
+                var $search = $dropdown.find(".select2-search__field");
+
+                function refresh() {
+                    var q = ($search.val() || "").trim();
+                    $footer.find(".select2-create-new__label").text(
+                        q ? 'Додај "' + q + '"' : "Додај нову особу"
+                    );
+                }
+                refresh();
+                $search.on("input.osobaCreate", refresh);
+
+                $footer.on("mousedown touchstart", function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var parts = parseName($search.val());
+                    $select.select2("close");
+                    if (!window.osobaModal || typeof window.osobaModal.open !== "function") return;
+                    window.osobaModal.open($select.attr("id"));
+                    setTimeout(function () {
+                        var imeEl = document.getElementById("modal-ime");
+                        var prezimeEl = document.getElementById("modal-prezime");
+                        if (imeEl) imeEl.value = parts.ime;
+                        if (prezimeEl) prezimeEl.value = parts.prezime;
+                        var focusEl = parts.prezime ? prezimeEl : imeEl;
+                        if (focusEl) {
+                            focusEl.focus();
+                            try { focusEl.setSelectionRange(focusEl.value.length, focusEl.value.length); } catch (e) {}
+                        }
+                    }, 60);
+                });
+            });
+        });
+    }
+
+    function init() {
+        $("select[data-osoba-create]").each(function () { attach($(this)); });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})(window.jQuery);

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -168,6 +168,7 @@
       })();
     </script>
     <script src="{% static 'registar/components/modal.js' %}"></script>
+    <script src="{% static 'registar/components/osoba_create.js' %}"></script>
     {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -74,7 +74,7 @@
         <h2 class="info-section__title"><i class="fa-solid fa-baby"></i> Дете</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.dete }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_dete')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.dete }}</div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.dete_po_redu_po_majci }}</div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value"><label>{{ form.dete_vanbracno }} ванбрачно</label></div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value"><label>{{ form.dete_blizanac }} близанац</label></div></li>
@@ -102,8 +102,8 @@
         <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.otac }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_otac')"><i class="fa-solid fa-plus"></i></button></div></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.majka }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_majka')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div><div class="info-row__value">{{ form.otac }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value">{{ form.majka }}</div></li>
           {% else %}
           <li class="info-row"><div class="info-row__icon" data-tooltip="Отац"><i class="fa-solid fa-person"></i></div><div class="info-row__value">{% if krstenje.otac %}<a href="{% url 'parohijan_detail' uid=krstenje.otac.uid %}">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}</a>{% else %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}{% endif %}{% if krstenje.zanimanje_oca %}<span class="info-row__sub">{{ krstenje.zanimanje_oca|lower }}</span>{% endif %}</div></li>
           <li class="info-row"><div class="info-row__icon" data-tooltip="Мајка"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value">{% if krstenje.majka %}<a href="{% url 'parohijan_detail' uid=krstenje.majka.uid %}">{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}</a>{% else %}{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}{% endif %}{% if krstenje.zanimanje_majke %}<span class="info-row__sub">{{ krstenje.zanimanje_majke|lower }}</span>{% endif %}</div></li>
@@ -118,7 +118,7 @@
         <h2 class="info-section__title"><i class="fa-solid fa-user-tag"></i> Кум</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.kum }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{{ form.kum }}</div></li>
           {% else %}
           <li class="info-row"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{% if krstenje.kum %}<a href="{% url 'parohijan_detail' uid=krstenje.kum.uid %}">{{ krstenje.ime_kuma }}</a>{% else %}{{ krstenje.ime_kuma }}{% endif %}{% if krstenje.zanimanje_kuma %}<span class="info-row__sub">{{ krstenje.zanimanje_kuma|lower }}</span>{% endif %}</div></li>
           {% if krstenje.adresa_kuma_mesto %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.adresa_kuma_mesto }}</div></li>{% endif %}

--- a/crkva/registar/templates/registar/unos_krstenja.html
+++ b/crkva/registar/templates/registar/unos_krstenja.html
@@ -73,10 +73,7 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.dete.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.dete }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_dete')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.dete }}
         </div>
       </div>
     </fieldset>
@@ -86,19 +83,13 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.otac.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.otac }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_otac')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.otac }}
         </div>
       </div>
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.majka.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.majka }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_majka')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.majka }}
         </div>
       </div>
     </fieldset>
@@ -122,10 +113,7 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.kum.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.kum }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.kum }}
         </div>
       </div>
     </fieldset>

--- a/crkva/registar/templates/registar/unos_vencanja.html
+++ b/crkva/registar/templates/registar/unos_vencanja.html
@@ -68,10 +68,7 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.zenik.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.zenik }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_zenik')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.zenik }}
         </div>
       </div>
     </fieldset>
@@ -81,10 +78,7 @@
       <div class="form-row">
         <div class="form-field" style="grid-column: 1 / -1;">
           {{ form.nevesta.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.nevesta }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_nevesta')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.nevesta }}
         </div>
       </div>
     </fieldset>
@@ -94,33 +88,21 @@
       <div class="form-row">
         <div class="form-field">
           {{ form.svekar.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.svekar }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekar')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.svekar }}
         </div>
         <div class="form-field">
           {{ form.svekrva.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.svekrva }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekrva')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.svekrva }}
         </div>
       </div>
       <div class="form-row">
         <div class="form-field">
           {{ form.tast.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.tast }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tast')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.tast }}
         </div>
         <div class="form-field">
           {{ form.tasta.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.tasta }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tasta')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.tasta }}
         </div>
       </div>
     </fieldset>
@@ -145,17 +127,11 @@
       <div class="form-row">
         <div class="form-field">
           {{ form.kum.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.kum }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.kum }}
         </div>
         <div class="form-field">
           {{ form.stari_svat.label_tag }}
-          <div class="form-field-with-action">
-            <div class="form-field-with-action__input">{{ form.stari_svat }}</div>
-            <button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_stari_svat')"><i class="fa-solid fa-plus"></i></button>
-          </div>
+          {{ form.stari_svat }}
         </div>
       </div>
     </fieldset>

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -68,7 +68,7 @@
         <h2 class="info-section__title"><i class="fa-solid fa-person"></i> Женик</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.zenik }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_zenik')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.zenik }}</div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.zenik_rb_brak }}</div></li>
           {% else %}
           <li class="info-row"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{% if vencanje.zenik %}<a href="{% url 'parohijan_detail' uid=vencanje.zenik.uid %}">{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}</a>{% else %}{{ vencanje.ime_zenika }} {{ vencanje.prezime_zenika }}{% endif %}</div></li>
@@ -87,7 +87,7 @@
         <h2 class="info-section__title"><i class="fa-solid fa-person-dress"></i> Невеста</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.nevesta }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_nevesta')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.nevesta }}</div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Редни брак"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.nevesta_rb_brak }}</div></li>
           {% else %}
           <li class="info-row"><div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{% if vencanje.nevesta %}<a href="{% url 'parohijan_detail' uid=vencanje.nevesta.uid %}">{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}</a>{% else %}{{ vencanje.ime_neveste }} {{ vencanje.prezime_neveste }}{% endif %}</div></li>
@@ -106,10 +106,10 @@
         <h2 class="info-section__title"><i class="fa-solid fa-people-group"></i> Родитељи</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.svekar }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekar')"><i class="fa-solid fa-plus"></i></button></div></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.svekrva }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_svekrva')"><i class="fa-solid fa-plus"></i></button></div></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Таст"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.tast }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tast')"><i class="fa-solid fa-plus"></i></button></div></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Ташта"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.tasta }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_tasta')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value">{{ form.svekar }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value">{{ form.svekrva }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Таст"><i class="fa-solid fa-person"></i></div><div class="info-row__value">{{ form.tast }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Ташта"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value">{{ form.tasta }}</div></li>
           {% else %}
           {% if vencanje.svekar %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекар"><i class="fa-solid fa-person"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekar.uid %}">{{ vencanje.svekar }}</a></div></li>{% endif %}
           {% if vencanje.svekrva %}<li class="info-row"><div class="info-row__icon" data-tooltip="Свекрва"><i class="fa-solid fa-person-dress"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.svekrva.uid %}">{{ vencanje.svekrva }}</a></div></li>{% endif %}
@@ -124,8 +124,8 @@
         <h2 class="info-section__title"><i class="fa-solid fa-user-check"></i> Сведоци</h2>
         <ul class="info-rows">
           {% if is_edit %}
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.kum }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_kum')"><i class="fa-solid fa-plus"></i></button></div></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value"><div class="form-field-with-action"><div class="form-field-with-action__input">{{ form.stari_svat }}</div><button type="button" class="button button--primary form-field-with-action__btn" title="Додај нову особу" onclick="osobaModal.open('id_stari_svat')"><i class="fa-solid fa-plus"></i></button></div></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value">{{ form.kum }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value">{{ form.stari_svat }}</div></li>
           {% else %}
           {% if vencanje.kum %}<li class="info-row"><div class="info-row__icon" data-tooltip="Кум"><i class="fa-solid fa-user-tag"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.kum.uid %}">{{ vencanje.kum }}</a></div></li>{% endif %}
           {% if vencanje.stari_svat %}<li class="info-row"><div class="info-row__icon" data-tooltip="Стари сват"><i class="fa-solid fa-user-tie"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=vencanje.stari_svat.uid %}">{{ vencanje.stari_svat }}</a></div></li>{% endif %}


### PR DESCRIPTION
* OsobaSelect2Widget gets data-osoba-create attr (via build_attrs)
* new osoba_create.js injects a sticky "+ Додај" footer in the dropdown
* click pre-fills shared osoba modal from the typed query
* drops the external + buttons across krstenje/vencanje view+create pages