### PR TITLE
feat(theme): full color audit — token parity 1-1-1, contrast fixes, n…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,17 @@ repos:
         pass_filenames: false
         files: '\.py$'
 
+
+  # Block hardcoded hex colors in component CSS (use design tokens instead)
+  - repo: local
+    hooks:
+      - id: check-hardcoded-colors
+        name: no hardcoded colors in component CSS
+        entry: python scripts/check_hardcoded_colors.py
+        language: system
+        files: ^crkva/registar/static/registar/.*\.css$
+        pass_filenames: true
+
   # Validate commit message subject (feat: / fix: / refactor: / ...)
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.6.0

--- a/crkva/registar/static/registar/base/tokens.css
+++ b/crkva/registar/static/registar/base/tokens.css
@@ -20,7 +20,7 @@
 
     /* ---------- Aged gold (secondary accent) ---------- */
     --color-accent:         #B08443;
-    --color-accent-700:     #8C6B2F;
+    --color-accent-700:     #6B4F1A;  /* deepened — AA on accent-50 cream */
     --color-accent-200:     #E3CFA6;
     --color-accent-100:     #F1E5C9;
     --color-accent-50:      #F8F1DF;

--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -19,12 +19,12 @@ input[type="time"], input[type="datetime-local"], select, textarea {
   box-shadow: 0 1px 2px rgba(0,0,0,0.04);
 }
 
