### PR TITLE
feat: render Подаци о детету as info-row + toggle-button slider

### DIFF
--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -126,7 +126,7 @@
 .info-row--editable .info-row__value {
     min-width: 0;
 }
-.info-row--editable .info-row__value > input,
+.info-row--editable .info-row__value > input:not([type="checkbox"]):not([type="radio"]),
 .info-row--editable .info-row__value > select,
 .info-row--editable .info-row__value > textarea,
 .info-row--editable .info-row__value > .select2,
@@ -148,6 +148,55 @@
 .info-row--editable .info-row__value > .visually-hidden + .toggle-group,
 .info-row--editable .info-row__value > .toggle-wrapper {
     margin: 0;
+}
+
+/* Toggle slider style for raw checkboxes inside an editable info-row.
+   Mirrors the .form-field input[type="checkbox"] slider in forme.css so
+   booleans rendered as standalone checkbox widgets get the same look. */
+.info-row--editable .info-row__value > input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 46px;
+    height: 26px;
+    border: 1px solid var(--color-border);
+    border-radius: 13px;
+    background: var(--color-surface-2);
+    position: relative;
+    cursor: pointer;
+    vertical-align: middle;
+    margin: 0;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+.info-row--editable .info-row__value > input[type="checkbox"]::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 22px;
+    height: 22px;
+    background: #fff;
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+    transition: transform 0.2s ease;
+}
+.info-row--editable .info-row__value > input[type="checkbox"]:hover {
+    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
+}
+.info-row--editable .info-row__value > input[type="checkbox"]:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 20%, transparent);
+}
+.info-row--editable .info-row__value > input[type="checkbox"]:checked {
+    background: color-mix(in oklab, var(--color-success, #22c55e) 60%, var(--color-surface-2));
+    border-color: var(--color-success, #22c55e);
+}
+.info-row--editable .info-row__value > input[type="checkbox"]:checked::after {
+    transform: translateX(20px);
+}
+.info-row--editable .info-row__value > input[type="checkbox"][disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .info-row--placeholder {

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -70,12 +70,12 @@
         <ul class="info-rows">
           {% if is_edit %}
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Особа"><i class="fa-solid fa-user"></i></div><div class="info-row__value">{{ form.dete }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете рођено живо"><i class="fa-solid fa-heart-pulse"></i></div><div class="info-row__value">{{ form.dete_rodjeno_zivo }}</div></li>
           <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.dete_po_redu_po_majci }}</div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value"><label>{{ form.dete_vanbracno }} ванбрачно</label></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value"><label>{{ form.dete_blizanac }} близанац</label></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Друго дете близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value">{{ form.drugo_dete_blizanac_ime }}</div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Телесна мана"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value"><label>{{ form.dete_sa_telesnom_manom }} са телесном маном</label></div></li>
-          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Рођено живо"><i class="fa-solid fa-heart-pulse"></i></div><div class="info-row__value"><label>{{ form.dete_rodjeno_zivo }} рођено живо</label></div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Ванбрачно дете"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ form.dete_vanbracno }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете близанац"><i class="fa-solid fa-people-arrows"></i></div><div class="info-row__value">{{ form.dete_blizanac }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Име другог детета близанца"><i class="fa-solid fa-tag"></i></div><div class="info-row__value">{{ form.drugo_dete_blizanac_ime }}</div></li>
+          <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете са телесном маном"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">{{ form.dete_sa_telesnom_manom }}</div></li>
           {% else %}
           <li class="info-row">
             <div class="info-row__icon" data-tooltip="Име"><i class="fa-solid fa-user"></i></div>
@@ -84,10 +84,11 @@
           {% if krstenje.dete.get_pol_display %}<li class="info-row"><div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div><div class="info-row__value">{{ krstenje.dete.get_pol_display }}</div></li>{% endif %}
           {% if krstenje.datum_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Датум рођења"><i class="fa-solid fa-cake-candles"></i></div><div class="info-row__value">{{ krstenje.datum_rodjenja }}</div></li>{% endif %}
           {% if krstenje.mesto_rodjenja %}<li class="info-row"><div class="info-row__icon" data-tooltip="Место рођења"><i class="fa-solid fa-location-dot"></i></div><div class="info-row__value">{{ krstenje.mesto_rodjenja }}</div></li>{% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Дете рођено живо"><i class="fa-solid fa-heart-pulse"></i></div><div class="info-row__value">{{ krstenje.dete_rodjeno_zivo|yesno:"Да,Не" }}</div></li>
           {% if krstenje.dete_po_redu_po_majci %}<li class="info-row"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ krstenje.dete_po_redu_po_majci }}</div></li>{% endif %}
-          <li class="info-row"><div class="info-row__icon" data-tooltip="Брачно"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ krstenje.dete_vanbracno|yesno:"није,јесте" }}</div></li>
-          {% if krstenje.dete_blizanac %}<li class="info-row"><div class="info-row__icon" data-tooltip="Близанац"><i class="fa-solid fa-user-group"></i></div><div class="info-row__value">Да{% if krstenje.drugo_dete_blizanac_ime %} ({{ krstenje.drugo_dete_blizanac_ime }}){% endif %}</div></li>{% endif %}
-          {% if krstenje.dete_sa_telesnom_manom %}<li class="info-row"><div class="info-row__icon" data-tooltip="Телесна мана"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">Да</div></li>{% endif %}
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Ванбрачно дете"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ krstenje.dete_vanbracno|yesno:"Да,Не" }}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Дете близанац"><i class="fa-solid fa-people-arrows"></i></div><div class="info-row__value">{{ krstenje.dete_blizanac|yesno:"Да,Не" }}{% if krstenje.dete_blizanac and krstenje.drugo_dete_blizanac_ime %} <span class="info-row__sub">{{ krstenje.drugo_dete_blizanac_ime }}</span>{% endif %}</div></li>
+          <li class="info-row"><div class="info-row__icon" data-tooltip="Дете са телесном маном"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">{{ krstenje.dete_sa_telesnom_manom|yesno:"Да,Не" }}</div></li>
           {% endif %}
         </ul>
       </div>

