### PR TITLE
feat(ui): page title + subtitle split on detail pages

### DIFF
--- a/crkva/registar/static/registar/base/tokens.css
+++ b/crkva/registar/static/registar/base/tokens.css
@@ -265,6 +265,19 @@ h1.u-page-title {
     letter-spacing: 0.02em;
 }
 
+/* Page title subtitle — the noun stays in display font; the proper name
+   sits below in PT Serif, demoted in weight + color but still readable. */
+.u-page-title__subtitle {
+    display: block;
+    font-family: var(--font-serif);
+    font-weight: 500;
+    font-size: 0.62em;
+    line-height: 1.3;
+    color: var(--color-text-muted);
+    letter-spacing: 0;
+    margin-top: var(--space-1);
+}
+
 /* Ledger utility */
 .u-ledger,
 .stavka__secondary,
@@ -352,7 +365,7 @@ a:hover { color: var(--color-link-hover); text-decoration: underline; }
 /* .u-container handled in pomocno.css — fluid, no max-width cap. */
 .u-page-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--space-3);
     padding: 0 var(--space-5);
     margin-top: var(--space-3);

--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -40,7 +40,7 @@
 
 .u-page-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: var(--space-4);
     margin: var(--space-5) 0 var(--space-3);

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -18,8 +18,8 @@
     <a href="{% if is_edit and domacinstvo %}{% url "domacinstvo_detail" uid=domacinstvo.uid %}{% else %}{% url "domacinstva" %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
     <h1 class="u-page-title">
       {% if is_edit and not domacinstvo %}Додавање домаћинства
-      {% elif is_edit %}Измена домаћинства{% if domacinstvo.domacin %} · {{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}{% endif %}
-      {% else %}Домаћинство · {{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}{% endif %}
+      {% elif is_edit %}Измена домаћинства{% if domacinstvo.domacin %}<span class="u-page-title__subtitle">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</span>{% endif %}
+      {% else %}Домаћинство{% if domacinstvo.domacin %}<span class="u-page-title__subtitle">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</span>{% endif %}{% endif %}
     </h1>
     {% if domacinstvo %}
       <span data-show-mode="view">

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -35,8 +35,8 @@
     <a href="{% if is_edit and krstenje %}{% url 'krstenje_detail' uid=krstenje.uid %}{% else %}{% url 'krstenja' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
     <h1 class="u-page-title">
       {% if is_edit and not krstenje %}Унос крштења
-      {% elif is_edit %}Измена крштења{% if krstenje %} — {{ krstenje.ime_deteta }}{% endif %}
-      {% else %}Крштење — {{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}{% endif %}
+      {% elif is_edit %}Измена крштења{% if krstenje %}<span class="u-page-title__subtitle">{{ krstenje.ime_deteta }}</span>{% endif %}
+      {% else %}Крштење<span class="u-page-title__subtitle">{{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}</span>{% endif %}
     </h1>
     {% if krstenje %}
       <span data-show-mode="view">

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -33,8 +33,8 @@
     </a>
     <h1 class="u-page-title">
       {% if is_edit and not parohijan %}Додавање парохијана
-      {% elif is_edit %}Измена: {{ parohijan.ime }} {{ parohijan.prezime }}
-      {% else %}{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime and parohijan.pol == "Ж" %} <span class="osoba__devojacko">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}{% endif %}
+      {% elif is_edit %}Измена парохијана{% if parohijan %}<span class="u-page-title__subtitle">{{ parohijan.ime }} {{ parohijan.prezime }}</span>{% endif %}
+      {% else %}Парохијан<span class="u-page-title__subtitle">{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime and parohijan.pol == "Ж" %} <span class="osoba__devojacko">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}</span>{% endif %}
     </h1>
     {% if parohijan %}
       <span data-show-mode="view">

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -18,8 +18,8 @@
     </a>
     <h1 class="u-page-title">
       {% if is_edit and not svestenik %}Додавање свештеника
-      {% elif is_edit %}Измена: {{ svestenik.ime }} {{ svestenik.prezime }}
-      {% else %}{{ svestenik.ime }} {{ svestenik.prezime }}{% endif %}
+      {% elif is_edit %}Измена свештеника{% if svestenik %}<span class="u-page-title__subtitle">{{ svestenik.ime }} {{ svestenik.prezime }}</span>{% endif %}
+      {% else %}Свештеник<span class="u-page-title__subtitle">{{ svestenik.ime }} {{ svestenik.prezime }}</span>{% endif %}
     </h1>
     {% if svestenik %}
       <span data-show-mode="view">

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -35,8 +35,8 @@
     <a href="{% if is_edit and vencanje %}{% url 'vencanje_detail' uid=vencanje.uid %}{% else %}{% url 'vencanja' %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
     <h1 class="u-page-title">
       {% if is_edit and not vencanje %}Унос венчања
-      {% elif is_edit %}Измена венчања
-      {% else %}Венчање — {{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}{% endif %}
+      {% elif is_edit %}Измена венчања{% if vencanje %}<span class="u-page-title__subtitle">{{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</span>{% endif %}
+      {% else %}Венчање<span class="u-page-title__subtitle">{{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</span>{% endif %}
     </h1>
     {% if vencanje %}
       <span data-show-mode="view">


### PR DESCRIPTION
- noun (e.g. Крштење, Венчање, Парохијан, Свештеник, Домаћинство) stays in the display font as the title
- proper name moves to a subtitle below in PT Serif, demoted in weight + color
- replaces the em-dash inline form "Крштење — ЈОВАНА Благојевић"
- new .u-page-title__subtitle utility class in tokens.css
- .u-page-header switched to align-items: flex-start so action buttons stay at top edge of a two-line title