### PR TITLE
fix(home): hero shows TODAY (not yesterday)

### DIFF
--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -641,10 +641,11 @@
   flex-direction: column;
   justify-content: center;
   padding: var(--space-3) var(--space-4);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: color-mix(in oklab, var(--color-accent) 8%, var(--color-surface));
+  border: 1px solid var(--color-accent-200);
   border-left: 4px solid var(--color-accent);
   border-radius: var(--radius-2);
+  box-shadow: var(--shadow-sm);
 }
 .dashboard-today__day-label {
   font-family: var(--font-sans);

--- a/crkva/registar/templates/registar/index.html
+++ b/crkva/registar/templates/registar/index.html
@@ -16,7 +16,7 @@
       </a>
     </div>
 
-    {% with today=calendar_cells.0 %}
+    {% with today=today_cell %}
       <div class="dashboard-today">
         <div class="dashboard-today__date">
           <div class="dashboard-today__day-label">{{ today.day_label }}</div>
@@ -66,7 +66,7 @@
     {% endwith %}
 
     <ul class="dashboard-upcoming">
-      {% for day in calendar_cells|slice:"1:" %}
+      {% for day in upcoming_cells %}
         {% with all_slavas=day.moveable_slavas|add:day.fixed_slavas %}
           {% if all_slavas %}
             {% with first_slava=all_slavas|first %}

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -209,6 +209,11 @@ def index(request) -> HttpResponse:
             }
         )
 
+    # Split cells for the home page: today gets the hero, the next 5 days
+    # form the upcoming-list. (calendar_cells stays full for backwards compat.)
+    today_cell = next((c for c in cells if c["is_today"]), None)
+    upcoming_cells = [c for c in cells if c["date"] > today]
+
     context = {
         "stats": {
             "parohijani": Parohijan.objects.count(),
@@ -217,6 +222,8 @@ def index(request) -> HttpResponse:
             "svestenici": Svestenik.objects.count(),
         },
         "calendar_cells": cells,
+        "today_cell": today_cell,
+        "upcoming_cells": upcoming_cells,
     }
 
     return render(request, "registar/index.html", context)


### PR DESCRIPTION
calendar_cells starts at today-1 (yesterday) per the view's loop range(-1, 6), so my earlier template used cells.0 == yesterday for the hero. that's why the page rendered "јуче, 18.5." even when today is 19.5.

view (registar/views/__init__.py):
- add today_cell  = next(c for c in cells if c["is_today"])
- add upcoming_cells = [c for c in cells if c["date"] > today]
- calendar_cells kept intact (no breakage)

template (index.html):
- hero uses today_cell instead of calendar_cells.0
- upcoming list iterates upcoming_cells instead of slice:"1:" (which previously included today as the first upcoming row)

visual emphasis on the today block:
- dashboard-today__date gets a soft gold-tinted background (color-mix accent 8% over surface) + accent-200 border + shadow-sm
- the existing 4px gold left rail stays — combined effect reads as "this is today" without being loud