### PR TITLE
fix: resolve FK PKs in history diff to readable labels

### DIFF
--- a/crkva/registar/history.py
+++ b/crkva/registar/history.py
@@ -1,18 +1,32 @@
 """Helpers for surfacing django-simple-history rows on detail pages.
 
-Each model with a `history` manager (HistoricalRecords) gets ordered
+Each model with a ``history`` manager (HistoricalRecords) gets ordered
 revisions. For each revision we compute the per-field diff against the
 previous revision, so the template can show 'who changed what, when'.
+
+ForeignKey-valued changes coming out of ``diff_against`` carry raw PK
+values (UUIDs, ints). To render them sensibly we resolve those PKs to
+the related model's ``__str__`` here, so templates can render the
+:class:`FieldChange` directly without knowing about FK plumbing.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+# Fallback string when a related row referenced by an old/new value can no
+# longer be loaded (e.g. it has been deleted since the revision was made).
+DELETED_LABEL = "(обрисано)"
+
 
 @dataclass(frozen=True)
 class FieldChange:
-    """One field change inside a single revision."""
+    """One field change inside a single revision.
+
+    ``old`` / ``new`` are the values as they will be rendered. For
+    ForeignKey fields they are already resolved to the related row's
+    ``__str__``; for everything else they are the raw scalar value.
+    """
 
     field: str
     old: object
@@ -38,10 +52,53 @@ ACTION_LABEL = {
 }
 
 
+def _resolve_fk_value(model, field_name: str, value):
+    """Return a display label for a FK ``value`` (PK), or ``value`` unchanged.
+
+    - ``None`` is passed through so the template's ``|default:"—"`` works.
+    - If the related instance can't be loaded (deleted row, wrong PK type,
+      schema mismatch) we fall back to :data:`DELETED_LABEL`.
+    - If ``field_name`` is not a relation on ``model`` we return ``value``
+      untouched (numbers, dates, booleans, strings stay as they are).
+    """
+    if value in (None, ""):
+        return value
+    try:
+        field = model._meta.get_field(field_name)
+    except Exception:  # pylint: disable=broad-except
+        return value
+    if not getattr(field, "is_relation", False):
+        return value
+    related = getattr(field, "related_model", None)
+    if related is None:
+        return value
+    try:
+        return str(related._default_manager.get(pk=value))
+    except related.DoesNotExist:  # pylint: disable=no-member
+        return DELETED_LABEL
+    except Exception:  # pylint: disable=broad-except
+        # Wrong PK type, multi-tenant routing surprises, etc. – degrade
+        # gracefully to the deleted label rather than raise on a panel.
+        return DELETED_LABEL
+
+
+def _resolve_change(model, field_name: str, old, new) -> tuple[object, object]:
+    """Resolve both ends of a diff entry. Returns ``(old, new)``."""
+    return (
+        _resolve_fk_value(model, field_name, old),
+        _resolve_fk_value(model, field_name, new),
+    )
+
+
 def history_for(instance, limit: int = 20) -> list[HistoryEntry]:
-    """Return up to `limit` revisions of `instance`, newest first."""
+    """Return up to ``limit`` revisions of ``instance``, newest first.
+
+    FK changes are resolved to the related row's ``__str__`` so templates
+    don't have to deal with raw PKs.
+    """
     if not hasattr(instance, "history"):
         return []
+    model = type(instance)
     records = list(
         instance.history.select_related("history_user").order_by("-history_date")[
             :limit
@@ -56,7 +113,8 @@ def history_for(instance, limit: int = 20) -> list[HistoryEntry]:
             try:
                 delta = rec.diff_against(prev)
                 for c in delta.changes:
-                    changes.append(FieldChange(field=c.field, old=c.old, new=c.new))
+                    old, new = _resolve_change(model, c.field, c.old, c.new)
+                    changes.append(FieldChange(field=c.field, old=old, new=new))
             except Exception:  # pylint: disable=broad-except
                 # If models differ between revisions diff_against can raise; ignore.
                 changes = []

--- a/crkva/registar/tests/test_history_display.py
+++ b/crkva/registar/tests/test_history_display.py
@@ -1,0 +1,89 @@
+"""Tests for FK-aware rendering of django-simple-history diffs.
+
+The history panel used to render FK changes as raw PKs/UUIDs, e.g.
+``zanimanje: — → f5f3a1b5-...``. After the fix the rendered value
+must be the related row's ``__str__`` (e.g. ``радник``).
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.test import TestCase
+from registar.history import DELETED_LABEL, history_for
+from registar.models import Osoba, Veroispovest, Zanimanje
+
+
+class HistoryFKDisplayTests(TestCase):
+    """``history_for()`` should resolve FK PKs to a readable label."""
+
+    def test_zanimanje_resolves_to_naziv_not_uuid(self):
+        radnik = Zanimanje.objects.create(sifra="1", naziv="радник")
+        o = Osoba.objects.create(ime="ФК", prezime="Тест1", pol="М")
+        o.zanimanje = radnik
+        o.save()
+
+        entries = history_for(o)
+        # newest first: the update we just did
+        update = entries[0]
+        change = next(c for c in update.changes if c.field == "zanimanje")
+        self.assertEqual(change.old, None)
+        self.assertEqual(change.new, "радник")
+        # Sanity: the raw PK must not leak through.
+        self.assertNotIn(str(radnik.pk), str(change.new))
+
+    def test_veroispovest_resolves_to_naziv_not_uuid(self):
+        pravo = Veroispovest.objects.create(naziv="православна")
+        o = Osoba.objects.create(ime="ФК", prezime="Тест2", pol="М")
+        o.veroispovest = pravo
+        o.save()
+
+        entries = history_for(o)
+        update = entries[0]
+        change = next(c for c in update.changes if c.field == "veroispovest")
+        self.assertEqual(change.new, "православна")
+        self.assertNotIn(str(pravo.pk), str(change.new))
+
+    def test_deleted_fk_target_falls_back_to_label(self):
+        z = Zanimanje.objects.create(sifra="2", naziv="привремено")
+        o = Osoba.objects.create(ime="ФК", prezime="Тест3", pol="М")
+        o.zanimanje = z
+        o.save()
+
+        # Wipe the FK target after the historical record was written; the
+        # historical row still points at the now-missing PK.
+        z.delete()
+
+        entries = history_for(o)
+        update = entries[0]
+        change = next(c for c in update.changes if c.field == "zanimanje")
+        self.assertEqual(change.new, DELETED_LABEL)
+
+    def test_non_fk_field_values_pass_through_unchanged(self):
+        o = Osoba.objects.create(ime="Скаларно", prezime="Прво", pol="М")
+        o.prezime = "Друго"
+        o.save()
+
+        entries = history_for(o)
+        update = entries[0]
+        change = next(c for c in update.changes if c.field == "prezime")
+        # Plain strings should not be touched by the FK resolver.
+        self.assertEqual(change.old, "Прво")
+        self.assertEqual(change.new, "Друго")
+
+    def test_template_renders_resolved_label_not_uuid(self):
+        """End-to-end: the panel template must show the readable label."""
+        from django.template import Context, Template
+
+        radnik = Zanimanje.objects.create(sifra="3", naziv="радник")
+        o = Osoba.objects.create(ime="Шаб.", prezime="Тест", pol="М")
+        o.zanimanje = radnik
+        o.save()
+
+        entries = history_for(o)
+        tpl = Template(
+            "{% for e in entries %}{% for c in e.changes %}"
+            "[{{ c.field }}:{{ c.old|default:'—' }}->{{ c.new|default:'—' }}]"
+            "{% endfor %}{% endfor %}"
+        )
+        rendered = tpl.render(Context({"entries": entries}))
+        self.assertIn("zanimanje:—->радник", rendered)
+        self.assertNotIn(str(radnik.pk), rendered)


### PR DESCRIPTION
History panel rendered FK changes as raw UUIDs/PKs (e.g. 'zanimanje: — → f5f3a1b5-...'). The diff coming out of django-simple-history's diff_against() carries raw PK values, so the template had nothing better to show.

history_for() now inspects the live model's _meta for each changed field; when the field is a relation it resolves the old/new PK to the related row's __str__. Deleted FK targets fall back to '(обрисано)'. Non-FK fields (strings, dates, booleans, numbers) are untouched.

Covered by registar.tests.test_history_display: zanimanje and veroispovest resolve to their naziv; deleted FK target falls back; non-FK fields pass through; end-to-end template render contains the label, not the UUID.