### PR TITLE
fix(theme): action title and registry count invisible on dark theme

### DIFF
--- a/crkva/registar/static/registar/components/akcije.css
+++ b/crkva/registar/static/registar/components/akcije.css
@@ -28,6 +28,7 @@
     border-color: var(--color-accent);
     box-shadow: inset 3px 0 0 var(--color-accent);
     color: var(--color-text);
+    text-decoration: none;
 }
 
 .actions__icon,
@@ -53,7 +54,7 @@
     font-family: var(--font-serif);
     font-weight: 700;
     margin-bottom: 2px;
-    color: var(--color-ink-900);
+    color: var(--color-text);
     font-size: 0.95rem;
     line-height: 1.2;
 }

--- a/crkva/registar/static/registar/components/kartice.css
+++ b/crkva/registar/static/registar/components/kartice.css
@@ -103,7 +103,7 @@
     font-family: var(--font-mono);
     font-weight: 500;
     font-variant-numeric: tabular-nums;
-    color: var(--color-ink-900);
+    color: var(--color-text);
     font-size: 1.5rem;
     letter-spacing: -0.02em;
 }


### PR DESCRIPTION
- .actions__title and .registry__count used --color-ink-900 (literal #15161D in all themes), so dark surface rendered near-black text → invisible
- switch both to --color-text (theme-aware: light=ink, dark=parchment)
- pin text-decoration: none on .actions__item:hover to suppress the global a:hover underline