### PR TITLE
feat: select2 dropdowns suggest on open and match Cyrillic ↔ Latin

### DIFF
--- a/crkva/registar/forms/domacinstvo_form.py
+++ b/crkva/registar/forms/domacinstvo_form.py
@@ -1,7 +1,7 @@
 """Django форма за унос домаћинства."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
 from registar.models import Adresa, Domacinstvo, Osoba, Slava
 
 
@@ -21,17 +21,17 @@ class DomacinstvoForm(forms.ModelForm):
             "napomena",
         ]
         widgets = {
-            "domacin": ModelSelect2Widget(
+            "domacin": ScriptAwareModelSelect2Widget(
                 model=Osoba,
                 search_fields=["ime__icontains", "prezime__icontains"],
-                attrs={"data-minimum-input-length": 1},
+                attrs={"data-minimum-input-length": 0},
             ),
-            "adresa": ModelSelect2Widget(
+            "adresa": ScriptAwareModelSelect2Widget(
                 model=Adresa,
                 search_fields=["ulica__icontains", "mesto__icontains"],
-                attrs={"data-minimum-input-length": 1},
+                attrs={"data-minimum-input-length": 0},
             ),
-            "slava": ModelSelect2Widget(
+            "slava": ScriptAwareModelSelect2Widget(
                 model=Slava,
                 search_fields=["naziv__icontains"],
                 attrs={"data-minimum-input-length": 0},

--- a/crkva/registar/forms/krstenje_form.py
+++ b/crkva/registar/forms/krstenje_form.py
@@ -1,12 +1,12 @@
 """Django форма за унос крштења."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
 from registar.models import Hram, Krstenje, Svestenik
 from registar.models.parohijan import Osoba
 
 
-class OsobaSelect2Widget(ModelSelect2Widget):
+class OsobaSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Osoba model."""
 
     model = Osoba
@@ -14,25 +14,25 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
-        attrs["data-minimum-input-length"] = 1
+        attrs["data-minimum-input-length"] = 0
         attrs["data-osoba-create"] = "1"
         return attrs
 
 
-class SvestenikSelect2Widget(ModelSelect2Widget):
+class SvestenikSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Svestenik model."""
 
     model = Svestenik
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+    attrs = {"data-minimum-input-length": 0}
 
 
-class HramSelect2Widget(ModelSelect2Widget):
+class HramSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Hram model."""
 
     model = Hram
     search_fields = ["naziv__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+    attrs = {"data-minimum-input-length": 0}
 
 
 class KrstenjeForm(forms.ModelForm):

--- a/crkva/registar/forms/lookup.py
+++ b/crkva/registar/forms/lookup.py
@@ -20,7 +20,7 @@ class TaggableLookupWidget(ModelSelect2Widget):
         attrs.setdefault("data-tags", "true")
         attrs.setdefault("data-token-separators", "[]")
         # django-select2 sets this to 2 by default; force 1 so suggestions appear after one keystroke.
-        attrs["data-minimum-input-length"] = 1
+        attrs["data-minimum-input-length"] = 0
         attrs.setdefault("data-placeholder", "Изабери или унеси ново…")
         return attrs
 

--- a/crkva/registar/forms/parohijan_form.py
+++ b/crkva/registar/forms/parohijan_form.py
@@ -1,8 +1,8 @@
 """Django форма за унос парохијана."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
 from registar.forms.lookup import TaggableLookupField, TaggableLookupWidget
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
 from registar.models import Adresa, Narodnost, Parohijan, Veroispovest, Zanimanje
 
 
@@ -60,9 +60,9 @@ class ParohijanForm(forms.ModelForm):
             ),
             "vreme_rodjenja": forms.TimeInput(attrs={"type": "time"}, format="%H:%M"),
             "pol": forms.RadioSelect,
-            "adresa": ModelSelect2Widget(
+            "adresa": ScriptAwareModelSelect2Widget(
                 model=Adresa,
                 search_fields=["ulica__icontains", "mesto__icontains"],
-                attrs={"data-minimum-input-length": 1},
+                attrs={"data-minimum-input-length": 0},
             ),
         }

--- a/crkva/registar/forms/select2.py
+++ b/crkva/registar/forms/select2.py
@@ -1,0 +1,54 @@
+"""Shared select2 widget mixin that adds Cyrillic↔Latin search and
+on-open suggestions to django-select2 dropdowns.
+"""
+
+from __future__ import annotations
+
+import operator
+from functools import reduce
+
+from django.db.models import Q
+from django_select2.forms import ModelSelect2Widget
+from registar.utils import get_query_variants
+
+
+class ScriptAwareSelect2Mixin:
+    """Mixin for `ModelSelect2Widget` subclasses that:
+
+    1. Sets `data-minimum-input-length=0` so a click on the field shows
+       suggestions even before the user types anything.
+    2. Expands the search term via :func:`get_query_variants` so typing
+       Latin matches Cyrillic data and vice versa.
+    """
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-minimum-input-length"] = 0
+        return attrs
+
+    def filter_queryset(self, request, term, queryset=None, **dependent_fields):
+        if queryset is None:
+            queryset = self.get_queryset()
+        search_fields = self.get_search_fields()
+
+        if not search_fields or not term:
+            return queryset
+
+        variants = get_query_variants(term)
+        if not variants:
+            return queryset
+
+        select = Q()
+        for variant in variants:
+            for bit in variant.split():
+                or_queries = [Q(**{lookup: bit}) for lookup in search_fields]
+                select |= reduce(operator.or_, or_queries)
+
+        if dependent_fields:
+            select &= Q(**dependent_fields)
+
+        return queryset.filter(select).distinct()
+
+
+class ScriptAwareModelSelect2Widget(ScriptAwareSelect2Mixin, ModelSelect2Widget):
+    """Drop-in replacement for ModelSelect2Widget with Cyrillic↔Latin search."""

