### PR TITLE
fix: parohijani importer dedups Osoba by name + safety signal

### DIFF
--- a/crkva/registar/management/commands/migracija_ukucana_parohijana.py
+++ b/crkva/registar/management/commands/migracija_ukucana_parohijana.py
@@ -15,7 +15,12 @@ from django.db import connection
 from registar.management.commands.base_migration import MigrationCommand
 from registar.migracija.address import find_or_create_adresa, warm_adresa_cache
 from registar.migracija.helpers import cyr, extract_maiden
-from registar.migracija.osoba_repo import find_or_create_osoba, warm_osoba_cache
+from registar.migracija.osoba_repo import (
+    cache_osoba,
+    find_or_create_osoba,
+    lookup_osoba,
+    warm_osoba_cache,
+)
 from registar.models import Domacinstvo, Osoba, Slava, Ukucanin
 
 
@@ -83,6 +88,7 @@ class Command(MigrationCommand):
     def _create_parohijani_and_domacinstva(self, limit: int = 0) -> None:
         created_parohijani = 0
         created_domacinstva = 0
+        self._dbf_uid_to_osoba_uid: Dict[int, int] = {}
 
         with connection.cursor() as cursor:
             cursor.execute(
@@ -157,28 +163,73 @@ class Command(MigrationCommand):
                 if slava_uid:
                     slava = Slava.objects.filter(uid=slava_uid).first()
 
-                osoba, p_created = Osoba.objects.get_or_create(
-                    uid=parohijan_uid,
-                    defaults={
-                        "ime": ime,
-                        "prezime": prezime,
-                        "devojacko_prezime": devojacko_prezime or None,
-                        "parohijan": True,
-                        "adresa": adresa,
-                        "tel_fiksni": (telefon_fiksni or "").strip() or None,
-                        "tel_mobilni": (telefon_mobilni or "").strip() or None,
-                    },
+                tel_f = (telefon_fiksni or "").strip() or None
+                tel_m = (telefon_mobilni or "").strip() or None
+
+                # Name-based dedup: if an Osoba with this (ime, prezime) already
+                # exists AND shares a safety signal (same canonical Adresa,
+                # tel_fiksni, or tel_mobilni), reuse it instead of creating a
+                # second row with a different uid.
+                cached = lookup_osoba(ime, prezime)
+                safe_to_merge = bool(cached) and (
+                    (adresa is not None and cached.adresa_id == adresa.uid)
+                    or (tel_f and cached.tel_fiksni and str(cached.tel_fiksni) == tel_f)
+                    or (
+                        tel_m
+                        and cached.tel_mobilni
+                        and str(cached.tel_mobilni) == tel_m
+                    )
                 )
-                if p_created:
-                    created_parohijani += 1
+
+                if safe_to_merge:
+                    osoba = cached
+                    updates = {}
+                    if not osoba.parohijan:
+                        updates["parohijan"] = True
+                    if not osoba.adresa_id and adresa is not None:
+                        updates["adresa"] = adresa
+                    if not osoba.tel_fiksni and tel_f:
+                        updates["tel_fiksni"] = tel_f
+                    if not osoba.tel_mobilni and tel_m:
+                        updates["tel_mobilni"] = tel_m
+                    if not osoba.devojacko_prezime and devojacko_prezime:
+                        updates["devojacko_prezime"] = devojacko_prezime
+                    if updates:
+                        Osoba.objects.filter(pk=osoba.pk).update(**updates)
+                        osoba.refresh_from_db()
+                else:
+                    osoba, p_created = Osoba.objects.get_or_create(
+                        uid=parohijan_uid,
+                        defaults={
+                            "ime": ime,
+                            "prezime": prezime,
+                            "devojacko_prezime": devojacko_prezime or None,
+                            "parohijan": True,
+                            "adresa": adresa,
+                            "tel_fiksni": tel_f,
+                            "tel_mobilni": tel_m,
+                        },
+                    )
+                    if p_created:
+                        created_parohijani += 1
+                        # Only cache the FIRST occurrence of this name. If the
+                        # cache already holds an Osoba with this name (cached
+                        # was non-None above but we landed here because the
+                        # safety check failed), keep the original cache entry.
+                        if not lookup_osoba(ime, prezime):
+                            cache_osoba(osoba)
+
+                # Track DBF UID -> canonical Osoba so the ukucani pass can resolve
+                # UK_RBRDOM even when we deduped onto an Osoba with a different uid.
+                self._dbf_uid_to_osoba_uid[parohijan_uid] = osoba.uid
 
                 _, d_created = Domacinstvo.objects.get_or_create(
                     domacin=osoba,
                     defaults={
                         "adresa": adresa,
                         "slava": slava,
-                        "tel_fiksni": (telefon_fiksni or "").strip() or None,
-                        "tel_mobilni": (telefon_mobilni or "").strip() or None,
+                        "tel_fiksni": tel_f,
+                        "tel_mobilni": tel_m,
                         "slavska_vodica": slavska_vodica
                         and slavska_vodica.strip() == "D",
                         "vaskrsnja_vodica": uskrsnja_vodica
@@ -200,9 +251,16 @@ class Command(MigrationCommand):
     # ---------------- Ukucanin pass ----------------
 
     def _prepare_ukucanin_records(self) -> Iterable[dict | None]:
-        domacinstva_cache: Dict[int, Domacinstvo] = {
+        # Resolve via dbf-uid -> osoba-uid -> domacinstvo so deduped parohijani
+        # still match their ukucani.
+        osoba_to_dom: Dict[int, Domacinstvo] = {
             d.domacin.uid: d for d in Domacinstvo.objects.select_related("domacin")
         }
+        domacinstva_cache: Dict[int, Domacinstvo] = {}
+        for dbf_uid, osoba_uid in self._dbf_uid_to_osoba_uid.items():
+            dom = osoba_to_dom.get(osoba_uid)
+            if dom is not None:
+                domacinstva_cache[dbf_uid] = dom
 
         with connection.cursor() as cursor:
             cursor.execute(

--- a/crkva/registar/migracija/osoba_repo.py
+++ b/crkva/registar/migracija/osoba_repo.py
@@ -27,6 +27,31 @@ def warm_osoba_cache() -> int:
     return len(_OSOBA_CACHE)
 
 
+def lookup_osoba(ime: str | None, prezime: str | None) -> Osoba | None:
+    """Cache-first lookup of an existing Osoba by (ime, prezime).
+
+    Returns the cached Osoba or None. Use this BEFORE deciding whether
+    to create a new row keyed on an external UID.
+    """
+    if not ime or not prezime:
+        return None
+    key = _key(ime.strip(), prezime.strip())
+    return _OSOBA_CACHE.get(key)
+
+
+def cache_osoba(osoba: Osoba) -> None:
+    """Insert (or update) an Osoba in the in-memory cache.
+
+    Use this after creating an Osoba via a path that bypasses
+    find_or_create_osoba (e.g. raw get_or_create on a UID key) so
+    subsequent lookups still find it without round-tripping the DB.
+    """
+    if osoba is None or not osoba.ime or not osoba.prezime:
+        return
+    key = _key(osoba.ime, osoba.prezime)
+    _OSOBA_CACHE[key] = osoba
+
+
 def find_or_create_osoba(ime: str | None, prezime: str | None, **extra) -> Osoba | None:
     """Find an Osoba by (ime, prezime) case-insensitively, or create one.
 

--- a/crkva/registar/tests/test_import_dedup.py
+++ b/crkva/registar/tests/test_import_dedup.py
@@ -1,0 +1,116 @@
+"""Tests for safety-checked dedup in migracija_ukucana_parohijana."""
+
+from django.test import TestCase
+from registar.migracija.osoba_repo import lookup_osoba, warm_osoba_cache
+from registar.models import Osoba
+
+
+class LookupOsobaCacheTest(TestCase):
+    """lookup_osoba must hit the warmed cache by (ime, prezime)."""
+
+    def test_returns_none_for_blank(self):
+        warm_osoba_cache()
+        self.assertIsNone(lookup_osoba("", "Марковић"))
+        self.assertIsNone(lookup_osoba("Марко", ""))
+        self.assertIsNone(lookup_osoba(None, None))
+
+    def test_returns_existing_osoba(self):
+        o = Osoba.objects.create(ime="Марко", prezime="Марковић")
+        warm_osoba_cache()
+        found = lookup_osoba("Марко", "Марковић")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.pk, o.pk)
+
+    def test_case_insensitive_match(self):
+        Osoba.objects.create(ime="Марко", prezime="Марковић")
+        warm_osoba_cache()
+        self.assertIsNotNone(lookup_osoba("марко", "МАРКОВИЋ"))
+
+    def test_unknown_name_returns_none(self):
+        Osoba.objects.create(ime="Марко", prezime="Марковић")
+        warm_osoba_cache()
+        self.assertIsNone(lookup_osoba("Petar", "Petrović"))
+
+
+class ImporterSafetyCheckedDedup(TestCase):
+    """Run the parohijan creation loop directly and assert safe-merge behaviour."""
+
+    def setUp(self):
+        # The migracija helpers keep module-level caches that survive across
+        # tests; clear them so a previous tests Adresa/Osoba refs dont leak in.
+        from registar.migracija.address import _ADRESA_CACHE, warm_adresa_cache
+        from registar.migracija.osoba_repo import _OSOBA_CACHE, warm_osoba_cache
+
+        _ADRESA_CACHE.clear()
+        _OSOBA_CACHE.clear()
+        warm_adresa_cache()
+        warm_osoba_cache()
+
+    def _create_staging_table(self):
+        from django.db import connection
+
+        with connection.cursor() as cur:
+            cur.execute("""
+                CREATE TEMPORARY TABLE hsp_domacini (
+                    "DOM_RBR" INT, "DOM_IME" VARCHAR(200), "DOM_RBRUL" INT,
+                    "DOM_BROJ" VARCHAR(10), "DOM_OZNAKA" VARCHAR(10),
+                    "DOM_STAN" VARCHAR(10), "DOM_TELDIR" VARCHAR(40),
+                    "DOM_TELMOB" VARCHAR(40), "DOM_RBRSL" INT,
+                    "DOM_SLAVOD" VARCHAR(1), "DOM_USKVOD" VARCHAR(1),
+                    "DOM_NAPOM" TEXT
+                )
+            """)
+            cur.execute("""
+                CREATE TEMPORARY TABLE hsp_ukucani (
+                    "UK_RBRDOM" INT, "UK_IME" VARCHAR(200)
+                )
+            """)
+            cur.execute(
+                'CREATE TEMPORARY TABLE hsp_ulice ("UL_SIFRA" INT, "UL_NAZIV" VARCHAR(200))'
+            )
+
+    def test_same_name_same_phone_merges_into_one_osoba(self):
+        """Two DBF rows with identical name + tel_fiksni → one Osoba."""
+        from django.db import connection
+        from registar.management.commands.migracija_ukucana_parohijana import Command
+
+        self._create_staging_table()
+        with connection.cursor() as cur:
+            cur.execute("""
+                INSERT INTO hsp_domacini VALUES
+                  (10, 'Драган Станчић', NULL, '12', '', '', '+3812544899', NULL, NULL, NULL, NULL, ''),
+                  (583, 'Драган Станчић', NULL, '12', '', '', '+3812544899', NULL, NULL, NULL, NULL, '')
+            """)
+
+        cmd = Command()
+        cmd._dry_run = False
+        cmd.stdout = type("S", (), {"write": lambda self, *a, **k: None})()
+        cmd.ulice_cache = {}
+        cmd._create_parohijani_and_domacinstva()
+
+        dragans = Osoba.objects.filter(ime="Драган", prezime="Станчић")
+        self.assertEqual(
+            dragans.count(), 1, "should dedup to one Osoba on shared phone"
+        )
+
+    def test_same_name_different_phones_keeps_both(self):
+        """Two DBF rows with same name but different phones → two Osobe."""
+        from django.db import connection
+        from registar.management.commands.migracija_ukucana_parohijana import Command
+
+        self._create_staging_table()
+        with connection.cursor() as cur:
+            cur.execute("""
+                INSERT INTO hsp_domacini VALUES
+                  (10, 'Никола Петровић', NULL, '12', '', '', '+38111111', NULL, NULL, NULL, NULL, ''),
+                  (583, 'Никола Петровић', NULL, '34', '', '', '+38122222', NULL, NULL, NULL, NULL, '')
+            """)
+
+        cmd = Command()
+        cmd._dry_run = False
+        cmd.stdout = type("S", (), {"write": lambda self, *a, **k: None})()
+        cmd.ulice_cache = {}
+        cmd._create_parohijani_and_domacinstva()
+
+        nikolas = Osoba.objects.filter(ime="Никола", prezime="Петровић")
+        self.assertEqual(nikolas.count(), 2, "different phones → don't merge")


### PR DESCRIPTION
* lookup_osoba + cache_osoba helpers in migracija.osoba_repo
* parohijani-pass: same name + (canonical Adresa OR tel_fiksni OR tel_mobilni) → reuse, no dup
* dbf_uid -> osoba.uid alias map so ukucani pass resolves UK_RBRDOM through dedup
* 6 tests