### PR TITLE
feat: render list-toolbar sort as a native <select> dropdown

### DIFF
--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -631,13 +631,62 @@ input.list-toolbar__search-input::placeholder {
     box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
 }
 
+/* Sort dropdown — matches the search-input frame next to it */
+.list-toolbar__sort {
+    position: relative;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+select.list-toolbar__sort-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    font-size: 14px;
+    line-height: 20px;
+    padding: 8px 36px 8px 14px;
+    min-height: 36px;
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23888%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
+    font-family: inherit;
+    box-shadow: none;
+    margin: 0;
+}
+
+select.list-toolbar__sort-select:hover {
+    background-color: var(--color-surface-2);
+    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
+}
+
+select.list-toolbar__sort-select:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+
+/* Native option list — ensure legibility in both light and dark themes */
+select.list-toolbar__sort-select option {
+    background-color: var(--color-surface);
+    color: var(--color-text);
+}
+
 @media (max-width: 640px) {
     .list-toolbar {
         flex-direction: column;
         align-items: stretch;
     }
     .list-toolbar__search,
-    .list-toolbar__select {
+    .list-toolbar__select,
+    .list-toolbar__sort,
+    .list-toolbar__sort-select {
         width: 100%;
     }
 }

--- a/crkva/registar/templates/registar/_list_toolbar.html
+++ b/crkva/registar/templates/registar/_list_toolbar.html
@@ -4,13 +4,12 @@
         <input type="search" name="search" value="{{ upit }}" placeholder="Претражи..." class="list-toolbar__search-input" autocomplete="off" aria-label="Претрага">
     </div>
     {% if sort_options %}
-    <div class="toggle-group toggle-group--sm" role="radiogroup" aria-label="Сортирање">
-        {% for value, label in sort_options %}
-        <label class="toggle-button">
-            <input type="radio" name="sort" value="{{ value }}"{% if current_sort == value %} checked{% endif %} onchange="this.form.submit()">
-            <span>{{ label }}</span>
-        </label>
-        {% endfor %}
+    <div class="list-toolbar__sort">
+        <select id="sort-select" name="sort" class="list-toolbar__sort-select" aria-label="Сортирање" onchange="this.form.submit()">
+            {% for value, label in sort_options %}
+            <option value="{{ value }}"{% if current_sort == value %} selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
     </div>
     {% endif %}
 

--- a/crkva/registar/tests/test_list_sort_dropdown.py
+++ b/crkva/registar/tests/test_list_sort_dropdown.py
@@ -1,0 +1,216 @@
+"""Tests for the sort-as-dropdown control in the list toolbar.
+
+The sort selector renders as a native <select> with name="sort" instead of the
+old segmented radio toggle. Submission of the parent form keeps the existing
+?sort=<value> contract validated by ListControlsMixin.get_ordering.
+"""
+
+import datetime
+import re
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Hram, Krstenje, Osoba, Svestenik, Vencanje
+
+
+class ListSortDropdownRendersAsSelectTests(TestCase):
+    """The sort control is a native <select name='sort'> dropdown."""
+
+    def setUp(self):
+        self.client = Client()
+        # A handful of parohijani so the list has rows to render.
+        Osoba.objects.create(ime="Ана", prezime="Андрић", parohijan=True)
+        Osoba.objects.create(ime="Бојан", prezime="Бркић", parohijan=True)
+        Osoba.objects.create(ime="Васа", prezime="Васић", parohijan=True)
+
+    def test_parohijani_renders_select_with_name_sort(self):
+        """The toolbar emits exactly one <select name='sort'> with the sort class."""
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        # A <select> with name="sort" is present (single source of truth).
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body.count("<select"), body.count('name="sort"'))
+        self.assertIn('name="sort"', body)
+        self.assertIn("list-toolbar__sort-select", body)
+
+    def test_parohijani_radio_toggle_is_gone(self):
+        """The old radio markup must no longer appear in the toolbar."""
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        # The old toggle put radios named "sort" — that pattern must not exist.
+        self.assertNotIn('type="radio" name="sort"', body)
+
+    def test_select_has_aria_label_sortiranje(self):
+        """Accessibility: the <select> exposes aria-label='Сортирање'."""
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        self.assertRegex(
+            body,
+            r'<select[^>]*\baria-label="Сортирање"',
+        )
+
+    def test_select_submits_form_onchange(self):
+        """Picking an option must submit the enclosing GET form."""
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        self.assertRegex(
+            body,
+            r'<select[^>]*\bonchange="this\.form\.submit\(\)"',
+        )
+
+    def test_no_visible_sortiranje_label_next_to_dropdown(self):
+        """The visible <label>Сортирање</label> must not appear.
+
+        Accessibility comes from aria-label on the <select>; the surrounding
+        toolbar must not render a visible "Сортирање" word.
+        """
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        # No <label ...>Сортирање</label> anywhere — visible or visually-hidden.
+        self.assertNotRegex(
+            body,
+            r"<label[^>]*>\s*Сортирање\s*</label>",
+        )
+        # The .list-toolbar__sort wrapper holds the <select> but no <label> child.
+        match = re.search(
+            r'<div class="list-toolbar__sort">(.*?)</div>',
+            body,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(match, "sort wrapper not rendered")
+        self.assertNotIn("<label", match.group(1))
+
+    def test_all_sort_options_appear_as_options(self):
+        """Every (value, label) in sort_options renders as an <option>."""
+        response = self.client.get(reverse("parohijani"))
+        body = response.content.decode()
+        sort_options = response.context["sort_options"]
+        self.assertTrue(sort_options, "view must declare sort_options")
+        for value, label in sort_options:
+            self.assertIn(f'value="{value}"', body, msg=f"option {value} missing")
+            self.assertIn(label, body, msg=f"label {label} missing")
+
+    def test_current_sort_option_is_selected(self):
+        """?sort=-prezime marks the matching <option> selected, not its prefix."""
+        response = self.client.get(reverse("parohijani") + "?sort=-prezime")
+        body = response.content.decode()
+        self.assertRegex(
+            body,
+            r'<option value="-prezime"[^>]*\bselected\b[^>]*>',
+        )
+        self.assertNotRegex(
+            body,
+            r'<option value="prezime"[^>]*\bselected\b[^>]*>',
+        )
+
+    def test_default_sort_marks_first_matching_option(self):
+        """?sort=prezime marks the matching <option> selected."""
+        response = self.client.get(reverse("parohijani") + "?sort=prezime")
+        body = response.content.decode()
+        self.assertRegex(
+            body,
+            r'<option value="prezime"[^>]*\bselected\b[^>]*>',
+        )
+
+    def test_unknown_sort_value_marks_no_option_selected(self):
+        """An out-of-list sort value yields a <select> with no selected option."""
+        response = self.client.get(reverse("parohijani") + "?sort=bogus")
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        # Pull out the inside of the sort <select> and check no option carries
+        # the `selected` attribute when the user passed an invalid value.
+        match = re.search(
+            r'<select[^>]*class="[^"]*list-toolbar__sort-select[^"]*"[^>]*>(.*?)</select>',
+            body,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(match, "sort <select> not rendered")
+        inner = match.group(1)
+        self.assertNotIn("selected", inner)
+
+
+class ListSortDropdownAcrossAllListPagesTests(TestCase):
+    """Every list page that declares sort_options must render the dropdown."""
+
+    def setUp(self):
+        self.client = Client()
+        self.hram = Hram.objects.create(naziv="Тест Храм")
+        # parohijani
+        Osoba.objects.create(ime="Петар", prezime="Петровић", parohijan=True)
+        # svestenici
+        Svestenik.objects.create(ime="Јован", prezime="Јовановић", zvanje="јереј")
+        # krstenja
+        Krstenje.objects.create(
+            knjiga=1,
+            broj=1,
+            strana=1,
+            redni_broj=1,
+            godina_registracije=2024,
+            datum=datetime.date(2024, 2, 10),
+            dete_vanbracno=False,
+            dete_blizanac=False,
+            dete_sa_telesnom_manom=False,
+            hram=self.hram,
+        )
+        # vencanja
+        Vencanje.objects.create(
+            knjiga=1,
+            broj=1,
+            strana=1,
+            redni_broj=1,
+            godina_registracije=2024,
+            datum=datetime.date(2024, 6, 1),
+            hram=self.hram,
+        )
+
+    def _assert_dropdown_rendered(self, url_name):
+        """Helper: GET <url_name> and assert the toolbar renders the dropdown."""
+        response = self.client.get(reverse(url_name))
+        self.assertEqual(response.status_code, 200, msg=url_name)
+        body = response.content.decode()
+        self.assertIn("list-toolbar__sort-select", body, msg=url_name)
+        self.assertIn('name="sort"', body, msg=url_name)
+        self.assertNotIn('type="radio" name="sort"', body, msg=url_name)
+
+    def test_parohijani(self):
+        """/parohijani/ renders the sort dropdown."""
+        self._assert_dropdown_rendered("parohijani")
+
+    def test_krstenja(self):
+        """/krstenja/ renders the sort dropdown."""
+        self._assert_dropdown_rendered("krstenja")
+
+    def test_vencanja(self):
+        """/vencanja/ renders the sort dropdown."""
+        self._assert_dropdown_rendered("vencanja")
+
+    def test_svestenici(self):
+        """/svestenici/ renders the sort dropdown."""
+        self._assert_dropdown_rendered("svestenici")
+
+    def test_domacinstva(self):
+        """/domacinstva/ renders the sort dropdown."""
+        self._assert_dropdown_rendered("domacinstva")
+
+
+class ListSortDropdownStillSortsTests(TestCase):
+    """The dropdown still drives ordering via the ?sort=<value> contract."""
+
+    def setUp(self):
+        self.client = Client()
+        # Three parohijani with surnames that have a deterministic order.
+        Osoba.objects.create(ime="А", prezime="Аврамовић", parohijan=True)
+        Osoba.objects.create(ime="Б", prezime="Бабић", parohijan=True)
+        Osoba.objects.create(ime="Ц", prezime="Цвијић", parohijan=True)
+
+    def test_ascending_sort_orders_object_list(self):
+        """?sort=prezime sorts the object list by surname ascending."""
+        response = self.client.get(reverse("parohijani") + "?sort=prezime")
+        ordering = [o.prezime for o in response.context["object_list"]]
+        self.assertEqual(ordering, sorted(ordering))
+
+    def test_descending_sort_orders_object_list(self):
+        """?sort=-prezime sorts the object list by surname descending."""
+        response = self.client.get(reverse("parohijani") + "?sort=-prezime")
+        ordering = [o.prezime for o in response.context["object_list"]]
+        self.assertEqual(ordering, sorted(ordering, reverse=True))


### PR DESCRIPTION
* old segmented radio toggle (.toggle-group / .toggle-button) took too much horizontal space when a list had 3-4 sort options
* replaced with a native <select name=\"sort\"> styled to match the search input box next to it (same height, border-radius, surface + border tokens, custom chevron via background-image)
* aria-label=\"Сортирање\" on the <select> preserves the accessibility name; no visible label (the selected option text is enough context)
* onchange=\"this.form.submit()\" keeps the ?sort=<value> contract that ListControlsMixin.get_ordering already validates — no Python changes needed
* spiskovi.css gets .list-toolbar__sort + .list-toolbar__sort-select; uses var(--color-surface) / var(--color-border) / var(--color-text) so both light and dark themes look right
* test_list_sort_dropdown.py (16 tests): markup is <select> not radios, every sort_options value renders as <option>, current_sort marks the right option as selected, unknown sort values mark nothing as selected, no visible <label>Сортирање</label> remains, all five list pages (parohijani/krstenja/vencanja/svestenici/domacinstva) render the dropdown, and ?sort=prezime / ?sort=-prezime still order the queryset