### PR TITLE
fix(layout): global box-sizing border-box + body overflow-x hidden

### DIFF
--- a/crkva/registar/static/registar/base/tokens.css
+++ b/crkva/registar/static/registar/base/tokens.css
@@ -175,6 +175,15 @@
     --font-body:    var(--font-sans);
 }
 
+/* Global box-sizing reset — every element computes width from total
+   (padding + border included), not from content only. Without this,
+   any child with width:100% + padding overflows its parent. */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
 html,
 body {
     margin: 0;
@@ -184,6 +193,9 @@ body {
     font-family: var(--font-sans);
     color: var(--color-text);
     background-color: var(--color-surface);
+    /* Suppress horizontal scrollbar if any descendant ever overflows
+       (defensive — content should never need horizontal scroll). */
+    overflow-x: hidden;
 }
 
 body > main { flex: 1; }


### PR DESCRIPTION
users reported elements partially hidden beyond the right edge when resizing the viewport. likely cause: only a handful of selectors had explicit box-sizing:border-box (.u-container, .grid). every other element (.card, .dashboard-today, .calendar-cell, ...) inherited the default content-box, so width:100% + padding would push past the parent edge and clip on the right.

added universal selector reset:
  *, *::before, *::after { box-sizing: border-box; }

plus a defensive overflow-x: hidden on body so any future overflow caused by extension overlays or untested wide content does not produce horizontal scrollbars.

no visual change for content that was already sized correctly. fixes the class of bugs where padding + width:100% would overflow.