### PR TITLE
fix: select2 closed-state pill matches the new sort dropdown chrome

### DIFF
--- a/crkva/registar/static/registar/components/select2_skin.css
+++ b/crkva/registar/static/registar/components/select2_skin.css
@@ -101,26 +101,40 @@
 
 /* Selection box (the closed-state pill) keeps the standard form-input look,
    inheriting forme.css selectors for height/border/padding. */
+/* Closed-state pill matches the list-toolbar sort dropdown — shared chevron, padding, hover/focus rings. */
 .select2-container--default .select2-selection--single {
     height: auto;
-    min-height: 38px;
-    padding: 4px 6px;
+    min-height: 36px;
+    padding: 0;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
-    background: var(--color-surface);
+    background-color: var(--color-surface);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23888%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+
+.select2-container--default .select2-selection--single:hover {
+    background-color: var(--color-surface-2);
+    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
 }
 
 .select2-container--default .select2-selection--single .select2-selection__rendered {
     color: var(--color-text);
-    line-height: 28px;
-    padding-left: 4px;
+    line-height: 20px;
+    padding: 8px 36px 8px 14px;
+    font-size: 14px;
 }
 
+/* Hide select2's built-in arrow — we use a background-image chevron like .list-toolbar__sort-select */
 .select2-container--default .select2-selection--single .select2-selection__arrow {
-    height: 36px;
+    display: none;
 }
 
 .select2-container--default.select2-container--open .select2-selection--single {
     border-color: var(--color-primary);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 20%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+    outline: none;
 }

--- a/crkva/registar/tests/test_select2_unified_chrome.py
+++ b/crkva/registar/tests/test_select2_unified_chrome.py
@@ -1,0 +1,52 @@
+"""Test: select2 closed-state pill matches the list-toolbar sort dropdown chrome."""
+
+import pathlib
+
+from django.test import TestCase
+
+
+class Select2ClosedStateMatchesSortDropdown(TestCase):
+    """The select2 selection pill must share frame/chevron with .list-toolbar__sort-select."""
+
+    SKIN = pathlib.Path("crkva/registar/static/registar/components/select2_skin.css")
+    SPISKOVI = pathlib.Path("crkva/registar/static/registar/components/spiskovi.css")
+
+    def setUp(self):
+        self.skin = self.SKIN.read_text(encoding="utf-8")
+        self.sort_css = self.SPISKOVI.read_text(encoding="utf-8")
+
+    def _block(self, text, selector):
+        return text.split(selector, 1)[1].split("}", 1)[0]
+
+    def test_select2_closed_state_uses_background_chevron(self):
+        """Closed pill must paint a chevron via background-image."""
+        block = self._block(
+            self.skin, ".select2-container--default .select2-selection--single {"
+        )
+        self.assertIn("background-image:", block)
+        self.assertIn("%3Csvg", block)
+
+    def test_select2_closed_state_min_height_36(self):
+        """Closed pill height matches the sort dropdown (36px)."""
+        block = self._block(
+            self.skin, ".select2-container--default .select2-selection--single {"
+        )
+        self.assertIn("min-height: 36px", block)
+
+    def test_select2_built_in_arrow_is_hidden(self):
+        """Built-in select2 arrow is hidden in favour of the background chevron."""
+        block = self._block(
+            self.skin,
+            ".select2-container--default .select2-selection--single .select2-selection__arrow {",
+        )
+        self.assertIn("display: none", block)
+
+    def test_select2_rendered_padding_matches_sort_select_padding(self):
+        """Inner padding is identical to .list-toolbar__sort-select."""
+        select2_block = self._block(
+            self.skin,
+            ".select2-container--default .select2-selection--single .select2-selection__rendered {",
+        )
+        sort_block = self._block(self.sort_css, "select.list-toolbar__sort-select {")
+        self.assertIn("padding: 8px 36px 8px 14px", select2_block)
+        self.assertIn("padding: 8px 36px 8px 14px", sort_block)


### PR DESCRIPTION
* shared chevron SVG, min-height: 36px, padding: 8px 36px 8px 14px, hover-on-surface-2
* hides select2 native arrow, applies the same focus ring as .list-toolbar__sort-select
* every Свештеник/Храм/Особа dropdown across the app inherits the unified look
* 4 tests in test_select2_unified_chrome.py pin chevron + dimensions + arrow-hidden + padding match