--- a/crkva/registar/templates/registar/unos_krstenja.html
+++ b/crkva/registar/templates/registar/unos_krstenja.html
@@ -87,19 +87,17 @@
       </div>
     </fieldset>
 
-    <fieldset class="form-section">
-      <legend>Податци о детету</legend>
-      <div class="form-row">
-        <div class="form-field">{{ form.dete_rodjeno_zivo.label_tag }} {{ form.dete_rodjeno_zivo }}</div>
-        <div class="form-field">{{ form.dete_po_redu_po_majci.label_tag }} {{ form.dete_po_redu_po_majci }}</div>
-      </div>
-      <div class="form-row">
-        <div class="form-field">{{ form.dete_vanbracno.label_tag }} {{ form.dete_vanbracno }}</div>
-        <div class="form-field">{{ form.dete_blizanac.label_tag }} {{ form.dete_blizanac }}</div>
-        <div class="form-field">{{ form.drugo_dete_blizanac_ime.label_tag }} {{ form.drugo_dete_blizanac_ime }}</div>
-        <div class="form-field">{{ form.dete_sa_telesnom_manom.label_tag }} {{ form.dete_sa_telesnom_manom }}</div>
-      </div>
-    </fieldset>
+    <div class="info-section">
+      <h2 class="info-section__title"><i class="fa-solid fa-baby"></i> Подаци о детету</h2>
+      <ul class="info-rows">
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете рођено живо"><i class="fa-solid fa-heart-pulse"></i></div><div class="info-row__value">{{ form.dete_rodjeno_zivo }}</div></li>
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете по реду (по мајци)"><i class="fa-solid fa-list-ol"></i></div><div class="info-row__value">{{ form.dete_po_redu_po_majci }}</div></li>
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Ванбрачно дете"><i class="fa-solid fa-ring"></i></div><div class="info-row__value">{{ form.dete_vanbracno }}</div></li>
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете близанац"><i class="fa-solid fa-people-arrows"></i></div><div class="info-row__value">{{ form.dete_blizanac }}</div></li>
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Име другог детета близанца"><i class="fa-solid fa-tag"></i></div><div class="info-row__value">{{ form.drugo_dete_blizanac_ime }}</div></li>
+        <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Дете са телесном маном"><i class="fa-solid fa-hand-holding-medical"></i></div><div class="info-row__value">{{ form.dete_sa_telesnom_manom }}</div></li>
+      </ul>
+    </div>
 
     <fieldset class="form-section">
       <legend><i class="fa-solid fa-user-tag"></i> Кум</legend>

