### PR TITLE
chore: track scripts/gunicorn.conf.py so git clean cannot delete it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         args:
           - --rcfile=.pylintrc
           - --django-settings-module=crkva.settings
-        exclude: ^.*/migrations/.*$
+        exclude: ^(.*/migrations/.*|scripts/gunicorn\.conf\.py)$
 
   # Django tests
   - repo: local

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,3 +24,4 @@ django-settings-module = crkva.settings
 [TOOL:pylint]
 ignore-paths=
     ^.*/migrations/.*$
+    ^scripts/gunicorn\.conf\.py$

--- a/scripts/gunicorn.conf.py
+++ b/scripts/gunicorn.conf.py
@@ -1,0 +1,15 @@
+"""Gunicorn configuration for the bare-metal systemd deploy.
+
+Read by /etc/systemd/system/spc-registar.service (ExecStart ... -c <this file>).
+Docker deployments ignore this file — see docker-compose.prod.yml for the
+in-container gunicorn command.
+"""
+
+bind = "0.0.0.0:9000"
+workers = 3
+worker_class = "sync"
+timeout = 120
+accesslog = "/var/log/spc-registar/access.log"
+errorlog = "/var/log/spc-registar/error.log"
+loglevel = "info"
+chdir = "/root/projects/spc-registar-main/crkva"


### PR DESCRIPTION
* file is only read by the systemd unit; docker uses its own gunicorn command
* prevents the 127.0.0.1 vs 0.0.0.0 bind regression we hit today
* pylint excludes the file (gunicorn config uses lowercase module-level names)