### PR TITLE
feat: polish domacinstvo edit — inline adresa edit, slider toggles, c…

### DIFF
--- a/crkva/registar/forms/domacinstvo_form.py
+++ b/crkva/registar/forms/domacinstvo_form.py
@@ -1,7 +1,10 @@
 """Django форма за унос домаћинства."""
 
 from django import forms
-from registar.forms.select2 import ScriptAwareModelSelect2Widget
+from registar.forms.select2 import (
+    PublicSchemaModelSelect2Widget,
+    ScriptAwareModelSelect2Widget,
+)
 from registar.models import Adresa, Domacinstvo, Osoba, Slava
 
 
@@ -29,9 +32,15 @@ class DomacinstvoForm(forms.ModelForm):
             "adresa": ScriptAwareModelSelect2Widget(
                 model=Adresa,
                 search_fields=["ulica__icontains", "mesto__icontains"],
-                attrs={"data-minimum-input-length": 0},
+                attrs={
+                    "data-minimum-input-length": 0,
+                    "data-adresa-edit": "1",
+                },
             ),
-            "slava": ScriptAwareModelSelect2Widget(
+            # Slava lives in the public schema (shared model); the dedicated
+            # widget wraps every SQL call in schema_context("public") so the
+            # select2 AJAX endpoint returns rows even inside a tenant request.
+            "slava": PublicSchemaModelSelect2Widget(
                 model=Slava,
                 search_fields=["naziv__icontains"],
                 attrs={"data-minimum-input-length": 0},

--- a/crkva/registar/forms/select2.py
+++ b/crkva/registar/forms/select2.py
@@ -9,6 +9,7 @@ from functools import reduce
 
 from django.db.models import Q
 from django_select2.forms import ModelSelect2Widget
+from django_tenants.utils import schema_context
 from registar.utils import get_query_variants
 
 
@@ -52,3 +53,41 @@ class ScriptAwareSelect2Mixin:
 
 class ScriptAwareModelSelect2Widget(ScriptAwareSelect2Mixin, ModelSelect2Widget):
     """Drop-in replacement for ModelSelect2Widget with Cyrillic↔Latin search."""
+
+
+class PublicSchemaModelSelect2Widget(ScriptAwareModelSelect2Widget):
+    """Select2 widget for shared (public-schema) models referenced by tenants.
+
+    django-tenants switches the Postgres ``search_path`` per-request based on
+    the request's tenant. Plain ``Model.objects.all()`` queries therefore look
+    in the tenant schema. For models that physically live in the ``public``
+    schema (e.g. :class:`kalendar.models.Slava`), that lookup fails because
+    the table does not exist in the tenant schema.
+
+    Every SQL access this widget performs — the cached widget config, the
+    selected-option label render, and the AJAX search response — is wrapped
+    in ``schema_context("public")`` so the queries always hit the public
+    schema regardless of which tenant is currently active.
+    """
+
+    def set_to_cache(self):
+        # Materialise queryset metadata while the public schema is active so
+        # the cached ``queryset.query`` resolves the right table.
+        with schema_context("public"):
+            super().set_to_cache()
+
+    def optgroups(self, name, value, attrs=None):
+        # Rendering the selected <option> triggers a SELECT against Slava
+        # via ``self.choices.queryset.filter(...)``. Run it in public schema.
+        with schema_context("public"):
+            return super().optgroups(name, value, attrs=attrs)
+
+    def filter_queryset(self, request, term, queryset=None, **dependent_fields):
+        with schema_context("public"):
+            qs = super().filter_queryset(
+                request, term, queryset=queryset, **dependent_fields
+            )
+            # Force evaluation while still inside the public schema context
+            # so subsequent pagination/serialisation does not re-run the
+            # query under the wrong search_path.
+            return list(qs)

--- a/crkva/registar/static/registar/components/adresa_edit.js
+++ b/crkva/registar/static/registar/components/adresa_edit.js
@@ -1,0 +1,187 @@
+/* ==========================================================================
+   ADRESA-EDIT — inline "Edit address" pencil + modal save handler
+   ==========================================================================
+   Wires a small pencil button next to any Adresa select2 (marked with
+   `data-adresa-edit="1"`) that opens #adresa-modal pre-filled with the
+   currently selected Adresa's fields.
+
+   On save, POSTs to /api/brzi-izmena-adrese/<uid>/ and refreshes the
+   select2's selected <option> label with the updated representation so the
+   user sees the change immediately.
+
+   Architecture mirrors osoba_create.js — both use Modal.bindForm but this
+   one targets an existing row (PUT-semantics POST) rather than creating
+   a new one. The endpoint UUID is taken from the select2's current value.
+   ========================================================================== */
+
+(function ($) {
+    "use strict";
+    if (!$) return;
+
+    function csrfToken() {
+        const el = document.querySelector("[name=csrfmiddlewaretoken]");
+        return el ? el.value : "";
+    }
+
+    function getInitialPayload() {
+        const node = document.getElementById("adresa-modal-initial");
+        if (!node) return null;
+        try {
+            return JSON.parse(node.textContent);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function fillModalFields(payload) {
+        const map = {
+            ulica: "modal-adresa-ulica",
+            broj: "modal-adresa-broj",
+            broj_stana: "modal-adresa-broj_stana",
+            mesto: "modal-adresa-mesto",
+        };
+        Object.entries(map).forEach(function (entry) {
+            const el = document.getElementById(entry[1]);
+            if (el) el.value = (payload && payload[entry[0]]) || "";
+        });
+        const err = document.querySelector("#adresa-modal .error-text");
+        if (err) {
+            err.style.display = "none";
+            err.textContent = "";
+        }
+    }
+
+    function showError(msg) {
+        const err = document.querySelector("#adresa-modal .error-text");
+        if (!err) return;
+        err.textContent = msg;
+        err.style.display = "block";
+    }
+
+    function currentAdresaUid($select) {
+        const v = $select.val();
+        if (v) return v;
+        const payload = getInitialPayload();
+        return payload ? payload.uid : "";
+    }
+
+    function refreshSelectLabel($select, data) {
+        const select = $select[0];
+        if (!select) return;
+        // Strip any existing options matching this uid so the new label wins.
+        Array.from(select.options).forEach(function (opt) {
+            if (opt.value === String(data.id)) opt.remove();
+        });
+        const option = new Option(data.text, data.id, true, true);
+        select.appendChild(option);
+        $select.trigger("change");
+    }
+
+    function attach($select) {
+        if ($select.data("adresaEditBound")) return;
+        $select.data("adresaEditBound", true);
+
+        const fieldId = $select.attr("id");
+        if (!fieldId) return;
+
+        // Build a small pencil button immediately to the right of the
+        // .info-row__value wrapper holding this select.
+        const $container = $select.closest(".info-row__value");
+        if (!$container.length) return;
+        if ($container.find(".adresa-edit-btn").length) return;
+
+        const $btn = $(
+            '<button type="button" class="adresa-edit-btn" ' +
+                'data-tooltip="Измени адресу" aria-label="Измени адресу">' +
+                '<i class="fa-solid fa-pen" aria-hidden="true"></i>' +
+            "</button>"
+        );
+        $container.append($btn);
+
+        $btn.on("click", function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const uid = currentAdresaUid($select);
+            if (!uid) {
+                showError("Прво изаберите адресу из листе.");
+                if (window.Modal) Modal.open("adresa-modal");
+                fillModalFields({});
+                return;
+            }
+            // Pull the cached payload if it matches the current select value;
+            // otherwise leave fields blank and let the user retype.
+            const payload = getInitialPayload();
+            fillModalFields(payload && payload.uid === uid ? payload : {});
+            const modal = document.getElementById("adresa-modal");
+            if (modal) {
+                modal.dataset.targetFieldId = fieldId;
+                modal.dataset.adresaUid = uid;
+            }
+            if (window.Modal) Modal.open("adresa-modal");
+        });
+
+        // Enter inside any modal input submits.
+        document
+            .querySelectorAll("#adresa-modal input[type=text]")
+            .forEach(function (input) {
+                input.addEventListener("keydown", function (ev) {
+                    if (ev.key === "Enter") {
+                        ev.preventDefault();
+                        save();
+                    }
+                });
+            });
+
+        function save() {
+            const modal = document.getElementById("adresa-modal");
+            if (!modal) return;
+            const uid = modal.dataset.adresaUid || currentAdresaUid($select);
+            if (!uid) {
+                showError("Нема изабране адресе за измену.");
+                return;
+            }
+            const fd = new FormData();
+            ["ulica", "broj", "broj_stana", "mesto"].forEach(function (f) {
+                const el = document.getElementById("modal-adresa-" + f);
+                fd.append(f, el ? el.value.trim() : "");
+            });
+            fetch("/api/brzi-izmena-adrese/" + uid + "/", {
+                method: "POST",
+                headers: { "X-CSRFToken": csrfToken() },
+                body: fd,
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (data.error) {
+                        showError(data.error);
+                        return;
+                    }
+                    refreshSelectLabel($select, data);
+                    if (window.Modal) Modal.close("adresa-modal");
+                })
+                .catch(function () {
+                    showError("Грешка при чувању. Покушајте поново.");
+                });
+        }
+
+        // The save button is shared across attaches; only bind once.
+        const saveBtn = document.getElementById("adresa-modal-save");
+        if (saveBtn && !saveBtn.dataset.bound) {
+            saveBtn.dataset.bound = "1";
+            saveBtn.addEventListener("click", save);
+        } else if (saveBtn) {
+            // Re-attach the latest closure so saving routes to the active select.
+            saveBtn.onclick = save;
+        }
+    }
+
+    function init() {
+        $("select[data-adresa-edit]").each(function () { attach($(this)); });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})(window.jQuery);

--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -199,6 +199,45 @@
     cursor: not-allowed;
 }
 
+/* Label rendered next to a slider-toggle checkbox in an editable info-row.
+   The checkbox itself stays a direct child of .info-row__value so the
+   slider styling above applies; this label sits inline. */
+.info-row--editable .info-row__value > .info-row__bool-label {
+    margin-left: 10px;
+    cursor: pointer;
+    vertical-align: middle;
+    user-select: none;
+}
+
+/* Inline pencil button rendered next to the Adresa select2 in the editable
+   Domacinstvo form. Sits on the right edge of the value column and shares
+   the icon-only look of the page-header action buttons. */
+.info-row__value .adresa-edit-btn {
+    appearance: none;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-2);
+    color: var(--color-text);
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    margin-left: 8px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    vertical-align: middle;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+.info-row__value .adresa-edit-btn:hover {
+    border-color: var(--color-primary);
+    background: color-mix(in oklab, var(--color-primary) 12%, var(--color-surface-2));
+}
+.info-row__value .adresa-edit-btn:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 20%, transparent);
+}
 .info-row--placeholder {
     color: var(--color-text-muted);
 }

--- a/crkva/registar/templates/registar/_modal_adresa.html
+++ b/crkva/registar/templates/registar/_modal_adresa.html
@@ -1,0 +1,47 @@
+{% comment %}
+Inline-edit Adresa modal. Mirrors _modal_osoba.html / modal.js architecture.
+Reads the currently selected Adresa from the linked select2 widget, pulls its
+fields from a hidden data block prerendered by the form, and POSTs to the
+brzi_izmena_adrese endpoint to update the row in place.
+{% endcomment %}
+<div id="adresa-modal" class="modal-overlay" style="display:none;">
+  <div class="modal">
+    <div class="modal__header">
+      <h3><i class="fa-solid fa-location-dot"></i> Измена адресе</h3>
+      <button type="button" class="modal__close" onclick="Modal.close('adresa-modal')">&times;</button>
+    </div>
+    <div class="modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-adresa-ulica">Улица</label>
+          <input type="text" id="modal-adresa-ulica" autocomplete="off">
+        </div>
+        <div class="form-field">
+          <label for="modal-adresa-broj">Број</label>
+          <input type="text" id="modal-adresa-broj" autocomplete="off">
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-adresa-broj_stana">Број стана</label>
+          <input type="text" id="modal-adresa-broj_stana" autocomplete="off">
+        </div>
+        <div class="form-field">
+          <label for="modal-adresa-mesto">Место</label>
+          <input type="text" id="modal-adresa-mesto" autocomplete="off">
+        </div>
+      </div>
+      <div class="error-text" style="display:none;"></div>
+    </div>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('adresa-modal')">Откажи</button>
+      <button type="button" class="button button--primary" id="adresa-modal-save">
+        <i class="fa-solid fa-check" style="margin-right:6px;"></i>Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+{% if domacinstvo and domacinstvo.adresa %}
+<script id="adresa-modal-initial" type="application/json">{"uid": "{{ domacinstvo.adresa.uid }}", "ulica": "{{ domacinstvo.adresa.ulica|escapejs }}", "broj": "{{ domacinstvo.adresa.broj|escapejs }}", "broj_stana": "{{ domacinstvo.adresa.broj_stana|escapejs }}", "mesto": "{{ domacinstvo.adresa.mesto|escapejs }}"}</script>
+{% endif %}

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% load static %}
+{% load phone_filters %}
 
 {% block extra_css %}{% if is_edit %}{{ form.media.css }}{% endif %}{% endblock %}
