### PR TITLE
feat(forms): inline per-field error UX

### DIFF
--- a/crkva/registar/static/registar/components/form-errors.js
+++ b/crkva/registar/static/registar/components/form-errors.js
@@ -1,0 +1,86 @@
+/* Inline form-error decorator.
+ *
+ * Reads the JSON payload emitted by registar/_form_errors.html
+ * (`#form-errors-data` = { field_name: ["error", ...] }), finds the matching
+ * input/select/textarea by [name], walks up to its closest .info-row, marks
+ * it with .info-row--has-error, and injects a .info-row__error bubble.
+ *
+ * Auto-scrolls and focuses the first errored field on load. Clears the error
+ * state for a field as soon as the user starts editing it (input/change),
+ * so the red border + bubble disappear without waiting for a re-submit.
+ */
+(function () {
+  'use strict';
+
+  var dataEl = document.getElementById('form-errors-data');
+  if (!dataEl) return;
+
+  var errorsByField;
+  try {
+    errorsByField = JSON.parse(dataEl.textContent || '{}');
+  } catch (e) {
+    return;
+  }
+
+  function findInput(name) {
+    // Prefer an input directly inside an .info-row over any other [name]
+    // (e.g. hidden helpers from select2 / formsets).
+    var candidates = document.querySelectorAll(
+      '[name="' + name.replace(/"/g, '\\"') + '"]'
+    );
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].closest('.info-row')) return candidates[i];
+    }
+    return candidates[0] || null;
+  }
+
+  function decorateField(name, messages) {
+    var input = findInput(name);
+    if (!input) return null;
+    var row = input.closest('.info-row');
+    if (!row) return null;
+
+    row.classList.add('info-row--has-error');
+    input.setAttribute('aria-invalid', 'true');
+
+    // Inject the bubble after the input's value-wrapper, only if not present.
+    var bubble = row.querySelector('.info-row__error');
+    if (!bubble) {
+      bubble = document.createElement('div');
+      bubble.className = 'info-row__error';
+      bubble.setAttribute('role', 'alert');
+      // Anchor the bubble inside the row body for layout consistency.
+      var anchor = row.querySelector('.info-row__body') || row;
+      anchor.appendChild(bubble);
+    }
+    bubble.textContent = messages.join(' · ');
+
+    // Clear on first edit. `once: true` ensures we don't re-bind.
+    var clear = function () {
+      row.classList.remove('info-row--has-error');
+      input.removeAttribute('aria-invalid');
+      if (bubble && bubble.parentNode) bubble.parentNode.removeChild(bubble);
+    };
+    input.addEventListener('input', clear, { once: true });
+    input.addEventListener('change', clear, { once: true });
+
+    return input;
+  }
+
+  var firstInput = null;
+  Object.keys(errorsByField).forEach(function (name) {
+    var messages = errorsByField[name];
+    if (!messages || !messages.length) return;
+    var input = decorateField(name, messages);
+    if (input && !firstInput) firstInput = input;
+  });
+
+  if (firstInput) {
+    // Wait one frame so layout settles before scrolling.
+    requestAnimationFrame(function () {
+      firstInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Focusing select2-hidden inputs jumps weirdly — only focus visible ones.
+      if (firstInput.offsetParent !== null) firstInput.focus({ preventScroll: true });
+    });
+  }
+})();

--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -458,3 +458,59 @@
 
 /* Move 8 — inline variant of info-row__sub (used inside .info-list__item) */
 .info-row__sub--inline { display: inline; }
