### PR TITLE
fix: style password/tel/time inputs + tidy users/add page

### DIFF
--- a/crkva/registar/static/registar/base/tokens.css
+++ b/crkva/registar/static/registar/base/tokens.css
@@ -31,6 +31,9 @@
     --color-warning-border: #ffc107;
     --color-info-bg: #f8f9fa;
     --color-info-border: #dee2e6;
+    --color-error-text: #991b1b;
+    --color-error-bg: #fef2f2;
+    --color-error-border: #fca5a5;
 
     /* Gray shades */
     --color-gray-100: #f8f9fa;

--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -7,7 +7,8 @@ label {
 }
 
 input[type="text"], input[type="search"], input[type="number"], input[type="date"],
-input[type="email"], select, textarea {
+input[type="email"], input[type="password"], input[type="tel"], input[type="url"],
+input[type="time"], input[type="datetime-local"], select, textarea {
   width: 100%;
   padding: 8px 10px;
   font-size: 16px;
@@ -87,7 +88,8 @@ fieldset.form-section legend i {
 
   /* Better input sizing for mobile */
   input[type="text"], input[type="number"], input[type="date"],
-  input[type="email"], select, textarea {
+  input[type="email"], input[type="password"], input[type="tel"], input[type="url"],
+  input[type="time"], input[type="datetime-local"], select, textarea {
     font-size: 16px; /* Prevent zoom on iOS */
     padding: 12px;
     min-height: 44px;

--- a/crkva/registar/static/registar/components/oznake.css
+++ b/crkva/registar/static/registar/components/oznake.css
@@ -85,6 +85,13 @@
     padding: 15px;
 }
 
+.u-alert--error {
+    background-color: var(--color-error-bg);
+    border: 1px solid var(--color-error-border);
+    color: var(--color-error-text);
+    padding: 15px;
+}
+
 .u-alert__title {
     margin-top: 0;
     color: var(--color-warning-text);

--- a/crkva/registar/templates/registar/users_add.html
+++ b/crkva/registar/templates/registar/users_add.html
@@ -13,38 +13,49 @@
       </button>
     </div>
 
-    {% if form.errors %}
-      <div class="form-errors" style="background:#fef2f2;border:1px solid #fca5a5;border-radius:var(--radius-2);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-4);color:#991b1b;">
-        <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
-        <ul style="margin:8px 0 0;padding-left:20px;">
-          {% for field, errors in form.errors.items %}
-            {% for error in errors %}<li>{{ field }}: {{ error }}</li>{% endfor %}
-          {% endfor %}
-        </ul>
-      </div>
+    {% if form.non_field_errors %}
+      <div class="u-alert u-alert--error">{{ form.non_field_errors }}</div>
     {% endif %}
 
     <fieldset class="form-section">
       <legend>Налог</legend>
       <div class="form-row">
-        <div class="form-field">{{ form.username.label_tag }} {{ form.username }}</div>
-        <div class="form-field">{{ form.password.label_tag }} {{ form.password }}</div>
+        <div class="form-field">
+          {{ form.username.label_tag }} {{ form.username }}
+          {% if form.username.errors %}<div class="error-text">{{ form.username.errors|join:" " }}</div>{% endif %}
+        </div>
+        <div class="form-field">
+          {{ form.password.label_tag }} {{ form.password }}
+          {% if form.password.errors %}<div class="error-text">{{ form.password.errors|join:" " }}</div>{% endif %}
+        </div>
       </div>
       <div class="form-row">
-        <div class="form-field">{{ form.first_name.label_tag }} {{ form.first_name }}</div>
-        <div class="form-field">{{ form.last_name.label_tag }} {{ form.last_name }}</div>
+        <div class="form-field">
+          {{ form.first_name.label_tag }} {{ form.first_name }}
+          {% if form.first_name.errors %}<div class="error-text">{{ form.first_name.errors|join:" " }}</div>{% endif %}
+        </div>
+        <div class="form-field">
+          {{ form.last_name.label_tag }} {{ form.last_name }}
+          {% if form.last_name.errors %}<div class="error-text">{{ form.last_name.errors|join:" " }}</div>{% endif %}
+        </div>
       </div>
       <div class="form-row">
-        <div class="form-field">{{ form.email.label_tag }} {{ form.email }}</div>
+        <div class="form-field">
+          {{ form.email.label_tag }} {{ form.email }}
+          {% if form.email.errors %}<div class="error-text">{{ form.email.errors|join:" " }}</div>{% endif %}
+        </div>
       </div>
     </fieldset>
 
     <fieldset class="form-section">
       <legend>Приступ у парохији</legend>
       <div class="form-row">
-        <div class="form-field">{{ form.role.label_tag }} {{ form.role }}</div>
         <div class="form-field">
-          <label>{{ form.is_default }} {{ form.is_default.label }}</label>
+          {{ form.role.label_tag }} {{ form.role }}
+          {% if form.role.errors %}<div class="error-text">{{ form.role.errors|join:" " }}</div>{% endif %}
+        </div>
+        <div class="form-field">
+          {{ form.is_default }} <label for="{{ form.is_default.id_for_label }}">{{ form.is_default.label }}</label>
         </div>
       </div>
     </fieldset>


### PR DESCRIPTION
* forme.css now styles password, tel, url, time, datetime-local inputs (login/profile/users-add all benefit)
* users_add: per-field error display + .u-alert--error block + checkbox label alignment
* oznake.css adds .u-alert--error variant with new error-{bg,border,text} tokens