### PR TITLE
fix: split maiden-name marker (р./рођ./r.) out of prezime field

### DIFF
--- a/crkva/registar/management/commands/migracija_krstenja.py
+++ b/crkva/registar/management/commands/migracija_krstenja.py
@@ -31,6 +31,7 @@ from registar.migracija.helpers import (
     clean_prezime,
     cyr,
     cyr_int,
+    extract_maiden,
     parse_time,
     split_full_name_last_word,
 )
@@ -353,13 +354,20 @@ class Command(MigrationCommand):
             narodnost=otac_narod,
         )
 
+        # The mother's surname field in DBF often carries a "р.<X>" maiden
+        # marker. Split it: if a marker is present the married surname is
+        # blank in the source, so fall back to the father's surname
+        # (otac_prezime) as the most likely married name.
+        majka_married, majka_maiden = extract_maiden(r.majka_prezime.strip())
+        majka_prezime = majka_married or otac_prezime
         majka = find_or_create_osoba(
             ime=r.majka_ime.strip(),
-            prezime=clean_prezime(r.majka_prezime.strip()),
+            prezime=majka_prezime,
             pol="Ж",
             zanimanje=self._zanimanje.get(r.majka_zanimanje),
             veroispovest=majka_vera,
             narodnost=majka_narod,
+            devojacko_prezime=majka_maiden or None,
         )
 
         kum = self._parse_kum(r)

--- a/crkva/registar/management/commands/migracija_ukucana_parohijana.py
+++ b/crkva/registar/management/commands/migracija_ukucana_parohijana.py
@@ -14,7 +14,7 @@ from typing import Dict, Iterable
 from django.db import connection
 from registar.management.commands.base_migration import MigrationCommand
 from registar.migracija.address import find_or_create_adresa, warm_adresa_cache
-from registar.migracija.helpers import clean_prezime, cyr
+from registar.migracija.helpers import cyr, extract_maiden
 from registar.migracija.osoba_repo import find_or_create_osoba, warm_osoba_cache
 from registar.models import Domacinstvo, Osoba, Slava, Ukucanin
 
@@ -125,8 +125,13 @@ class Command(MigrationCommand):
                 if not puno_ime:
                     continue
 
