### PR TITLE
refactor: rename user-facing tenant -> parohija (URLs, namespace, lab…

### DIFF
--- a/crkva/crkva/urls.py
+++ b/crkva/crkva/urls.py
@@ -21,7 +21,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("tenant/", include("tenants.urls")),
+    path("parohija/", include("tenants.urls")),
     path("", include("registar.urls")),
 ]
 

--- a/crkva/registar/templates/registar/users_add.html
+++ b/crkva/registar/templates/registar/users_add.html
@@ -4,10 +4,10 @@
   <form method="post" class="form form--single-column">
     {% csrf_token %}
     <div class="u-page-header">
-      <a href="{% url 'tenants:user_list' %}" class="back-button" aria-label="Назад" title="Назад">
+      <a href="{% url 'parohija:user_list' %}" class="back-button" aria-label="Назад" title="Назад">
         <i class="fa-solid fa-arrow-left"></i>
       </a>
-      <h1 class="u-page-title">Нови корисник — {{ tenant.naziv }}</h1>
+      <h1 class="u-page-title">Нови корисник — {{ parohija.parohija_naziv|default:parohija.naziv }}</h1>
       <button class="button button--primary" type="submit" title="Сачувај">
         <i class="fa-solid fa-floppy-disk" style="margin-right:6px;"></i> Сачувај
       </button>

--- a/crkva/registar/templates/registar/users_list.html
+++ b/crkva/registar/templates/registar/users_list.html
@@ -2,8 +2,8 @@
 
 {% block content %}
   <div class="u-page-header">
-    <h1 class="u-page-title">Корисници — {{ tenant.naziv }}</h1>
-    <a href="{% url 'tenants:user_add' %}" class="button button--primary" title="Додај корисника">
+    <h1 class="u-page-title">Корисници — {{ parohija.parohija_naziv|default:parohija.naziv }}</h1>
+    <a href="{% url 'parohija:user_add' %}" class="button button--primary" title="Додај корисника">
       <i class="fa-solid fa-user-plus" style="margin-right:6px;"></i> Додај корисника
     </a>
   </div>
@@ -36,7 +36,7 @@
           <td style="padding:var(--space-3);">{{ m.user.first_name }} {{ m.user.last_name }}</td>
           <td style="padding:var(--space-3);">{{ m.user.email|default:"—" }}</td>
           <td style="padding:var(--space-3);">
-            <form method="post" action="{% url 'tenants:user_edit_role' m.user.pk %}" style="display:inline-flex;gap:8px;align-items:center;">
+            <form method="post" action="{% url 'parohija:user_edit_role' m.user.pk %}" style="display:inline-flex;gap:8px;align-items:center;">
               {% csrf_token %}
               <select name="role" onchange="this.form.submit()" class="list-toolbar__select">
                 {% for value, label in m.Role.choices %}{% endfor %}
@@ -56,7 +56,7 @@
           </td>
           <td style="padding:var(--space-3);text-align:right;">
             {% if m.user.pk != request.user.pk %}
-              <form method="post" action="{% url 'tenants:user_deactivate' m.user.pk %}" style="display:inline;" onsubmit="return confirm('{% if m.user.is_active %}Деактивирати{% else %}Активирати{% endif %} {{ m.user.username }}?');">
+              <form method="post" action="{% url 'parohija:user_deactivate' m.user.pk %}" style="display:inline;" onsubmit="return confirm('{% if m.user.is_active %}Деактивирати{% else %}Активирати{% endif %} {{ m.user.username }}?');">
                 {% csrf_token %}
                 <button type="submit" class="button button--ghost" title="{% if m.user.is_active %}Деактивирај{% else %}Активирај{% endif %}">
                   <i class="fa-solid {% if m.user.is_active %}fa-user-slash{% else %}fa-user-check{% endif %}"></i>

--- a/crkva/registar/templates/sidebar.html
+++ b/crkva/registar/templates/sidebar.html
@@ -107,15 +107,15 @@
       <span class="sidebar-text">Тема</span>
     </button>
 
-    {% if is_tenant_admin %}
-    <a href="{% url 'tenants:user_list' %}" class="sidebar-action-btn {% if request.path == '/tenant/users/' or request.path|slice:':14' == '/tenant/users/' %}active{% endif %}" title="Корисници" aria-label="Корисници">
+    {% if is_parohija_admin %}
+    <a href="{% url 'parohija:user_list' %}" class="sidebar-action-btn {% if request.path == '/parohija/users/' or request.path|slice:':16' == '/parohija/users/' %}active{% endif %}" title="Корисници" aria-label="Корисници">
       <i class="fa-solid fa-users-gear"></i>
       <span class="sidebar-text">Корисници</span>
     </a>
     {% endif %}
 
     {% if user.is_authenticated %}
-    <a href="{% url 'tenants:profile' %}" class="sidebar-action-btn {% if request.path == '/tenant/profile/' %}active{% endif %}" title="Профил" aria-label="Профил">
+    <a href="{% url 'parohija:profile' %}" class="sidebar-action-btn {% if request.path == '/parohija/profile/' %}active{% endif %}" title="Профил" aria-label="Профил">
       <i class="fa-solid fa-user"></i>
       <span class="sidebar-text">{{ user.username }}</span>
     </a>