-input::placeholder { color: var(--color-placeholder, #94a3b8); }
+input::placeholder { color: var(--color-placeholder, var(--color-placeholder, var(--color-muted))); }
 
 .form-actions { display: flex; gap: 8px; }
 
-.help-text { color: #475569; font-size: 14px; margin-top: 6px; }
-.error-text { color: #b91c1c; font-size: 14px; margin-top: 6px; }
+.help-text { color: var(--color-text-muted); font-size: 14px; margin-top: 6px; }
+.error-text { color: var(--color-error-text, var(--color-danger)); font-size: 14px; margin-top: 6px; }
 
 /* Vidljiv fokus */
 input:focus, select:focus, textarea:focus {
@@ -267,8 +267,8 @@ input[name="vreme_rodjenja"]:focus {
 .form-field input[type="checkbox"]:hover { border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border)); }
 .form-field input[type="checkbox"]:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 20%, transparent); }
 .form-field input[type="checkbox"]:checked {
-  background: color-mix(in oklab, var(--color-success, #22c55e) 60%, var(--color-surface-2));
-  border-color: var(--color-success, #22c55e);
+  background: color-mix(in oklab, var(--color-success, var(--color-success)) 60%, var(--color-surface-2));
+  border-color: var(--color-success, var(--color-success));
 }
 .form-field input[type="checkbox"]:checked::after { transform: translateX(20px); }
 /* Greenish check mark when true */
@@ -279,8 +279,8 @@ input[name="vreme_rodjenja"]:focus {
   top: 6px;
   width: 8px;
   height: 14px;
-  border-right: 3px solid var(--color-success, #22c55e);
-  border-bottom: 3px solid var(--color-success, #22c55e);
+  border-right: 3px solid var(--color-success, var(--color-success));
+  border-bottom: 3px solid var(--color-success, var(--color-success));
   transform: rotate(45deg) scale(0.8);
   opacity: 0;
   transition: opacity 0.2s ease;
@@ -312,7 +312,7 @@ input[name="vreme_rodjenja"]:focus {
 .form__group { margin-bottom: 12px; }
 .form__actions { display: flex; gap: 8px; }
 .form__help-text { color: var(--color-text-muted); font-size: 14px; margin-top: 6px; }
-.form__error-text { color: #b91c1c; font-size: 14px; margin-top: 6px; }
+.form__error-text { color: var(--color-error-text, var(--color-danger)); font-size: 14px; margin-top: 6px; }
 
 
 /* FK поље са акцијским дугметом (+ за додавање) */

--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -188,8 +188,8 @@
     box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 20%, transparent);
 }
 .info-row--editable .info-row__value > input[type="checkbox"]:checked {
-    background: color-mix(in oklab, var(--color-success, #22c55e) 60%, var(--color-surface-2));
-    border-color: var(--color-success, #22c55e);
+    background: color-mix(in oklab, var(--color-success, var(--color-success)) 60%, var(--color-surface-2));
+    border-color: var(--color-success, var(--color-success));
 }
 .info-row--editable .info-row__value > input[type="checkbox"]:checked::after {
     transform: translateX(20px);

--- a/crkva/registar/static/registar/components/modali.css
+++ b/crkva/registar/static/registar/components/modali.css
@@ -114,7 +114,7 @@
 }
 
 .modal .error-text {
-    color: var(--color-danger, #b91c1c);
+    color: var(--color-danger, var(--color-error-text, var(--color-danger)));
     font-size: 13px;
     margin-top: 8px;
 }
@@ -125,7 +125,7 @@
     padding: 10px 14px;
     border-top: 1px solid var(--color-border);
     background: var(--color-surface-2);
-    color: var(--color-primary, #a21514);
+    color: var(--color-primary, var(--color-primary));
     cursor: pointer;
     font-weight: 600;
     font-size: 13px;

--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -101,7 +101,7 @@
 
 .stavka__member {
     padding: 10px;
-    border-left: 3px solid #28a745;
+    border-left: 3px solid var(--color-success);
     margin: 10px 0;
     background: var(--color-surface);
     border-radius: 4px;

--- a/crkva/registar/static/registar/themes/sepia.css
+++ b/crkva/registar/static/registar/themes/sepia.css
@@ -76,6 +76,92 @@
     --fasting-fish-bg:  rgba(61, 88, 120, 0.16);
     --fasting-oil-bg:   rgba(176, 132, 67, 0.26);
     --fasting-water-bg: rgba(61, 88, 120, 0.24);
+
+    /* ---------- Token parity (Move 7) — explicit values per theme ---------- */
+
+    /* Accent: keep family, slightly cooler on sepia */
+    --color-accent:         #B08443;
+    --color-accent-700:     #6B4F1A;   /* deepened for AA contrast on cream */
+    --color-accent-200:     #E3CFA6;
+    --color-accent-100:     #F1E5C9;
+    --color-accent-50:      #F8F1DF;
+    --color-accent-transparent: rgba(176, 132, 67, 0.18);
+
+    /* Info — warm-toned to fit sepia */
+    --color-info-light:        #EFE6CE;
+    --color-info-border-light: #D8C9A0;
+    --color-info-link:         #3D5878;
+
+    /* Link tokens */
+    --color-link:        var(--color-primary);
+    --color-link-hover:  var(--color-primary-700);
+
+    /* Sidebar muted (was rgba on light — explicit on sepia) */
+    /* (already declared in sidebar block above) */
+
+    /* Ink family — same conceptual color across themes */
+    --color-ink-900:     #15161D;
+    --color-ink-800:     #1B1D26;
+    --color-ink-700:     #262934;
+    --color-ink-600:     #3A3E4C;
+
+    /* Greys — re-toned to warm so they fit sepia surfaces */
+    --color-gray-100: #FBF5E3;
+    --color-gray-200: #F1E9D9;
+    --color-gray-300: #E0D4B6;
+    --color-gray-400: #C9B79A;
+    --color-gray-500: #9E8D72;
+    --color-gray-600: #7A6A55;
+    --color-gray-700: #3D2E1F;
+    --color-gray-800: #F4ECD6;
+    --color-gray-900: #FBF5E3;
+    --color-gray-light:  #E0D4B6;
+    --color-gray-border: rgba(176, 132, 67, 0.30);
+    --color-gray-dark:   #C9B79A;
+
+    /* Amber/today highlight — warm */
+    --color-amber-500: #B08443;
+    --color-amber-400: #C19A57;
+    --color-amber-300: #D5B475;
+    --color-amber-200: #E3CFA6;
+    --color-amber-100: #F1E5C9;
+    --color-amber-900: #5A3F18;
+    --color-amber-800: #6B4F1A;
+
+    /* Fasting cells — explicit (light's color-mix values resolve here too, but
+       declaring guarantees identical computation in tools and avoids surprises). */
+    --fasting-dairy-bg: rgba(176, 132, 67, 0.18);
+    --fasting-fish-bg:  rgba(61, 88, 120, 0.16);
+    --fasting-oil-bg:   rgba(176, 132, 67, 0.28);
+    --fasting-water-bg: rgba(61, 88, 120, 0.26);
+
+    /* Other utility */
+    --color-black-alpha-90: rgba(0, 0, 0, 0.9);
+    --color-white-alpha-20: rgba(237, 230, 214, 0.18);
+
+    /* Legacy dark-* aliases (kept for back-compat) */
+    --color-dark-bg:            var(--color-ink-800);
+    --color-dark-bg-deep:       var(--color-ink-900);
+    --color-dark-border:        #2D3140;
+    --color-dark-text:          #EDE6D6;
+    --color-dark-text-secondary:#9C8E7D;
+
+    /* Secondary */
+    --color-secondary: #6E0F0E;
+
+    /* Fasting cells — explicit values (Move 7b token parity) */
+    --fasting-oil-cell:       #F1E5C9;
+    --fasting-oil-cell-end:   #F8F1DF;
+    --fasting-oil-border:     #E3CFA6;
+    --fasting-dairy-cell:     #F3EAD2;
+    --fasting-dairy-cell-end: #FBF5E3;
+    --fasting-dairy-border:   #E3CFA6;
+    --fasting-fish-cell:      #E8E0CC;
+    --fasting-fish-cell-end:  #F4ECD6;
+    --fasting-fish-border:    #B8C0CC;
+    --fasting-water-cell:     #C2C4C2;
+    --fasting-water-cell-end: #D6D6CE;
+    --fasting-water-border:   #95A3B5;
 }
 
 [data-theme="sepia"] body {

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -5,9 +5,9 @@
    ========================================================================== */
 :root[data-theme="dark"] {
     /* ---------- Brand ---------- */
-    --color-primary:       #D14A48;
+    --color-primary:       #E5605E;
     --color-primary-700:   #B0302E;
-    --color-primary-hover: #E26967;
+    --color-primary-hover: #F08886;
     --color-primary-transparent: rgba(209, 74, 72, 0.18);
     --color-primary-50:    color-mix(in oklab, var(--color-primary) 14%, var(--color-ink-900));
     --color-primary-100:   color-mix(in oklab, var(--color-primary) 22%, var(--color-ink-900));
@@ -92,6 +92,91 @@
     --tooltip-bg:     #2A2D3A;
     --tooltip-text:   #EDE6D6;
     --tooltip-shadow: rgba(0, 0, 0, 0.6);
+
+    /* ---------- Token parity (Move 7) — explicit values for dark surfaces ---------- */
+
+    /* Info — dark-tinted instead of inheriting light cream */
+    --color-info-light:        #1A2A3A;
+    --color-info-border-light: #2E4868;
+    --color-info-link:         #7BA6C6;
+    --color-info-bg:           #1A2A3A;
+    --color-info-border:       #2E4868;
+
+    /* Warning — dark-tinted */
+    --color-warning-text:      #F5D88A;
+    --color-warning-bg:        #2D2410;
+    --color-warning-border:    #7C5E1C;
+
+    /* Error — dark-tinted */
+    --color-error-text:        #F5A5A3;
+    --color-error-bg:          #2A1311;
+    --color-error-border:      #7C2624;
+
+    /* Slava already overridden above; explicit for completeness */
+
+    /* Link tokens */
+    --color-link:        var(--color-primary);
+    --color-link-hover:  var(--color-primary-hover);
+
+    /* Ink family */
+    --color-ink-900:     #15161D;
+    --color-ink-800:     #1B1D26;
+    --color-ink-700:     #262934;
+    --color-ink-600:     #3A3E4C;
+
+    /* Greys — dark-friendly */
+    --color-gray-100: #2A2D3A;
+    --color-gray-200: #383C4D;
+    --color-gray-300: #484F58;
+    --color-gray-400: #6E7681;
+    --color-gray-500: #9C8E7D;
+    --color-gray-600: #B5A99A;
+    --color-gray-700: #EDE6D6;
+    --color-gray-800: #383C4D;
+    --color-gray-900: #2A2D3A;
+    --color-gray-light:  #484F58;
+    --color-gray-border: rgba(213, 180, 117, 0.16);
+    --color-gray-dark:   #6E7681;
+
+    /* Amber (today highlight) — bright on dark */
+    --color-amber-500: #D5B475;
+    --color-amber-400: #E3CFA6;
+    --color-amber-300: #F1E5C9;
+    --color-amber-200: #F8F1DF;
+    --color-amber-100: #FBF5E3;
+    --color-amber-900: #B08443;
+    --color-amber-800: #8C6B2F;
+
+    /* Accent transparent on dark */
+    --color-accent-transparent: rgba(213, 180, 117, 0.18);
+
+    /* Other utility */
+    --color-black-alpha-90: rgba(0, 0, 0, 0.95);
+    --color-white-alpha-20: rgba(237, 230, 214, 0.14);
+
+    /* Legacy dark-* aliases */
+    --color-dark-bg:            var(--color-ink-800);
+    --color-dark-bg-deep:       var(--color-ink-900);
+    --color-dark-border:        var(--color-border-strong);
+    --color-dark-text:          var(--color-text);
+    --color-dark-text-secondary:var(--color-text-muted);
+
+    /* Secondary */
+    --color-secondary: #B0302E;
+
+    /* Fasting cells — explicit dark values (Move 7b token parity) */
+    --fasting-oil-cell:       #2D2410;
+    --fasting-oil-cell-end:   #1F212B;
+    --fasting-oil-border:     #7C5E1C;
+    --fasting-dairy-cell:     #262934;
+    --fasting-dairy-cell-end: #1F212B;
+    --fasting-dairy-border:   #3A3E4C;
+    --fasting-fish-cell:      #1A2A3A;
+    --fasting-fish-cell-end:  #1F212B;
+    --fasting-fish-border:    #2E4868;
+    --fasting-water-cell:     #1F2E40;
+    --fasting-water-cell-end: #1F212B;
+    --fasting-water-border:   #2E4868;
 }
 
 [data-theme="dark"] body {

--- a/scripts/check_hardcoded_colors.py
+++ b/scripts/check_hardcoded_colors.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Block hardcoded hex colors in component CSS — they bypass theming.
+
+Allowed locations for raw hex:
+  - crkva/registar/static/registar/base/tokens.css   (canonical palette)
+  - crkva/registar/static/registar/themes/*.css      (theme overrides)
+
+Allowed values everywhere (affordance colors):
+  - #fff / #ffffff   (white knob on toggle switches, text on red buttons)
+  - #000 / #000000   (true black, rarely used)
+
+Everything else under components/, layout/, utilities/, pages/ must
+reference a `var(--color-*)` token so themes (light / sepia / dark)
+can override it. Run by pre-commit on staged .css files.
+"""
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+
+HEX_RE = re.compile(r"#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}\b")
+ALLOWED_VALUES = {"#fff", "#ffffff", "#000", "#000000"}
+# Path fragments where raw hex is OK (the canonical palette + theme overrides)
+ALLOWED_PATH_FRAGMENTS = (
+    "/base/tokens.css",
+    "/themes/",
+    "/print/",  # print stylesheets target paper — fixed colors are fine
+)
+
+def is_allowed_file(path: Path) -> bool:
+    s = str(path).replace("\\", "/")
+    return any(frag in s for frag in ALLOWED_PATH_FRAGMENTS)
+
+def scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return list of (line_no, value, line_text) for offending hexes."""
+    findings: list[tuple[int, str, str]] = []
+    in_block_comment = False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return findings
+    for ln, raw in enumerate(text.splitlines(), 1):
+        line = raw
+        # naive block-comment tracking
+        if in_block_comment:
+            end = line.find("*/")
+            if end < 0:
+                continue
+            line = line[end + 2:]
+            in_block_comment = False
+        while True:
+            start = line.find("/*")
+            if start < 0:
+                break
+            end = line.find("*/", start + 2)
+            if end < 0:
+                line = line[:start]
+                in_block_comment = True
+                break
+            line = line[:start] + line[end + 2:]
+        if line.strip().startswith("//"):  # not real CSS but defensive
+            continue
+        for m in HEX_RE.finditer(line):
+            value = m.group(0).lower()
+            if value in ALLOWED_VALUES:
+                continue
+            findings.append((ln, value, raw.strip()))
+    return findings
+
+def main(argv: list[str]) -> int:
+    # pre-commit passes filenames; if none provided, scan project default dirs.
+    if argv:
+        paths = [Path(a) for a in argv]
+    else:
+        base = Path("crkva/registar/static/registar")
+        paths = list(base.rglob("*.css"))
+    # Only CSS files
+    paths = [p for p in paths if p.suffix == ".css"]
+    violations: list[tuple[Path, list[tuple[int, str, str]]]] = []
+    for p in paths:
+        if is_allowed_file(p):
+            continue
+        findings = scan_file(p)
+        if findings:
+            violations.append((p, findings))
+    if not violations:
+        return 0
+    print("Hardcoded hex colors found in component CSS (use var(--color-*) tokens):")
+    print()
+    for path, findings in violations:
+        for ln, value, snippet in findings:
+            print(f"  {path}:{ln}  {value}")
+            print(f"      {snippet}")
+    print()
+    print("Allowed only in:")
+    print("  - crkva/registar/static/registar/base/tokens.css")
+    print("  - crkva/registar/static/registar/themes/*.css")
+    print("  - crkva/registar/static/registar/print/*.css")
+    print(f"  - the values {sorted(ALLOWED_VALUES)} (affordance whites/blacks)")
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
…o hardcoded hex

audit findings (before this commit):
- 54 color tokens declared in light but missing in sepia
- 45 missing in dark — they inherited cream/warm values, broke on dark
- 7 contrast pairs failed WCAG AA in at least one theme
- 12 hardcoded hex colors in component CSS bypassed theming (#22c55e ×7, #28a745, #475569, #94a3b8, #a21514, #b91c1c ×3)

fixes:
- themes/sepia.css: declared all 54 missing tokens with warm sepia values (accent family, ink, info, warm greys, amber, fasting cells, etc.)
- themes/tamna.css: declared all 45 missing tokens with dark-tinted values (info-light → dark blue, warning bg → dark amber, error bg → dark red)
- tokens.css: deepened --color-accent-700 #8C6B2F → #6B4F1A (lifts AA contrast on accent-50 cream from 4.38 → 6.66)
- tamna.css: brightened --color-primary #D14A48 → #E5605E for AA on dark
- all hardcoded greens in info.css/spiskovi.css/forme.css/modali.css replaced with var(--color-success) / var(--color-primary) / var(--color-error-text) / var(--color-text-muted)
- explicit fasting-* tokens in sepia and dark (were inheriting color-mix values that resolved to light surface tones)

post-audit:
- 0 tokens missing in either sepia or dark
- 0 hardcoded hex remaining in components (only #fff/#000 affordance allowed)
- all critical text/bg pairs ≥ AA across all 3 themes

guardrails:
- new scripts/check_hardcoded_colors.py scans component CSS for raw hex outside the allowed paths (tokens.css, themes/, print/) and the allowed values (#fff/#000)
- wired into .pre-commit-config.yaml as a local hook
- will block future commits that reintroduce theme-bypassing colors