--- a/crkva/registar/tests/test_izmena.py
+++ b/crkva/registar/tests/test_izmena.py
@@ -283,6 +283,187 @@ class IzmenaKrstenjaTests(TestCase):
             r, 'name="dete_sa_telesnom_manom" id="id_dete_sa_telesnom_manom" checked'
         )
 
+    def test_dete_bool_fields_use_info_row_editable_markup(self):
+        """Each Дете bool/text field must render as its own info-row--editable."""
+        k = self._create_krstenje(
+            dete_rodjeno_zivo=True,
+            dete_vanbracno=False,
+            dete_blizanac=True,
+            dete_sa_telesnom_manom=False,
+            drugo_dete_blizanac_ime="Лука",
+        )
+        self.client.force_login(self.clerk)
+        html = self.client.get(self.url(k)).content.decode("utf-8")
+        # No leftover plain-label wrappers from the old form-row layout.
+        self.assertNotIn("<label>{0}".format("<input"), html)
+        self.assertNotIn("ванбрачно</label>", html)
+        self.assertNotIn("близанац</label>", html)
+        self.assertNotIn("рођено живо</label>", html)
+        self.assertNotIn("са телесном маном</label>", html)
+        # Each field is wrapped in its own .info-row.info-row--editable list
+        # item with the matching tooltip on .info-row__icon.
+        expected_tooltips = [
+            "Дете рођено живо",
+            "Дете по реду (по мајци)",
+            "Ванбрачно дете",
+            "Дете близанац",
+            "Име другог детета близанца",
+            "Дете са телесном маном",
+        ]
+        for tooltip in expected_tooltips:
+            # Use a relaxed marker so trailing whitespace / attribute ordering
+            # variations between Django versions don't break the assertion.
+            needle = f'data-tooltip="{tooltip}"'
+            self.assertIn(
+                needle,
+                html,
+                msg=f'Missing data-tooltip for "{tooltip}"',
+            )
+            # And verify the row that hosts the icon is an info-row--editable.
+            idx = html.index(needle)
+            preceding = html[max(0, idx - 200) : idx]
+            self.assertIn(
+                "info-row info-row--editable",
+                preceding,
+                msg=(
+                    f"Row hosting tooltip {tooltip!r} should carry "
+                    f"info-row--editable; preceding 200 chars: {preceding!r}"
+                ),
+            )
+
+    def test_dete_bool_widgets_are_bare_checkboxes(self):
+        """Bool widgets render as bare <input type=checkbox> (slider style)."""
+        k = self._create_krstenje()
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url(k))
+        # No surrounding inline <label> text node — the value cell directly
+        # contains the checkbox so the slider CSS attaches cleanly.
+        for fname in (
+            "dete_rodjeno_zivo",
+            "dete_vanbracno",
+            "dete_blizanac",
+            "dete_sa_telesnom_manom",
+        ):
+            self.assertContains(
+                r,
+                f'<div class="info-row__value">'
+                f'<input type="checkbox" name="{fname}"',
+                msg_prefix=f"{fname} should be bare checkbox in info-row__value",
+            )
+
+
+class PrikazKrstenjaDeteSectionTests(TestCase):
+    """View-mode (is_edit=False) rendering of the Дете bool fields."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def _create_krstenje(self, **overrides):
+        defaults = dict(
+            godina_registracije=2024,
+            redni_broj=1,
+            knjiga=1,
+            strana=1,
+            broj=1,
+            datum=datetime.date(2024, 2, 10),
+            dete_rodjeno_zivo=True,
+            dete_vanbracno=False,
+            dete_blizanac=True,
+            dete_sa_telesnom_manom=False,
+            drugo_dete_blizanac_ime="Лука",
+        )
+        defaults.update(overrides)
+        return Krstenje.objects.create(**defaults)
+
+    def url(self, k):
+        return reverse("krstenje_detail", kwargs={"uid": k.uid})
+
+    def test_view_mode_shows_da_ne_for_each_bool(self):
+        """View mode must render Да/Не values for every dete bool."""
+        k = self._create_krstenje()
+        html = self.client.get(self.url(k)).content.decode("utf-8")
+        # Each bool field has its own info-row with the right tooltip in view
+        # mode, and the value is exactly "Да" or "Не".
+        cases = [
+            ("Дете рођено живо", "Да"),
+            ("Ванбрачно дете", "Не"),
+            ("Дете близанац", "Да"),
+            ("Дете са телесном маном", "Не"),
+        ]
+        for tooltip, expected in cases:
+            row_marker = (
+                f'<div class="info-row__icon" data-tooltip="{tooltip}">'
+            )
+            self.assertIn(row_marker, html, msg=f'No row for "{tooltip}"')
+            # Find the value cell that follows this icon and check it begins
+            # with the expected Да/Не label.
+            idx = html.index(row_marker)
+            value_open = html.index('<div class="info-row__value">', idx)
+            value_close = html.index("</div>", value_open)
+            value_html = html[value_open:value_close]
+            self.assertIn(
+                expected,
+                value_html,
+                msg=f'Expected "{expected}" inside {tooltip} value, got: {value_html!r}',
+            )
+
+    def test_view_mode_shows_twin_sibling_name_when_blizanac(self):
+        """If dete_blizanac is true, drugo_dete_blizanac_ime is shown beside it."""
+        k = self._create_krstenje(
+            dete_blizanac=True, drugo_dete_blizanac_ime="Лука"
+        )
+        r = self.client.get(self.url(k))
+        self.assertContains(r, "Лука")
+
+    def test_view_mode_renders_false_bools_as_ne(self):
+        """All four bools set to False render Не (not omitted)."""
+        k = self._create_krstenje(
+            dete_rodjeno_zivo=False,
+            dete_vanbracno=False,
+            dete_blizanac=False,
+            dete_sa_telesnom_manom=False,
+        )
+        html = self.client.get(self.url(k)).content.decode("utf-8")
+        for tooltip in (
+            "Дете рођено живо",
+            "Ванбрачно дете",
+            "Дете близанац",
+            "Дете са телесном маном",
+        ):
+            row_marker = (
+                f'<div class="info-row__icon" data-tooltip="{tooltip}">'
+            )
+            self.assertIn(row_marker, html)
+            value_open = html.index('<div class="info-row__value">', html.index(row_marker))
+            value_close = html.index("</div>", value_open)
+            self.assertIn("Не", html[value_open:value_close])
+
+
+class InfoCssRulesTests(TestCase):
+    """Smoke-test that the info-section / info-row CSS rules are present."""
+
+    def test_info_css_defines_section_and_editable_row(self):
+        import pathlib
+        from django.conf import settings
+
+        css_path = (
+            pathlib.Path(settings.BASE_DIR)
+            / "registar"
+            / "static"
+            / "registar"
+            / "components"
+            / "info.css"
+        )
+        content = css_path.read_text(encoding="utf-8")
+        self.assertIn(".info-section", content)
+        self.assertIn(".info-row--editable", content)
+        # The slider styling that gives bool checkboxes the toggle look must
+        # also be present so the Дете section renders correctly.
+        self.assertIn(
+            '.info-row--editable .info-row__value > input[type="checkbox"]',
+            content,
+        )
+
 
 class IzmenaVencanjaTests(TestCase):
     """Edit-form rendering for Vencanje — razresenje BooleanField round-trip."""


### PR DESCRIPTION
* replace form-section fieldset with info-section + info-rows in unos_krstenja.html
* split bool fields into per-row info-row--editable with FA icons + tooltips
* extend info.css to apply slider toggle styling to checkboxes in info-rows
* show Да/Не in view mode for every dete bool; preserve twin-name sub-label
* add 6 tests covering edit markup, bare checkbox widgets, view-mode and CSS rules