### PR TITLE
fix(ui): suppress hover underline on all card-style anchors

### DIFF
--- a/crkva/registar/static/registar/components/kartice.css
+++ b/crkva/registar/static/registar/components/kartice.css
@@ -86,7 +86,7 @@
 }
 
 .card__link:hover,
-.view-all-link:hover { color: var(--color-primary-700); }
+.view-all-link:hover { color: var(--color-primary-700); text-decoration: none; }
 
 /* Registry Overview */
 .registry,
@@ -127,6 +127,7 @@
     background: var(--color-surface);
     border-color: var(--color-accent);
     box-shadow: inset 3px 0 0 var(--color-accent), var(--shadow-sm);
+    text-decoration: none;
 }
 
 .registry__icon,

--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -36,6 +36,7 @@
 
 .stavka-veza:hover {
     color: var(--color-text-muted);
+    text-decoration: none;
 }
 
 .stavka-veza {

--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -770,6 +770,7 @@
 .dashboard-upcoming__row:hover {
   background: color-mix(in oklab, var(--color-accent) 6%, var(--color-surface-2));
   color: var(--color-text);
+  text-decoration: none;
 }
 .dashboard-upcoming__date {
   font-family: var(--font-mono);


### PR DESCRIPTION
- .registry__card (home page registry tiles)
- .card__link / .view-all-link (home page "see all" links)
- .dashboard-upcoming__row (upcoming-days list rows)
- .stavka-veza (every ledger row across list + search pages)
- previous PR only patched .actions__item:hover; the global a:hover { text-decoration: underline } from tokens.css still leaked onto every other tile/card-style anchor