### PR TITLE
fix(detail): restore edit + history buttons on krstenje/vencanje

### DIFF
--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -40,7 +40,9 @@
     </h1>
     {% if krstenje %}
       <span data-show-mode="view">
+        {% if can_edit_krstenje %}<a href="{% url 'izmena_krstenja' uid=krstenje.uid %}" data-action="enter-edit" class="button button--neutral button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
         <a href="{% url 'krstenje_pdf' krstenje.uid %}" target="_blank" class="button button--neutral button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+        <button type="button" id="history-toggle" class="button button--ghost button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
       </span>
       <span data-show-mode="edit">
         <button type="button" data-action="cancel-edit" class="button button--secondary button--icon" data-tooltip="Откажи"><i class="fa-solid fa-xmark"></i></button>

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -40,7 +40,9 @@
     </h1>
     {% if vencanje %}
       <span data-show-mode="view">
+        {% if can_edit_vencanje %}<a href="{% url 'izmena_vencanja' uid=vencanje.uid %}" data-action="enter-edit" class="button button--neutral button--icon" data-tooltip="Измени"><i class="fa-solid fa-pen-to-square"></i></a>{% endif %}
         <a href="{% url 'vencanje_pdf' vencanje.uid %}" target="_blank" class="button button--neutral button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
+        <button type="button" id="history-toggle" class="button button--ghost button--icon" data-tooltip="Историја измена"><i class="fa-solid fa-clock-rotate-left"></i></button>
       </span>
       <span data-show-mode="edit">
         <button type="button" data-action="cancel-edit" class="button button--secondary button--icon" data-tooltip="Откажи"><i class="fa-solid fa-xmark"></i></button>


### PR DESCRIPTION
i misread the earlier slava-print request as "strip vencanje + krstenje down to print-only". the request was actually "slava needs a print button too" — vencanje and krstenje always had edit + print + history and should not have lost them.

restoring on both krstenje.html and vencanje.html view-mode toolbar:
- {% if can_edit_<obj> %} Измени  (button--neutral button--icon)
- Штампај                          (button--neutral, was already there)
- Историја измена                  (button--ghost button--icon)

same hierarchy as parohijan/svestenik/domacinstvo detail pages.