### PR TITLE
fix(kalendar): lock 7-col grid at ALL viewports, no more auto-fit ove…

### DIFF
--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -308,20 +308,17 @@
   color: var(--color-text-muted);
 }
 
-/* Tablet and mobile optimizations */
+/* Tablet: keep 7 columns, tighten the gutters and hide nothing.
+   (Previously dropped weekday headers + placeholders + used auto-fit,
+   which caused days to land under the wrong weekday.) */
 @media (max-width: 900px) {
   .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 8px;
+    gap: var(--space-1);
   }
-  .weekday-header { display: none; }
-  .calendar-cell.placeholder { display: none; }
 }
 
 @media (max-width: 768px) {
-  .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  }
+  /* keep grid-template-columns from base (7 cols) — only relax cell sizing */
   .calendar-cell {
     height: auto;
     min-height: 110px;
@@ -362,13 +359,10 @@
 }
 
 @media (max-width: 600px) {
-  .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-    gap: 6px;
-  }
+  /* grid switches to single-column stack via the dedicated rule further down */
   .calendar-cell {
     min-height: 90px;
-    padding: 8px;
+    padding: var(--space-2);
   }
   .calendar-cell .date { font-size: 1rem; }
   .calendar-cell .weekday { font-size: 0.7rem; }
@@ -376,11 +370,10 @@
   .slava-link__count { font-size: 10px; padding: 0 4px; }
 }
 
-/* Small mobile - single column for better readability */
+/* Small mobile — covered by the single-column stack rule below */
 @media (max-width: 480px) {
   .calendar-grid {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 6px;
+    gap: var(--space-1);
   }
   .calendar-cell {
     height: auto;


### PR DESCRIPTION
…rrides

last fix changed the BASE rule to 7 cols, but kalendar.css had four more @media overrides (900/768/600/480) that re-introduced auto-fit with minmax(110-140px). on the 600-900 range the grid still rendered 3-5 columns instead of 7 — days landed under the wrong weekday header (friday under tuesday etc).

now:
- base + 900/768/480: always repeat(7, minmax(0, 1fr)) from the base declaration. responsive only relaxes gap/padding, never column count.
- <=600px: explicit single-column stack via the dedicated rule that already lived at the bottom of the file (drops weekday headers + placeholders, lets days flow as a list).
- 0 auto-fit usages remain.