### PR TITLE
fix: drop hardcoded chdir from gunicorn.conf.py

### DIFF
--- a/crkva/registar/tests/test_gunicorn_conf.py
+++ b/crkva/registar/tests/test_gunicorn_conf.py
@@ -1,0 +1,23 @@
+"""scripts/gunicorn.conf.py must stay portable — no hardcoded install dir."""
+
+import pathlib
+
+from django.test import SimpleTestCase
+
+
+class GunicornConfPortableTest(SimpleTestCase):
+    """The committed gunicorn.conf.py must not pin the install directory."""
+
+    def test_no_hardcoded_install_path(self):
+        text = pathlib.Path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
+        self.assertNotIn(
+            "chdir =",
+            text,
+            "Hardcoded chdir is a deploy hazard — let systemd WorkingDirectory= drive cwd.",
+        )
+        self.assertNotIn("/root/projects/spc-registar/crkva", text)
+        self.assertNotIn("/root/projects/spc-registar-main", text)
+
+    def test_bind_to_all_interfaces(self):
+        text = pathlib.Path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
+        self.assertIn('bind = "0.0.0.0:9000"', text)

--- a/scripts/gunicorn.conf.py
+++ b/scripts/gunicorn.conf.py
@@ -12,4 +12,5 @@ timeout = 120
 accesslog = "/var/log/spc-registar/access.log"
 errorlog = "/var/log/spc-registar/error.log"
 loglevel = "info"
-chdir = "/root/projects/spc-registar-main/crkva"
+
+# No chdir here — systemd unit sets WorkingDirectory=, and docker uses its own command (see docker-compose.prod.yml).


### PR DESCRIPTION
* the systemd unit already sets WorkingDirectory=, and docker uses its own gunicorn command — chdir was redundant and pinned the deploy to a specific install path
* removing it lets the install directory get renamed without a follow-up commit
* 2 tests pin the constraint (no chdir, bind to 0.0.0.0)