### PR TITLE
fix: /parohijani/ list now filters by parohijan=True

### DIFF
--- a/crkva/registar/tests/test_parohijani_filter.py
+++ b/crkva/registar/tests/test_parohijani_filter.py
@@ -1,0 +1,29 @@
+"""Test that /parohijani/ only shows Osobe with parohijan=True."""
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Osoba
+
+
+class SpisakParohijanaFiltersByParohijanFlag(TestCase):
+    """The list page is named 'парохијани' — must not include parohijan=False Osobe."""
+
+    def setUp(self):
+        self.client = Client()
+        Osoba.objects.create(ime="Парохијан", prezime="Прави", parohijan=True)
+        Osoba.objects.create(ime="Мати", prezime="Из крштења", parohijan=False)
+        Osoba.objects.create(
+            ime="Биљана", prezime="", devojacko_prezime="Томић", parohijan=False
+        )
+
+    def test_list_includes_only_parohijani(self):
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        self.assertIn("Парохијан Прави", body)
+        self.assertNotIn("Мати Из крштења", body)
+
+    def test_orphan_with_blank_prezime_is_excluded(self):
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        # The "Биљана" with parohijan=False and no surname must NOT leak in
+        self.assertNotIn(">Биљана<", body)

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -59,7 +59,8 @@ class SpisakParohijana(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
             "domacinstvo", "domacinstvo__domacin", "domacinstvo__adresa"
         )
         return self.get_search_queryset(
-            Parohijan.objects.select_related("adresa")
+            Parohijan.objects.filter(parohijan=True)
+            .select_related("adresa")
             .select_related("domacinstvo", "domacinstvo__adresa")
             .prefetch_related(
                 Prefetch(


### PR DESCRIPTION
* Parohijan = Osoba alias meant the list rendered every Osoba — including ~19k krstenje mothers / godparents / Ukucanin members without a household
* added .filter(parohijan=True) to SpisakParohijana.get_queryset
* 2 tests in test_parohijani_filter.py lock in the filter (real parohijan visible, non-parohijan excluded, blank-prezime orphan excluded)