+
+/* ─── Inline form errors ───────────────────────────────────────────────
+ * components/form-errors.js adds .info-row--has-error to rows whose input
+ * the server rejected. The row turns red, the icon shifts color, and a
+ * small bubble below the input carries the message.
+ *
+ * Token-only (no raw hex). Works across light/sepia/dark via theme tokens.
+ * ─────────────────────────────────────────────────────────────────── */
+
+/* Highlight the row icon to draw the eye toward the offending field. */
+.info-row--has-error > .info-row__icon {
+    color: var(--color-danger);
+}
+
+/* Red border + soft danger halo on the input itself. Covers the common
+   editable widgets seen in info-row__value: bare inputs, selects, textareas,
+   plus the .select2 wrapper used by django-select2. */
+.info-row--has-error .info-row__value > input:not([type='checkbox']):not([type='radio']),
+.info-row--has-error .info-row__value > select,
+.info-row--has-error .info-row__value > textarea,
+.info-row--has-error .info-row__value > .select2 .select2-selection,
+.info-row--has-error .info-row__value > .select2-container .select2-selection {
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 3px var(--color-primary-100);
+}
+
+/* Error bubble: lives inside .info-row__body (or row), positioned in flow
+   so it pushes the next field down rather than overlapping anything.
+   Subtle slide-down on first appearance so it doesn't snap. */
+.info-row__error {
+    margin-top: var(--space-1);
+    padding: 6px var(--space-2);
+    background: var(--color-primary-50);
+    color: var(--color-danger);
+    border-left: 3px solid var(--color-danger);
+    border-radius: var(--radius-1);
+    font-size: 0.85rem;
+    line-height: 1.35;
+    animation: info-row-error-in 180ms ease-out;
+}
+
+@keyframes info-row-error-in {
+    from { opacity: 0; transform: translateY(-2px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Compact banner above the form: leans on existing .u-alert--error styling
+   so the only thing this rule adds is rhythm with the rest of the form. */
+.form-errors-banner {
+    margin-bottom: var(--space-4);
+}
+.form-errors-banner .form-errors__list {
+    margin: var(--space-1) 0 0 var(--space-4);
+    padding: 0;
+    list-style: disc;
+}

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -184,5 +184,6 @@
     {% block extra_js %}{% endblock %}
     <script src="{% static 'registar/components/osoba_create.js' %}"></script>
     <script src="{% static 'registar/components/edit_toggle.js' %}"></script>
+    <script src="{% static 'registar/components/form-errors.js' %}"></script>
   </body>
 </html>

--- a/crkva/registar/templates/registar/_form_errors.html
+++ b/crkva/registar/templates/registar/_form_errors.html
@@ -1,15 +1,20 @@
+{% load form_errors_extras %}
+{% comment %}
+  Form errors include — compact banner + JSON payload for inline highlighting.
+
+  - Banner: short summary + any non-field errors (rendered server-side, works without JS)
+  - JSON payload: field_name -> [errors] consumed by components/form-errors.js
+    which marks the matching input's .info-row with --has-error and injects
+    a per-field error bubble next to it
+{% endcomment %}
 {% if form.errors %}
-  <div class="u-alert u-alert--error">
-    <strong><i class="fa-solid fa-exclamation-circle"></i> Исправите следеће грешке:</strong>
-    <ul class="form-errors__list">
-      {% for error in form.non_field_errors %}
-        <li>{{ error }}</li>
-      {% endfor %}
-      {% for bound_field in form %}
-        {% for error in bound_field.errors %}
-          <li><strong>{{ bound_field.label }}</strong>: {{ error }}</li>
-        {% endfor %}
-      {% endfor %}
-    </ul>
+  <div class="u-alert u-alert--error form-errors-banner" role="alert">
+    <strong><i class="fa-solid fa-exclamation-circle"></i> Постоје грешке у форми. Погледајте обележена поља.</strong>
+    {% if form.non_field_errors %}
+      <ul class="form-errors__list">
+        {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+      </ul>
+    {% endif %}
   </div>
+  {{ form|field_errors_dict|json_script:"form-errors-data" }}
 {% endif %}

--- a/crkva/registar/templatetags/form_errors_extras.py
+++ b/crkva/registar/templatetags/form_errors_extras.py
@@ -1,0 +1,29 @@
+"""Template filter that exposes a form's field errors as a plain dict.
+
+Used by registar/_form_errors.html to feed components/form-errors.js, which
+highlights the corresponding inputs and injects per-field error bubbles.
+
+Why a custom filter: `form.errors` is an ErrorDict whose values are
+ErrorList objects. json_script encodes those as strings of joined items,
+not arrays, so we coerce to {fieldname: [str, ...]} ourselves.
+"""
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name="field_errors_dict")
+def field_errors_dict(form):
+    """Return {field_name: [str, ...]} for fields that have errors.
+
+    Skips form.non_field_errors — those are rendered in the banner directly.
+    Each error is coerced via str() so lazy translation proxies materialize
+    before json_script encodes them.
+    """
+    out = {}
+    for name, error_list in form.errors.items():
+        if name == "__all__":
+            continue
+        out[name] = [str(e) for e in error_list]
+    return out


### PR DESCRIPTION
- replace top-of-page error list with a compact banner ("Постоје грешке…") + a JSON payload (#form-errors-data) of {field: [messages]}
- new form-errors.js reads the JSON, finds inputs by [name], marks their .info-row with --has-error, injects an .info-row__error bubble under the input
- auto-scrolls and focuses the first errored field on load; clears the error state for a field as soon as the user edits it (input/change)
- works for both {% info_row %} partials and raw <li class="info-row"> markup — no template changes needed in the 5 detail pages
- new template filter field_errors_dict coerces ErrorList values to plain {field: [str]} so json_script encodes cleanly
- token-only CSS (red border + danger halo, danger icon tint, bubble in primary-50) — light/sepia/dark all covered
- non-field errors still listed in the banner; works with JS disabled (just no per-field bubbles)