-{% block extra_js %}{% if is_edit %}{{ form.media.js }}{% endif %}{% endblock %}
-{% load phone_filters %}
+{% block extra_js %}{% if is_edit %}{{ form.media.js }}<script src="{% static 'registar/components/adresa_edit.js' %}"></script>{% endif %}{% endblock %}
 
 {% block content %}
 {% if is_edit %}<form method="post" class="info-page">{% csrf_token %}{% else %}<div class="info-page">{% endif %}
@@ -33,8 +34,8 @@
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Слава"><i class="fa-solid fa-gift"></i></div><div class="info-row__value">{{ form.slava }}</div></li>
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Мобилни телефон"><i class="fa-solid fa-mobile-screen"></i></div><div class="info-row__value">{{ form.tel_mobilni }}</div></li>
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Фиксни телефон"><i class="fa-solid fa-phone"></i></div><div class="info-row__value">{{ form.tel_fiksni }}</div></li>
-    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Славска водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value"><label>{{ form.slavska_vodica }} Славска водица</label></div></li>
-    <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Васкршња водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value"><label>{{ form.vaskrsnja_vodica }} Васкршња водица</label></div></li>
+    <li class="info-row info-row--editable" data-tooltip="Славска водица"><div class="info-row__icon" data-tooltip="Славска водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">{{ form.slavska_vodica }}<label for="id_slavska_vodica" class="info-row__bool-label">Славска водица</label></div></li>
+    <li class="info-row info-row--editable" data-tooltip="Васкршња водица"><div class="info-row__icon" data-tooltip="Васкршња водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">{{ form.vaskrsnja_vodica }}<label for="id_vaskrsnja_vodica" class="info-row__bool-label">Васкршња водица</label></div></li>
     <li class="info-row info-row--editable"><div class="info-row__icon" data-tooltip="Напомена"><i class="fa-solid fa-note-sticky"></i></div><div class="info-row__value">{{ form.napomena }}</div></li>
     {% else %}
     <li class="info-row"><div class="info-row__icon" data-tooltip="Домаћин"><i class="fa-solid fa-house"></i></div><div class="info-row__value"><a href="{% url 'parohijan_detail' uid=domacinstvo.domacin.uid %}">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</a></div></li>