--- a/crkva/tenants/context_processors.py
+++ b/crkva/tenants/context_processors.py
@@ -14,12 +14,22 @@ from tenants.permissions import (
 
 
 def current_tenant(request):
-    """Make request.tenant, can_edit_<resource>, and is_admin available."""
+    """Make request.tenant, can_edit_<resource>, and is_admin available.
+
+    Templates may use either `tenant`/`is_tenant_admin` (django-tenants
+    schema-level naming) or the user-facing aliases `parohija`/
+    `is_parohija_admin` interchangeably.
+    """
     tenant = getattr(request, "tenant", None)
     user = getattr(request, "user", None)
+    admin_flag = is_tenant_admin(user, tenant)
     return {
+        # django-tenants infrastructure naming (kept for backwards compat)
         "tenant": tenant,
-        "is_tenant_admin": is_tenant_admin(user, tenant),
+        "is_tenant_admin": admin_flag,
+        # User-facing aliases — preferred in new templates.
+        "parohija": tenant,
+        "is_parohija_admin": admin_flag,
         "can_edit_osoba": can_edit(user, tenant, OSOBA),
         "can_edit_domacinstvo": can_edit(user, tenant, DOMACINSTVO),
         "can_edit_krstenje": can_edit(user, tenant, KRSTENJE),

--- a/crkva/tenants/tests/test_profile.py
+++ b/crkva/tenants/tests/test_profile.py
@@ -10,7 +10,7 @@ User = get_user_model()
 
 
 class ProfileViewTests(TestCase):
-    """Smoke tests for /tenant/profile/ info + password change."""
+    """Smoke tests for /parohija/profile/ info + password change."""
 
     @classmethod
     def setUpTestData(cls):
@@ -22,7 +22,7 @@ class ProfileViewTests(TestCase):
         self.client = Client()
 
     def url(self):
-        return reverse("tenants:profile")
+        return reverse("parohija:profile")
 
     def test_anonymous_redirects_to_login(self):
         r = self.client.get(self.url())

--- a/crkva/tenants/tests/test_switch.py
+++ b/crkva/tenants/tests/test_switch.py
@@ -48,7 +48,7 @@ class SwitchTenantViewTests(TestCase):
         self.client = Client()
 
     def url(self, tenant_id):
-        return reverse("tenants:switch", kwargs={"tenant_id": tenant_id})
+        return reverse("parohija:switch", kwargs={"tenant_id": tenant_id})
 
     def test_anonymous_redirects_to_login(self):
         r = self.client.post(self.url(self.tenant_a.pk))

--- a/crkva/tenants/tests/test_user_management.py
+++ b/crkva/tenants/tests/test_user_management.py
@@ -11,7 +11,7 @@ User = get_user_model()
 
 
 class UserManagementViewTests(TestCase):
-    """Smoke tests for /tenant/users/ list, add, role-edit, deactivate."""
+    """Smoke tests for /parohija/users/ list, add, role-edit, deactivate."""
 
     @classmethod
     def setUpTestData(cls):
@@ -53,18 +53,18 @@ class UserManagementViewTests(TestCase):
     # ----- list -----
 
     def test_anonymous_redirects_to_login(self):
-        r = self.client.get(reverse("tenants:user_list"))
+        r = self.client.get(reverse("parohija:user_list"))
         self.assertEqual(r.status_code, 302)
         self.assertIn("/prijava/", r["Location"])
 
     def test_non_admin_forbidden(self):
         self.client.force_login(self.clerk)
-        r = self.client.get(reverse("tenants:user_list"))
+        r = self.client.get(reverse("parohija:user_list"))
         self.assertEqual(r.status_code, 403)
 
     def test_admin_sees_only_their_tenants_users(self):
         self.client.force_login(self.admin)
-        r = self.client.get(reverse("tenants:user_list"))
+        r = self.client.get(reverse("parohija:user_list"))
         self.assertEqual(r.status_code, 200)
         usernames = [m.user.username for m in r.context["memberships"]]
         self.assertIn("adm", usernames)
@@ -78,7 +78,7 @@ class UserManagementViewTests(TestCase):
         self.client.force_login(self.admin)
         before = User.objects.count()
         r = self.client.post(
-            reverse("tenants:user_add"),
+            reverse("parohija:user_add"),
             {
                 "username": "newuser",
                 "password": "veryStrong!Pass1",
@@ -99,7 +99,7 @@ class UserManagementViewTests(TestCase):
     def test_non_admin_cannot_add_user(self):
         self.client.force_login(self.clerk)
         r = self.client.post(
-            reverse("tenants:user_add"),
+            reverse("parohija:user_add"),
             {
                 "username": "nope",
                 "password": "veryStrong!Pass1",
@@ -111,7 +111,7 @@ class UserManagementViewTests(TestCase):
     def test_duplicate_username_rejected(self):
         self.client.force_login(self.admin)
         r = self.client.post(
-            reverse("tenants:user_add"),
+            reverse("parohija:user_add"),
             {
                 "username": "kanc",  # already exists
                 "password": "veryStrong!Pass1",
@@ -126,7 +126,7 @@ class UserManagementViewTests(TestCase):
     def test_admin_can_change_role(self):
         self.client.force_login(self.admin)
         r = self.client.post(
-            reverse("tenants:user_edit_role", kwargs={"user_id": self.clerk.pk}),
+            reverse("parohija:user_edit_role", kwargs={"user_id": self.clerk.pk}),
             {"role": Role.PREGLED},
         )
         self.assertEqual(r.status_code, 302)
@@ -137,7 +137,7 @@ class UserManagementViewTests(TestCase):
         self.client.force_login(self.admin)
         r = self.client.post(
             reverse(
-                "tenants:user_edit_role", kwargs={"user_id": self.foreign_clerk.pk}
+                "parohija:user_edit_role", kwargs={"user_id": self.foreign_clerk.pk}
             ),
             {"role": Role.PREGLED},
         )
@@ -152,7 +152,7 @@ class UserManagementViewTests(TestCase):
     def test_admin_can_deactivate_user(self):
         self.client.force_login(self.admin)
         r = self.client.post(
-            reverse("tenants:user_deactivate", kwargs={"user_id": self.clerk.pk}),
+            reverse("parohija:user_deactivate", kwargs={"user_id": self.clerk.pk}),
         )
         self.assertEqual(r.status_code, 302)
         self.clerk.refresh_from_db()
@@ -161,7 +161,7 @@ class UserManagementViewTests(TestCase):
     def test_admin_cannot_deactivate_self(self):
         self.client.force_login(self.admin)
         r = self.client.post(
-            reverse("tenants:user_deactivate", kwargs={"user_id": self.admin.pk}),
+            reverse("parohija:user_deactivate", kwargs={"user_id": self.admin.pk}),
         )
         self.assertEqual(r.status_code, 302)
         self.admin.refresh_from_db()
@@ -171,7 +171,7 @@ class UserManagementViewTests(TestCase):
         self.client.force_login(self.admin)
         r = self.client.post(
             reverse(
-                "tenants:user_deactivate", kwargs={"user_id": self.foreign_clerk.pk}
+                "parohija:user_deactivate", kwargs={"user_id": self.foreign_clerk.pk}
             ),
         )
         self.assertEqual(r.status_code, 404)

--- a/crkva/tenants/urls.py
+++ b/crkva/tenants/urls.py
@@ -3,7 +3,7 @@
 from django.urls import path
 from tenants import views
 
-app_name = "tenants"
+app_name = "parohija"
 
 urlpatterns = [
     path("switch/<int:tenant_id>/", views.switch_tenant, name="switch"),

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -58,14 +58,14 @@ def profile(request: HttpRequest) -> HttpResponse:
             if info_form.is_valid():
                 info_form.save()
                 messages.success(request, "Подаци сачувани.")
-                return redirect("tenants:profile")
+                return redirect("parohija:profile")
         elif action == "password":
             password_form = PasswordChangeForm(user=request.user, data=request.POST)
             if password_form.is_valid():
                 user = password_form.save()
                 update_session_auth_hash(request, user)
                 messages.success(request, "Лозинка промењена.")
-                return redirect("tenants:profile")
+                return redirect("parohija:profile")
 
     return render(
         request,
@@ -109,7 +109,7 @@ def user_add(request: HttpRequest) -> HttpResponse:
             is_default=data["is_default"],
         )
         messages.success(request, f"Корисник {user.username} креиран.")
-        return redirect("tenants:user_list")
+        return redirect("parohija:user_list")
     return render(request, "registar/users_add.html", {"form": form})
 
 
@@ -125,7 +125,7 @@ def user_edit_role(request: HttpRequest, user_id: int) -> HttpResponse:
         membership.role = form.cleaned_data["role"]
         membership.save(update_fields=["role"])
         messages.success(request, f"Улога ажурирана за {membership.user.username}.")
-    return redirect("tenants:user_list")
+    return redirect("parohija:user_list")
 
 
 @tenant_admin_required
@@ -138,9 +138,9 @@ def user_deactivate(request: HttpRequest, user_id: int) -> HttpResponse:
     target = membership.user
     if target.pk == request.user.pk:
         messages.error(request, "Не можете деактивирати свој налог.")
-        return redirect("tenants:user_list")
+        return redirect("parohija:user_list")
     target.is_active = not target.is_active
     target.save(update_fields=["is_active"])
     verb = "активиран" if target.is_active else "деактивиран"
     messages.success(request, f"Корисник {target.username} {verb}.")
-    return redirect("tenants:user_list")
+    return redirect("parohija:user_list")


### PR DESCRIPTION
…els)

- URL prefix /tenant/ -> /parohija/ and URL namespace tenants -> parohija
- Page titles use parohija_naziv (Serbian Cyrillic "парохија") instead of raw tenant.naziv
- Context processor exposes parohija/is_parohija_admin aliases alongside tenant/is_tenant_admin
- Keep tenants Django app, Tenant model and django-tenants Postgres schema infra untouched to avoid destructive multi-tenant DB rename