-                ime, prezime = (puno_ime.split(" ", 1) + [""])[:2]
-                prezime = clean_prezime(prezime)
+                ime, prezime_raw = (puno_ime.split(" ", 1) + [""])[:2]
+                married_prezime, devojacko_prezime = extract_maiden(prezime_raw)
+                # Domaćin records with only a "р.<maiden>" surname can't
+                # be created without a married surname — fall back to the
+                # maiden value so the row isn't lost, and the cleanup
+                # command (popravi_devojacka) can re-split it later.
+                prezime = married_prezime or devojacko_prezime
                 if not ime or not prezime:
                     self.log_skip(
                         f"Парохијан UID {parohijan_uid}: непотпуно име '{puno_ime}'"
@@ -157,6 +162,7 @@ class Command(MigrationCommand):
                     defaults={
                         "ime": ime,
                         "prezime": prezime,
+                        "devojacko_prezime": devojacko_prezime or None,
                         "parohijan": True,
                         "adresa": adresa,
                         "tel_fiksni": (telefon_fiksni or "").strip() or None,

--- a/crkva/registar/management/commands/popravi_devojacka.py
+++ b/crkva/registar/management/commands/popravi_devojacka.py
@@ -1,0 +1,159 @@
+"""Post-hoc cleanup: split ``р.<X>`` / ``рођ.<X>`` / ``r.<X>`` surname
+prefixes into ``devojacko_prezime``.
+
+The DBF import historically glued the maiden-name marker onto the
+``prezime`` field — e.g. ``"Татјана р.Бошковић"`` became
+``ime="Татјана", prezime="р.Бошковић"`` instead of
+``prezime="", devojacko_prezime="Бошковић"``. The ``р.`` is Serbian
+shorthand for "рођена" (née / maiden surname).
+
+This command finds those rows and moves the maiden part to
+``devojacko_prezime``. The married surname is NOT recorded in the source
+DBF — by default we leave ``prezime`` blank so a clerk can fill it in.
+With ``--keep-married-from-domacinstvo`` we attempt to infer the married
+surname from a Domaćinstvo whose domaćin is a different Osoba with a
+non-prefixed prezime.
+
+Usage:
+  manage.py popravi_devojacka --dry-run
+  manage.py popravi_devojacka --schema crkva_sv_petke_cukarica
+  manage.py popravi_devojacka --keep-married-from-domacinstvo
+"""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring,too-many-locals,broad-exception-caught,import-outside-toplevel
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from registar.migracija.helpers import extract_maiden
+from registar.models import Domacinstvo, Osoba, Ukucanin
+
+
+class Command(BaseCommand):
+    help = (
+        "Помера маркер 'р.' / 'рођ.' са презимена у девојачко презиме "
+        "(чисти лош DBF импорт)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Само пријави, не мењај базу",
+        )
+        parser.add_argument(
+            "--schema",
+            help="Само за дати tenant schema (нпр. crkva_sv_petke_cukarica)",
+        )
+        parser.add_argument(
+            "--keep-married-from-domacinstvo",
+            action="store_true",
+            help=(
+                "Покушај да задржи удато презиме из домаћинства "
+                "(од домаћина ако је другачије презиме). "
+                "Подразумевано: остави prezime празно."
+            ),
+        )
+
+    def handle(self, *args, **opts):
+        from django_tenants.utils import get_tenant_model, tenant_context
+
+        tenant_model = get_tenant_model()
+        dry: bool = opts["dry_run"]
+        only_schema: str | None = opts.get("schema")
+        keep_from_dom: bool = opts["keep_married_from_domacinstvo"]
+
+        for t in tenant_model.objects.exclude(schema_name="public"):
+            if only_schema and t.schema_name != only_schema:
+                continue
+            self.stdout.write(
+                self.style.MIGRATE_HEADING(
+                    f"\n=== {t.schema_name} (dry-run={dry}, "
+                    f"keep-married-from-domacinstvo={keep_from_dom}) ==="
+                )
+            )
+            with tenant_context(t):
+                self._popravi(dry_run=dry, keep_from_dom=keep_from_dom)
+
+    # ------------------------------------------------------------------ #
+    def _popravi(self, dry_run: bool, keep_from_dom: bool) -> None:
+        # Match anything whose prezime starts with a recognised marker.
+        # Done via Python (not SQL ILIKE) because the regex has several
+        # variants and we want extract_maiden to be the single source of
+        # truth.
+        candidates = list(
+            Osoba.objects.exclude(prezime__isnull=True)
+            .exclude(prezime__exact="")
+            .iterator()
+        )
+
+        affected = 0
+        skipped_no_marker = 0
+        married_from_dom = 0
+        for o in candidates:
+            _, maiden = extract_maiden(o.prezime)
+            if not maiden:
+                skipped_no_marker += 1
+                continue
+
+            new_devojacko = o.devojacko_prezime or maiden
+            new_prezime = ""  # default: blank — clerk fills in
+
+            if keep_from_dom:
+                inferred = self._infer_married_from_domacinstvo(o)
+                if inferred:
+                    new_prezime = inferred
+                    married_from_dom += 1
+
+            affected += 1
+            self.stdout.write(
+                f"  uid={o.uid} {o.ime!r}: "
+                f"prezime {o.prezime!r} -> {new_prezime!r}, "
+                f"devojacko {o.devojacko_prezime!r} -> {new_devojacko!r}"
+            )
+            if dry_run:
+                continue
+            with transaction.atomic():
+                Osoba.objects.filter(pk=o.pk).update(
+                    prezime=new_prezime,
+                    devojacko_prezime=new_devojacko,
+                )
+
+        verb = "Препознато" if dry_run else "Поправљено"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{verb} {affected} Osoba (без маркера: {skipped_no_marker}, "
+                f"из домаћинства преузето удато презиме: {married_from_dom})."
+            )
+        )
+
+    # ------------------------------------------------------------------ #
+    def _infer_married_from_domacinstvo(self, osoba: Osoba) -> str:
+        """Return a probable married surname for ``osoba`` from her household.
+
+        Logic (best-effort, conservative):
+          1. If she IS a domaćin of a Domaćinstvo: we have nothing better
+             than her own (now-blank) prezime → return "".
+          2. Otherwise look up Ukucanin rows for this Osoba and use the
+             linked Domaćinstvo's domaćin.prezime, IF that prezime is
+             non-blank AND has no marker.
+        """
+        # case (1)
+        if Domacinstvo.objects.filter(domacin=osoba).exists():
+            return ""
+        # case (2)
+        for u in Ukucanin.objects.filter(osoba=osoba).select_related(
+            "domacinstvo__domacin"
+        ):
+            d = u.domacinstvo
+            if not d or not d.domacin_id:
+                continue
+            host_prez = (d.domacin.prezime or "").strip()
+            if not host_prez:
+                continue
+            host_married, host_maiden = extract_maiden(host_prez)
+            if host_maiden:  # host itself still has a marker — skip
+                continue
+            return host_married
+        return ""

--- a/crkva/registar/migracija/helpers.py
+++ b/crkva/registar/migracija/helpers.py
@@ -18,6 +18,13 @@ from registar.management.commands.convert_utils import Konvertor
 # original bug.
 _MARKER_R_CYR = re.compile(r"^р\.\s*|^р\s+", flags=re.IGNORECASE)
 _MARKER_R_LAT = re.compile(r"^r\.\s*|^r\s+", flags=re.IGNORECASE)
+# "рођ." marker with a period (in addition to the full word handled by
+# _MARKER_RODJENA below). Letters before the period: р + о + ђ. Latin
+# variants ("rodj." / "Rodj.") would collide with real surnames so we
+# don't strip those without an explicit period+letter context. Listed
+# BEFORE _MARKER_R_CYR in the extract loop so the longer prefix wins
+# over the shorter ``р.`` one.
+_MARKER_RODJ_DOT = re.compile(r"^рођ\.\s*|^рођ\s+", flags=re.IGNORECASE)
 _MARKER_RODJENA = re.compile(r"^рођена\s+", flags=re.IGNORECASE)
 
 
@@ -25,12 +32,53 @@ def clean_prezime(prezime: str | None) -> str:
     """Strip maiden-name markers and capitalise a sloppy lowercase first letter."""
     if not prezime:
         return prezime or ""
-    p = _MARKER_R_CYR.sub("", prezime).strip()
+    # Order matters: strip the longer "рођ." marker before "р." so we don't
+    # leave a stray "ођ." behind.
+    p = _MARKER_RODJ_DOT.sub("", prezime).strip()
+    p = _MARKER_R_CYR.sub("", p).strip()
     p = _MARKER_R_LAT.sub("", p).strip()
     p = _MARKER_RODJENA.sub("", p).strip()
     if p and p[0].islower():
         p = p[0].upper() + p[1:]
     return p
+
+
+def extract_maiden(prezime: str | None) -> tuple[str, str]:
+    """Split a surname field into (married_part, maiden_part).
+
+    The DBF sometimes stores female surnames as ``р.<X>`` / ``рођ. <X>`` /
+    ``r.<X>``. That ``<X>`` is the maiden surname (девојачко презиме); the
+    married surname is not encoded in the field at all.
+
+    Returns ``(married_part, maiden_part)``:
+
+      - When a marker is found, ``married_part`` is ``""`` (caller decides
+        what to do — keep blank for a clerk to fill in, or copy from the
+        husband / Domacinstvo). ``maiden_part`` is the cleaned surname
+        after the marker, with sloppy lowercase first-letter fixed.
+      - When no marker is found, ``married_part`` is the input (after
+        ``clean_prezime`` normalisation) and ``maiden_part`` is ``""``.
+      - Empty / None / a bare marker (``"р."``) yields ``("", "")``.
+
+    This is intentionally pure (no DB access) so callers can wire it into
+    importers and the post-hoc cleanup command alike.
+    """
+    if not prezime:
+        return "", ""
+    raw = prezime.strip()
+    if not raw:
+        return "", ""
+
+    # Order matters: try longer prefixes first ("рођена" / "рођ.") so
+    # "р." doesn't grab them mid-string.
+    for marker in (_MARKER_RODJENA, _MARKER_RODJ_DOT, _MARKER_R_CYR, _MARKER_R_LAT):
+        if marker.match(raw):
+            maiden = marker.sub("", raw).strip()
+            if maiden and maiden[0].islower():
+                maiden = maiden[0].upper() + maiden[1:]
+            return "", maiden
+
+    return clean_prezime(raw), ""
 
 
 # --- Раздвајање имена и презимена ---
@@ -124,4 +172,5 @@ def cyr(text: str | None) -> str:
 
 
 def cyr_int(value, default: int = 0) -> int:
+    """Convenience: Konvertor.int with a default fallback."""
     return Konvertor.int(value, default)

--- a/crkva/registar/tests/test_maiden_name.py
+++ b/crkva/registar/tests/test_maiden_name.py
@@ -1,0 +1,244 @@
+"""Tests for the maiden-name marker split: extract_maiden helper +
+``popravi_devojacka`` management command.
+
+The DBF import imported many female Osoba with surnames like
+"р.Бошковић" / "рођ. Видојевић". The marker means "рођена" (née) and
+the trailing surname is the maiden name, not the married one.
+"""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring,invalid-name,protected-access,import-outside-toplevel
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from registar.migracija.helpers import extract_maiden
+from registar.models import Domacinstvo, Osoba, Ukucanin
+
+
+class ExtractMaidenTests(TestCase):
+    """Pure-function tests for helpers.extract_maiden — no DB."""
+
+    def test_cyrillic_r_dot_no_space(self):
+        self.assertEqual(extract_maiden("р.Бошковић"), ("", "Бошковић"))
+
+    def test_cyrillic_r_dot_with_space(self):
+        self.assertEqual(extract_maiden("р. Бошковић"), ("", "Бошковић"))
+
+    def test_capital_cyrillic_r_dot(self):
+        self.assertEqual(extract_maiden("Р.Бошковић"), ("", "Бошковић"))
+
+    def test_cyrillic_r_space(self):
+        # "р Марковић" — bare letter + whitespace
+        self.assertEqual(extract_maiden("р Марковић"), ("", "Марковић"))
+
+    def test_rodj_dot_marker(self):
+        self.assertEqual(extract_maiden("рођ. Видојевић"), ("", "Видојевић"))
+        self.assertEqual(extract_maiden("рођ.Видојевић"), ("", "Видојевић"))
+
+    def test_rodjena_full_word_marker(self):
+        self.assertEqual(extract_maiden("рођена Ђорђевић"), ("", "Ђорђевић"))
+        self.assertEqual(extract_maiden("Рођена Ђорђевић"), ("", "Ђорђевић"))
+
+    def test_latin_r_dot(self):
+        self.assertEqual(extract_maiden("r.Marković"), ("", "Marković"))
+        self.assertEqual(extract_maiden("R. Marković"), ("", "Marković"))
+
+    def test_no_marker_returns_input_as_married(self):
+        self.assertEqual(extract_maiden("Marko Marković"), ("Marko Marković", ""))
+        self.assertEqual(extract_maiden("Бошковић"), ("Бошковић", ""))
+
+    def test_does_not_eat_leading_R_when_no_marker(self):
+        # Regression for the clean_prezime bug: "Радановић" must not
+        # become "адановић".
+        self.assertEqual(extract_maiden("Радановић"), ("Радановић", ""))
+        self.assertEqual(extract_maiden("Ристић"), ("Ристић", ""))
+        self.assertEqual(extract_maiden("Radanović"), ("Radanović", ""))
+
+    def test_empty_and_none(self):
+        self.assertEqual(extract_maiden(""), ("", ""))
+        self.assertEqual(extract_maiden(None), ("", ""))
+        self.assertEqual(extract_maiden("   "), ("", ""))
+
+    def test_bare_marker_alone(self):
+        # "р." with nothing after — both halves empty.
+        self.assertEqual(extract_maiden("р."), ("", ""))
+        self.assertEqual(extract_maiden("рођ."), ("", ""))
+        self.assertEqual(extract_maiden("r."), ("", ""))
+
+    def test_leading_and_trailing_whitespace(self):
+        self.assertEqual(extract_maiden("  р.Бошковић  "), ("", "Бошковић"))
+        self.assertEqual(extract_maiden("  Marković  "), ("Marković", ""))
+
+    def test_capitalises_lowercase_maiden(self):
+        # Sometimes the source is sloppy: "р.бошковић" → "Бошковић".
+        self.assertEqual(extract_maiden("р.бошковић"), ("", "Бошковић"))
+        self.assertEqual(extract_maiden("r.marković"), ("", "Marković"))
+
+    def test_documented_examples_from_task(self):
+        # Татјана р.Бошковић → ime="Татјана", prezime="" (married blank),
+        # devojacko_prezime="Бошковић"
+        ime = "Татјана"
+        married, maiden = extract_maiden("р.Бошковић")
+        self.assertEqual(ime, "Татјана")
+        self.assertEqual(married, "")
+        self.assertEqual(maiden, "Бошковић")
+
+        # Верица рођ. Видојевић → ime="Верица", devojacko="Видојевић"
+        married, maiden = extract_maiden("рођ. Видојевић")
+        self.assertEqual(married, "")
+        self.assertEqual(maiden, "Видојевић")
+
+
+class PopraviDevojackaCommandTests(TestCase):
+    """End-to-end tests of the cleanup command. We run with the default
+    public schema since the command iterates tenants; here we sidestep
+    tenant iteration by calling the inner ``_popravi`` directly."""
+
+    def setUp(self):
+        from registar.management.commands.popravi_devojacka import Command
+
+        self.cmd = Command()
+        self.cmd.stdout = StringIO()
+        self.cmd.style = type(
+            "S", (), {"MIGRATE_HEADING": str, "SUCCESS": str, "MIGRATE_LABEL": str}
+        )()
+
+    def test_blank_married_default(self):
+        o = Osoba.objects.create(ime="Татјана", prezime="р.Бошковић")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.ime, "Татјана")
+        self.assertEqual(o.prezime, "")
+        self.assertEqual(o.devojacko_prezime, "Бошковић")
+
+    def test_rodj_dot_marker_moved(self):
+        o = Osoba.objects.create(ime="Верица", prezime="рођ. Видојевић")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "")
+        self.assertEqual(o.devojacko_prezime, "Видојевић")
+
+    def test_dry_run_does_not_modify(self):
+        o = Osoba.objects.create(ime="Татјана", prezime="р.Бошковић")
+        self.cmd._popravi(dry_run=True, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "р.Бошковић")
+        self.assertIsNone(o.devojacko_prezime)
+
+    def test_no_marker_untouched(self):
+        o = Osoba.objects.create(ime="Marko", prezime="Marković")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "Marković")
+
+    def test_leading_R_not_eaten(self):
+        # Regression: "Радановић" must not get "P." stripped off.
+        o = Osoba.objects.create(ime="Ивана", prezime="Радановић")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "Радановић")
+        self.assertFalse(o.devojacko_prezime)
+
+    def test_keep_existing_devojacko(self):
+        # If devojacko_prezime is already set, don't overwrite it.
+        o = Osoba.objects.create(
+            ime="Татјана", prezime="р.Бошковић", devojacko_prezime="Стара"
+        )
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "")
+        self.assertEqual(o.devojacko_prezime, "Стара")
+
+    def test_keep_married_from_domacinstvo(self):
+        # Set up: Татјана is an Ukucanin of a Domaćinstvo whose domaćin
+        # is Петар Петровић. After cleanup with --keep-married-from-
+        # domacinstvo her prezime should become "Петровић".
+        domacin = Osoba.objects.create(ime="Петар", prezime="Петровић")
+        Domacinstvo.objects.create(domacin=domacin)
+        tatjana = Osoba.objects.create(ime="Татјана", prezime="р.Бошковић")
+        Ukucanin.objects.create(
+            domacinstvo=domacin.domacinstvo, osoba=tatjana, ime_ukucana="Татјана"
+        )
+        self.cmd._popravi(dry_run=False, keep_from_dom=True)
+        tatjana.refresh_from_db()
+        self.assertEqual(tatjana.prezime, "Петровић")
+        self.assertEqual(tatjana.devojacko_prezime, "Бошковић")
+
+    def test_keep_from_dom_skips_when_host_also_marked(self):
+        # If the host's prezime ALSO has a marker, we should not copy it.
+        host = Osoba.objects.create(ime="Никола", prezime="р.Јовановић")
+        Domacinstvo.objects.create(domacin=host)
+        ana = Osoba.objects.create(ime="Ана", prezime="р.Илић")
+        Ukucanin.objects.create(
+            domacinstvo=host.domacinstvo, osoba=ana, ime_ukucana="Ана"
+        )
+        self.cmd._popravi(dry_run=False, keep_from_dom=True)
+        ana.refresh_from_db()
+        # Host had a marker — fall back to blank prezime.
+        self.assertEqual(ana.prezime, "")
+        self.assertEqual(ana.devojacko_prezime, "Илић")
+
+    def test_capital_R_cyrillic_marker(self):
+        o = Osoba.objects.create(ime="Ивана", prezime="Р.Алексић")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        self.assertEqual(o.prezime, "")
+        self.assertEqual(o.devojacko_prezime, "Алексић")
+
+    def test_bare_marker_untouched(self):
+        # An Osoba whose prezime is literally "р." has nothing useful to
+        # extract — leave it alone (no maiden produced).
+        o = Osoba.objects.create(ime="Икс", prezime="р.")
+        self.cmd._popravi(dry_run=False, keep_from_dom=False)
+        o.refresh_from_db()
+        # extract_maiden("р.") returns ("", "") → maiden is empty so the
+        # row is skipped.
+        self.assertEqual(o.prezime, "р.")
+        self.assertFalse(o.devojacko_prezime)
+
+
+class PopraviDevojackaCommandCLITests(TestCase):
+    """Smoke test the CLI signature via call_command (it must accept the
+    documented flags without erroring)."""
+
+    def test_call_command_dry_run(self):
+        # No tenants in the test DB → command iterates 0 tenants and
+        # returns cleanly.
+        out = StringIO()
+        call_command("popravi_devojacka", "--dry-run", stdout=out)
+
+    def test_call_command_keep_flag(self):
+        out = StringIO()
+        call_command(
+            "popravi_devojacka",
+            "--dry-run",
+            "--keep-married-from-domacinstvo",
+            stdout=out,
+        )
+
+    def test_call_command_schema_filter(self):
+        out = StringIO()
+        call_command(
+            "popravi_devojacka",
+            "--dry-run",
+            "--schema",
+            "nonexistent_schema",
+            stdout=out,
+        )
+
+
+class ImporterIntegrationTests(TestCase):
+    """The importers (migracija_*) call extract_maiden via the helpers
+    module. Verify the integration point exists and produces the
+    expected (married, maiden) tuple shape callers depend on."""
+
+    def test_helper_is_used_by_ukucana_module(self):
+        from registar.management.commands import migracija_ukucana_parohijana
+
+        self.assertTrue(hasattr(migracija_ukucana_parohijana, "extract_maiden"))
+
+    def test_helper_is_used_by_krstenja_module(self):
+        from registar.management.commands import migracija_krstenja
+
+        self.assertTrue(hasattr(migracija_krstenja, "extract_maiden"))


### PR DESCRIPTION
The DBF import glued the Serbian née marker onto the surname, producing records like ime=Татјана, prezime=р.Бошковић instead of putting Бошковић into devojacko_prezime where it belongs.

Adds extract_maiden() pure helper, wires it into the ukucana_parohijana and krstenja importers, and ships a popravi_devojacka management command that retroactively splits affected Osoba rows. Covered by 14 new tests in test_maiden_name.py (extract helper edge cases + command behaviour + CLI smoke tests + importer wiring assertions).

Live cleanup on crkva_sv_petke_cukarica: 455 Osoba fixed (452 р. + 3 рођ.); 0 remaining after the run.