### PR TITLE
fix: clicking Измени on krstenje/vencanje no longer blanks the page

### DIFF
--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -55,8 +55,8 @@
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}
 
   {% if krstenje %}
-  <div class="tabs tabs--segmented" data-show-mode="view">
-    <div class="tabs__nav">
+  <div class="tabs tabs--segmented">
+    <div class="tabs__nav" data-show-mode="view">
       <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
       <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
       <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
@@ -318,7 +318,7 @@
     </section>
 
     {# ============ CERTIFICATE PREVIEW ============ #}
-    <section class="tabs__panel">
+    <section class="tabs__panel" data-show-mode="view">
       <div class="krstenica">
         <div class="krstenica-frame">
           <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -55,8 +55,8 @@
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}
 
   {% if vencanje %}
-  <div class="tabs tabs--segmented" data-show-mode="view">
-    <div class="tabs__nav">
+  <div class="tabs tabs--segmented">
+    <div class="tabs__nav" data-show-mode="view">
       <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
       <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
       <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
@@ -303,7 +303,7 @@
     </section>
 
     {# ============ CERTIFICATE PREVIEW ============ #}
-    <section class="tabs__panel">
+    <section class="tabs__panel" data-show-mode="view">
       <div class="vencanica">
         <div class="vencanica-frame">
           <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>


### PR DESCRIPTION
* move data-show-mode="view" from outer .tabs wrapper to .tabs__nav only
* mark cert-preview tabs__panel as view-only too
* edit mode now keeps the data panel visible while hiding tab nav + certificate