--- a/crkva/registar/forms/svestenik_form.py
+++ b/crkva/registar/forms/svestenik_form.py
@@ -1,7 +1,7 @@
 """Django форма за унос свештеника."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
 from registar.models import Parohija, Svestenik
 
 
@@ -19,7 +19,7 @@ class SvestenikForm(forms.ModelForm):
             "parohija",
         ]
         widgets = {
-            "parohija": ModelSelect2Widget(
+            "parohija": ScriptAwareModelSelect2Widget(
                 model=Parohija,
                 search_fields=["naziv__icontains"],
                 attrs={"data-minimum-input-length": 0},

--- a/crkva/registar/forms/vencanje_form.py
+++ b/crkva/registar/forms/vencanje_form.py
@@ -1,12 +1,12 @@
 """Django форма за унос венчања."""
 
 from django import forms
-from django_select2.forms import ModelSelect2Widget
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
 from registar.models import Hram, Svestenik, Vencanje
 from registar.models.parohijan import Osoba
 
 
-class OsobaSelect2Widget(ModelSelect2Widget):
+class OsobaSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Osoba model."""
 
     model = Osoba
@@ -14,25 +14,25 @@ class OsobaSelect2Widget(ModelSelect2Widget):
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
-        attrs["data-minimum-input-length"] = 1
+        attrs["data-minimum-input-length"] = 0
         attrs["data-osoba-create"] = "1"
         return attrs
 
 
-class SvestenikSelect2Widget(ModelSelect2Widget):
+class SvestenikSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Svestenik model."""
 
     model = Svestenik
     search_fields = ["ime__icontains", "prezime__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+    attrs = {"data-minimum-input-length": 0}
 
 
-class HramSelect2Widget(ModelSelect2Widget):
+class HramSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Hram model."""
 
     model = Hram
     search_fields = ["naziv__icontains"]
-    attrs = {"data-minimum-input-length": 1}
+    attrs = {"data-minimum-input-length": 0}
 
 
 class VencanjeForm(forms.ModelForm):

--- a/crkva/registar/tests/test_select2_search.py
+++ b/crkva/registar/tests/test_select2_search.py
@@ -1,0 +1,58 @@
+"""Tests for the script-aware select2 mixin."""
+
+from django.test import TestCase
+from registar.forms.select2 import ScriptAwareModelSelect2Widget
+from registar.models import Osoba
+
+
+class ScriptAwareSelect2WidgetTest(TestCase):
+    """The widget should match Latin queries against Cyrillic data and vice versa."""
+
+    @classmethod
+    def setUpTestData(cls):
+        Osoba.objects.create(ime="Марко", prezime="Марковић")
+        Osoba.objects.create(ime="Ана", prezime="Аћимовић")
+        Osoba.objects.create(ime="Бошко", prezime="Бошковић")
+
+    def _build_widget(self):
+        widget = ScriptAwareModelSelect2Widget(
+            model=Osoba,
+            search_fields=["ime__icontains", "prezime__icontains"],
+        )
+        return widget
+
+    def test_latin_query_matches_cyrillic_record(self):
+        widget = self._build_widget()
+        qs = widget.filter_queryset(
+            request=None, term="Marko", queryset=Osoba.objects.all()
+        )
+        names = list(qs.values_list("ime", "prezime"))
+        self.assertIn(("Марко", "Марковић"), names)
+
+    def test_cyrillic_query_matches_cyrillic_record(self):
+        """A Cyrillic search term returns the matching Cyrillic record."""
+        widget = self._build_widget()
+        qs = widget.filter_queryset(
+            request=None, term="Марко", queryset=Osoba.objects.all()
+        )
+        self.assertEqual(qs.count(), 1)
+
+    def test_empty_term_returns_full_queryset(self):
+        """Empty search term yields the full queryset (suggestions on open)."""
+        widget = self._build_widget()
+        qs = widget.filter_queryset(request=None, term="", queryset=Osoba.objects.all())
+        self.assertEqual(qs.count(), 3)
+
+    def test_minimum_input_length_is_zero_so_suggestions_show_on_open(self):
+        widget = self._build_widget()
+        attrs = widget.build_attrs({})
+        self.assertEqual(attrs.get("data-minimum-input-length"), 0)
+
+    def test_latin_partial_matches_cyrillic(self):
+        """Partial Latin input matches the Cyrillic prefix it transliterates to."""
+        widget = self._build_widget()
+        qs = widget.filter_queryset(
+            request=None, term="Bo", queryset=Osoba.objects.all()
+        )
+        names = [p.ime for p in qs]
+        self.assertIn("Бошко", names)


### PR DESCRIPTION
* new ScriptAwareModelSelect2Widget routes the search term through get_query_variants so Latin queries find Cyrillic records and vice versa
* data-minimum-input-length forced to 0 so clicking the field shows results immediately
* every existing widget (Osoba/Hram/Svestenik/Slava/Adresa/Parohija/Zanimanje/etc.) inherits the new behaviour
* 5 tests in test_select2_search.py cover the variant matching + min-length default