@@ -42,9 +43,8 @@
     {% if domacinstvo.tel_mobilni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Мобилни"><i class="fa-solid {{ domacinstvo.tel_mobilni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ domacinstvo.tel_mobilni|tel_link }}">{{ domacinstvo.tel_mobilni|format_phone }}</a></div></li>{% endif %}
     {% if domacinstvo.tel_fiksni %}<li class="info-row"><div class="info-row__icon" data-tooltip="Фиксни"><i class="fa-solid {{ domacinstvo.tel_fiksni|phone_icon }}"></i></div><div class="info-row__value"><a href="tel:{{ domacinstvo.tel_fiksni|tel_link }}">{{ domacinstvo.tel_fiksni|format_phone }}</a></div></li>{% endif %}
     {% if domacinstvo.slava %}<li class="info-row"><div class="info-row__icon" data-tooltip="Слава"><i class="fa-solid fa-gift"></i></div><div class="info-row__value"><a href="{% url 'slava_detail' uid=domacinstvo.slava.uid %}">{{ domacinstvo.slava }}</a></div></li>{% endif %}
-    {% if domacinstvo.slavska_vodica or domacinstvo.vaskrsnja_vodica %}
-    <li class="info-row"><div class="info-row__icon" data-tooltip="Водице"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">{% if domacinstvo.slavska_vodica %}Славска{% endif %}{% if domacinstvo.slavska_vodica and domacinstvo.vaskrsnja_vodica %} · {% endif %}{% if domacinstvo.vaskrsnja_vodica %}Васкршња{% endif %}</div></li>
-    {% endif %}
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Славска водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">Славска водица: {{ domacinstvo.slavska_vodica|yesno:"Да,Не" }}</div></li>
+    <li class="info-row"><div class="info-row__icon" data-tooltip="Васкршња водица"><i class="fa-solid fa-droplet"></i></div><div class="info-row__value">Васкршња водица: {{ domacinstvo.vaskrsnja_vodica|yesno:"Да,Не" }}</div></li>
     {% endif %}
   </ul>
 
@@ -65,6 +65,6 @@
     {% endif %}
   {% endif %}
 
-{% if is_edit %}</form>{% else %}</div>{% endif %}
+{% if is_edit %}{% include "registar/_modal_adresa.html" %}</form>{% else %}</div>{% endif %}
 {% if not is_edit %}{% include "registar/_history_panel.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/tests/test_adresa_edit_modal.py
+++ b/crkva/registar/tests/test_adresa_edit_modal.py
@@ -1,0 +1,277 @@
+"""Tests for the inline Adresa edit modal on the Domacinstvo edit page.
+
+Covers:
+- The pencil button + #adresa-modal render in the edit-mode template.
+- The brzi_izmena_adrese endpoint updates the existing row in place.
+- The endpoint requires authentication and the domacinstvo role.
+- Boolean toggles render as slider-styled checkboxes (Bug 2 markup).
+- View mode renders the booleans as "Да" / "Не".
+"""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Adresa, Domacinstvo, Osoba
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class _BaseDomacinstvoMixin:
+    @classmethod
+    def _make_users_and_household(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="kanc-adr", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.priest = User.objects.create_user(username="svest-adr", password="x")
+        UserMembership.objects.create(
+            user=cls.priest, tenant=cls.tenant, role=Role.SVESTENSTVO
+        )
+        cls.domacin = Osoba.objects.create(ime="Адр", prezime="Тест", pol="М")
+        cls.adresa = Adresa.objects.create(
+            ulica="Стара", broj="1", broj_stana="", mesto="Београд"
+        )
+        cls.domacinstvo = Domacinstvo.objects.create(
+            domacin=cls.domacin, adresa=cls.adresa
+        )
+
+
+class AdresaEditMarkupTests(_BaseDomacinstvoMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls._make_users_and_household()
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse(
+            "izmena_domacinstva", kwargs={"uid": self.domacinstvo.uid}
+        )
+
+    def test_adresa_edit_button_renders_on_domacinstvo_edit_page(self):
+        """The Adresa select2 carries the data attribute the JS hooks into."""
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 200)
+        # The form widget exposes the hook attribute consumed by adresa_edit.js
+        # so the JS can mount the pencil button next to the select.
+        self.assertContains(r, 'data-adresa-edit="1"')
+
+    def test_adresa_edit_modal_in_dom(self):
+        """The inline-edit modal markup is present on the edit page."""
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'id="adresa-modal"')
+        self.assertContains(r, 'id="modal-adresa-ulica"')
+        self.assertContains(r, 'id="modal-adresa-broj"')
+        self.assertContains(r, 'id="modal-adresa-broj_stana"')
+        self.assertContains(r, 'id="modal-adresa-mesto"')
+
+    def test_adresa_edit_js_loaded(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        self.assertContains(r, "adresa_edit.js")
+
+    def test_initial_adresa_payload_in_dom(self):
+        """JSON block carries the currently-linked address so the modal can
+        pre-fill its inputs without an extra round-trip."""
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        self.assertContains(r, 'id="adresa-modal-initial"')
+        self.assertContains(r, '"ulica": "Стара"')
+        self.assertContains(r, '"mesto": "Београд"')
+
+    def test_adresa_select_preselects_current_household_address(self):
+        """The Adresa <select> renders the household's current adresa as the
+        initial selected option (Bug 1a)."""
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        body = r.content.decode("utf-8")
+        # find the <select name="adresa" ...> ... </select> block
+        start = body.find('name="adresa"')
+        self.assertGreater(start, -1)
+        end = body.find("</select>", start)
+        self.assertGreater(end, start)
+        block = body[start:end]
+        # The matching <option> for the saved uid must carry `selected`.
+        self.assertIn(str(self.adresa.uid), block)
+        # And the option carrying that uid must be marked selected.
+        self.assertIn("selected", block)
+
+
+class AdresaEditEndpointTests(_BaseDomacinstvoMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls._make_users_and_household()
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse(
+            "brzi_izmena_adrese", kwargs={"uid": self.adresa.uid}
+        )
+
+    def test_endpoint_updates_existing_row(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            self.url,
+            {
+                "ulica": "Нова",
+                "broj": "42",
+                "broj_stana": "3А",
+                "mesto": "Нови Сад",
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["id"], str(self.adresa.uid))
+        self.adresa.refresh_from_db()
+        self.assertEqual(self.adresa.ulica, "Нова")
+        self.assertEqual(self.adresa.broj, "42")
+        self.assertEqual(self.adresa.broj_stana, "3А")
+        self.assertEqual(self.adresa.mesto, "Нови Сад")
+
+    def test_endpoint_returns_refreshed_label(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            self.url,
+            {
+                "ulica": "Краља",
+                "broj": "7",
+                "broj_stana": "",
+                "mesto": "Београд",
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("Краља", r.json()["text"])
+
+    def test_endpoint_requires_auth_anonymous_redirects(self):
+        r = self.client.post(
+            self.url, {"ulica": "x", "broj": "1", "broj_stana": "", "mesto": "y"}
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/prijava/", r["Location"])
+
+    def test_endpoint_requires_domacinstvo_role(self):
+        self.client.force_login(self.priest)
+        r = self.client.post(
+            self.url,
+            {"ulica": "x", "broj": "1", "broj_stana": "", "mesto": "y"},
+        )
+        self.assertEqual(r.status_code, 403)
+        # Row must remain untouched.
+        self.adresa.refresh_from_db()
+        self.assertEqual(self.adresa.ulica, "Стара")
+
+    def test_endpoint_get_rejected(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 405)
+
+    def test_endpoint_404_for_missing_uid(self):
+        self.client.force_login(self.clerk)
+        import uuid as _uuid
+
+        bogus = reverse("brzi_izmena_adrese", kwargs={"uid": _uuid.uuid4()})
+        r = self.client.post(bogus, {"ulica": "x"})
+        self.assertEqual(r.status_code, 404)
+
+
+class VodicaSliderToggleMarkupTests(_BaseDomacinstvoMixin, TestCase):
+    """Bug 2: slavska_vodica / vaskrsnja_vodica must render as slider toggles.
+
+    The slider CSS in info.css targets
+    ``.info-row--editable .info-row__value > input[type="checkbox"]`` so the
+    checkbox MUST be a direct child of ``.info-row__value`` (i.e. not wrapped
+    in a <label>) for the slider style to apply.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls._make_users_and_household()
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse(
+            "izmena_domacinstva", kwargs={"uid": self.domacinstvo.uid}
+        )
+
+    def _editable_value_block(self, html, field_name):
+        marker = f'name="{field_name}"'
+        idx = html.find(marker)
+        self.assertGreater(idx, -1, f"{field_name} not in rendered HTML")
+        # Look back for the enclosing info-row__value div.
+        start = html.rfind('info-row__value', 0, idx)
+        self.assertGreater(start, -1)
+        end = html.find('</li>', idx)
+        return html[start:end]
+
+    def test_slavska_vodica_renders_as_slider_toggle(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        html = r.content.decode("utf-8")
+        block = self._editable_value_block(html, "slavska_vodica")
+        # Slider styling requires the checkbox to be a direct child of
+        # info-row__value, NOT nested inside a <label>.
+        # Check that the <input> immediately follows the opening tag.
+        self.assertIn('info-row__value">', block)
+        # Specifically: no <label>...<input>...</label> wrap.
+        label_idx = block.find("<label")
+        input_idx = block.find("<input")
+        self.assertGreater(input_idx, -1)
+        if label_idx > -1:
+            self.assertGreater(
+                label_idx,
+                input_idx,
+                "label must come AFTER the checkbox so the checkbox is a "
+                "direct child of info-row__value (slider CSS requirement).",
+            )
+
+    def test_vaskrsnja_vodica_renders_as_slider_toggle(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        html = r.content.decode("utf-8")
+        block = self._editable_value_block(html, "vaskrsnja_vodica")
+        label_idx = block.find("<label")
+        input_idx = block.find("<input")
+        self.assertGreater(input_idx, -1)
+        if label_idx > -1:
+            self.assertGreater(label_idx, input_idx)
+
+    def test_editable_row_class_present_for_both_vodica_fields(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(self.url)
+        html = r.content.decode("utf-8")
+        for field in ("slavska_vodica", "vaskrsnja_vodica"):
+            block = self._editable_value_block(html, field)
+            # The <li> wrapper must carry info-row--editable.
+            self.assertIn("info-row--editable", html[: html.find(block)])
+
+    def test_view_mode_shows_da_for_true_bools(self):
+        self.domacinstvo.slavska_vodica = True
+        self.domacinstvo.vaskrsnja_vodica = True
+        self.domacinstvo.save()
+        self.client.force_login(self.clerk)
+        r = self.client.get(
+            reverse("domacinstvo_detail", kwargs={"uid": self.domacinstvo.uid})
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.content.decode("utf-8")
+        self.assertIn("Славска водица: Да", body)
+        self.assertIn("Васкршња водица: Да", body)
+
+    def test_view_mode_shows_ne_for_false_bools(self):
+        self.domacinstvo.slavska_vodica = False
+        self.domacinstvo.vaskrsnja_vodica = False
+        self.domacinstvo.save()
+        self.client.force_login(self.clerk)
+        r = self.client.get(
+            reverse("domacinstvo_detail", kwargs={"uid": self.domacinstvo.uid})
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.content.decode("utf-8")
+        self.assertIn("Славска водица: Не", body)
+        self.assertIn("Васкршња водица: Не", body)

--- a/crkva/registar/tests/test_slava_select2_cross_schema.py
+++ b/crkva/registar/tests/test_slava_select2_cross_schema.py
@@ -1,0 +1,141 @@
+"""Tests for the Slava select2 widget across the public/tenant schema boundary.
+
+Slava lives in the public schema (shared model). The Domacinstvo form's
+``slava`` widget is a :class:`PublicSchemaModelSelect2Widget` which wraps every
+SQL call in ``schema_context("public")`` so the AJAX endpoint can return
+results even inside a tenant request.
+
+These tests assert:
+- The Slava widget on DomacinstvoForm is the public-schema variant.
+- ``filter_queryset`` returns the correct Slava rows when executed inside a
+  tenant schema context (where the bare ``Slava.objects`` would otherwise fail
+  because the table is not in the tenant schema).
+- The select2 AJAX endpoint reachable at ``/select2/fields/auto.json`` resolves
+  Slava rows when called from a tenant request.
+"""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.test.client import RequestFactory
+from django_tenants.utils import schema_context
+from kalendar.models import Slava
+from registar.forms import DomacinstvoForm
+from registar.forms.select2 import PublicSchemaModelSelect2Widget
+from registar.models import Domacinstvo, Osoba
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class SlavaWidgetTypeTests(TestCase):
+    def test_domacinstvo_form_slava_widget_is_public_schema_widget(self):
+        form = DomacinstvoForm()
+        widget = form.fields["slava"].widget
+        self.assertIsInstance(widget, PublicSchemaModelSelect2Widget)
+        self.assertEqual(widget.model, Slava)
+
+
+class SlavaFilterQuerysetCrossSchemaTests(TestCase):
+    """``filter_queryset`` must return Slava rows from the public schema even
+    when invoked under the tenant search_path."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="slavasel", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        with schema_context("public"):
+            cls.slava_jovan = Slava.objects.create(naziv="Свети Јован", dan=20, mesec=1)
+            cls.slava_petar = Slava.objects.create(naziv="Свети Петар", dan=12, mesec=7)
+
+    def test_filter_queryset_returns_public_slava_rows_inside_tenant(self):
+        widget = DomacinstvoForm().fields["slava"].widget
+        rf = RequestFactory()
+        request = rf.get("/select2/fields/auto.json")
+        # Simulate the AJAX call happening inside the tenant schema (where
+        # bare Slava.objects.filter() would error because the `slave` table
+        # is not in the tenant schema). The public-schema widget MUST still
+        # return rows.
+        results = widget.filter_queryset(request, "Јован", queryset=None)
+        labels = [str(o) for o in results]
+        self.assertTrue(
+            any("Јован" in l for l in labels),
+            f"expected Свети Јован in {labels!r}",
+        )
+
+    def test_filter_queryset_empty_term_returns_all_public_rows(self):
+        widget = DomacinstvoForm().fields["slava"].widget
+        rf = RequestFactory()
+        results = widget.filter_queryset(rf.get("/"), "", queryset=None)
+        # Two rows exist; widget MUST return them when no term is given.
+        pks = {o.pk for o in results}
+        self.assertIn(self.slava_jovan.pk, pks)
+        self.assertIn(self.slava_petar.pk, pks)
+
+    def test_get_queryset_does_not_break_set_to_cache(self):
+        """``set_to_cache`` materialises ``queryset.query`` — the override must
+        keep that path usable so widget caching still works."""
+        widget = DomacinstvoForm().fields["slava"].widget
+        # Render uses set_to_cache; build_attrs is needed first to assign uuid.
+        widget.build_attrs({})
+        # Should not raise (formerly broke when get_queryset returned a list).
+        widget.set_to_cache()
+
+
+class SlavaSelect2AjaxEndpointTests(TestCase):
+    """End-to-end: the django_select2 AJAX endpoint must return Slava rows
+    when called from inside a tenant request."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="slavajson", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.domacin = Osoba.objects.create(ime="Ђ", prezime="Тест", pol="М")
+        cls.dom = Domacinstvo.objects.create(domacin=cls.domacin)
+        with schema_context("public"):
+            cls.slava = Slava.objects.create(
+                naziv="Аранђеловдан", dan=21, mesec=11
+            )
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_ajax_endpoint_returns_slava_for_tenant_user(self):
+        self.client.force_login(self.clerk)
+        # Render the edit form first so the widget is cached under a fresh uuid.
+        from django.urls import reverse
+
+        page = self.client.get(
+            reverse("izmena_domacinstva", kwargs={"uid": self.dom.uid})
+        )
+        self.assertEqual(page.status_code, 200)
+        body = page.content.decode("utf-8")
+        # Extract the data-field_id for the slava widget so we can hit the
+        # auto-json endpoint just as the browser would.
+        idx = body.find('name="slava"')
+        self.assertGreater(idx, -1)
+        attr = 'data-field_id="'
+        start = body.find(attr, idx)
+        self.assertGreater(start, -1)
+        start += len(attr)
+        end = body.find('"', start)
+        field_id = body[start:end]
+        self.assertTrue(field_id)
+        r = self.client.get(
+            "/select2/fields/auto.json",
+            {"field_id": field_id, "term": "Аранђ"},
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        payload = r.json()
+        labels = [row["text"] for row in payload.get("results", [])]
+        self.assertTrue(
+            any("Аранђеловдан" in lbl for lbl in labels),
+            f"expected Аранђеловдан in {labels!r}",
+        )

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -69,6 +69,11 @@ urlpatterns = [
     path("search/", views.search_view, name="search_view"),
     path("api/search/", views.search_autocomplete, name="search_autocomplete"),
     path("api/brzi-unos-osobe/", views.brzi_unos_osobe, name="brzi_unos_osobe"),
+    path(
+        "api/brzi-izmena-adrese/<uuid:uid>/",
+        views.brzi_izmena_adrese,
+        name="brzi_izmena_adrese",
+    ),
     path("unos/parohijan/", views.unos_parohijana, name="unos_parohijana"),
     path("unos/krstenje/", views.unos_krstenja, name="unos_krstenja"),
     path("unos/vencanje/", views.unos_vencanja, name="unos_vencanja"),

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -5,8 +5,16 @@ from collections import defaultdict
 
 from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import render
-from registar.models import Domacinstvo, Krstenje, Parohijan, Slava, Svestenik, Vencanje
+from django.shortcuts import get_object_or_404, render
+from registar.models import (
+    Adresa,
+    Domacinstvo,
+    Krstenje,
+    Parohijan,
+    Slava,
+    Svestenik,
+    Vencanje,
+)
 from registar.utils import get_query_variants
 from registar.utils_fasting import get_fasting_type
 from tenants.permissions import tenant_role_required
@@ -450,3 +458,26 @@ def brzi_unos_osobe(request):
 
     osoba = Parohijan.objects.create(ime=ime, prezime=prezime, pol=pol or None)
     return JsonResponse({"id": osoba.uid, "text": str(osoba)})
+
+
+@tenant_role_required("domacinstvo")
+def brzi_izmena_adrese(request, uid):
+    """AJAX endpoint за брзу измену постојеће адресе из модалног дијалога.
+
+    Updates the address row identified by ``uid`` in place so that every
+    Domacinstvo currently pointing at that row sees the fresh values
+    without re-linking.
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    adresa = get_object_or_404(Adresa, uid=uid)
+    adresa.ulica = request.POST.get("ulica", "").strip()
+    adresa.broj = request.POST.get("broj", "").strip()
+    adresa.broj_stana = request.POST.get("broj_stana", "").strip()
+    adresa.mesto = request.POST.get("mesto", "").strip()
+    try:
+        adresa.save()
+    except Exception as exc:  # pragma: no cover - DB constraint surface
+        return JsonResponse({"error": str(exc)}, status=400)
+    return JsonResponse({"id": str(adresa.uid), "text": str(adresa)})


### PR DESCRIPTION
…ross-schema slava

* add PublicSchemaModelSelect2Widget that wraps queries in schema_context("public") so the Slava AJAX endpoint works inside tenant requests
* introduce inline Adresa edit modal + pencil button + brzi_izmena_adrese view to let clerks update the linked address in place
* unwrap slavska_vodica / vaskrsnja_vodica from <label> so the info-row slider CSS applies; render Да/Не in view mode
* cover the lot with 21 new tests (markup, endpoint, role gating, cross-schema queryset, ajax round-trip)