### PR TITLE
- unify .toggle-group and .tabs into single .tab-group component

### DIFF
--- a/crkva/registar/static/registar/components/forme.css
+++ b/crkva/registar/static/registar/components/forme.css
@@ -141,78 +141,10 @@ fieldset.form-section legend i {
 }
 
 /* ==========================================================================
-   TOGGLE GROUP — segmented control (joined buttons, sharp corners)
-   Used as a replacement for <select> when there are 2-5 discrete options.
+   Note: the segmented "toggle-group" control was unified into the
+   .tab-group component (see components/tabovi.css). For backward-compatible
+   wrappers around it we keep .toggle-wrapper / .toggle-label.
    ========================================================================== */
-.toggle-group {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-2);
-  overflow: hidden;
-  background: var(--color-surface-1);
-  flex-wrap: wrap;
-}
-.toggle-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0;
-  padding: 0 16px;
-  min-height: 36px;
-  cursor: pointer;
-  user-select: none;
-  font-family: inherit;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1;
-  color: var(--color-text-muted);
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.toggle-button + .toggle-button {
-  border-left: 1px solid var(--color-border);
-}
-.toggle-button:hover:not(.active):not(:disabled):not(:has(input:checked)) {
-  background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
-  color: var(--color-text);
-}
-.toggle-button:focus-visible,
-.toggle-button:focus-within {
-  outline: 2px solid var(--color-primary);
-  outline-offset: -2px;
-  z-index: 1;
-}
-.toggle-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-.toggle-button.active,
-.toggle-button:has(input:checked) {
-  color: #fff;
-  background: var(--color-primary);
-  font-weight: 600;
-}
-.toggle-button:has(input:checked):hover {
-  background: var(--color-primary-700, var(--color-primary));
-  color: #fff;
-}
-/* Hide the underlying radio/checkbox inside a label-style toggle */
-.toggle-button > input[type="radio"],
-.toggle-button > input[type="checkbox"] {
-  position: absolute;
-  width: 1px; height: 1px;
-  padding: 0; margin: -1px; overflow: hidden;
-  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
-}
-
-/* Compact variant for dense lists / toolbars */
-.toggle-group--sm .toggle-button {
-  padding: 5px 12px;
-  font-size: 13px;
-}
 
 .toggle-wrapper { display: flex; align-items: center; gap: 10px; }
 .toggle-label { font-weight: 600; color: var(--color-text-muted); }

--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -135,7 +135,7 @@
     max-width: 100%;
     box-sizing: border-box;
 }
-.info-row--editable .info-row__value > .toggle-group {
+.info-row--editable .info-row__value > .tab-group {
     max-width: 100%;
     flex-wrap: wrap;
 }
@@ -145,7 +145,7 @@
     align-items: center;
 }
 
-.info-row--editable .info-row__value > .visually-hidden + .toggle-group,
+.info-row--editable .info-row__value > .visually-hidden + .tab-group,
 .info-row--editable .info-row__value > .toggle-wrapper {
     margin: 0;
 }
@@ -358,9 +358,9 @@
 [data-mode="view"] .info-row--editable .info-row__value > .select2,
 [data-mode="view"] .info-row--editable .info-row__value > .select2-container,
 [data-mode="view"] .info-row--editable .info-row__value > .adresa-edit-btn,
-[data-mode="view"] .info-row--editable .info-row__value > .toggle-group,
+[data-mode="view"] .info-row--editable .info-row__value > .tab-group,
 [data-mode="view"] .info-row--editable .info-row__body--inline > input,
-[data-mode="view"] .info-row--editable .info-row__body--inline > .toggle-group,
+[data-mode="view"] .info-row--editable .info-row__body--inline > .tab-group,
 [data-mode="view"] .info-row--editable .info-row__body--inline > .info-row__label {
     display: none !important;
 }

--- a/crkva/registar/static/registar/components/modal.js
+++ b/crkva/registar/static/registar/components/modal.js
@@ -50,8 +50,8 @@
         // Clear inputs / errors
         overlay.querySelectorAll("input[type=text]").forEach((i) => (i.value = ""));
         overlay
-            .querySelectorAll(".toggle-button.active")
-            .forEach((b) => b.classList.remove("active"));
+            .querySelectorAll(".tab-group__item.is-active")
+            .forEach((b) => b.classList.remove("is-active"));
         const err = overlay.querySelector(".error-text");
         if (err) err.style.display = "none";
         // Focus the first input
@@ -98,17 +98,17 @@
             options || {},
         );
 
-        // Wire toggle-group buttons (e.g. pol: M/Ж)
+        // Wire tab-group items (e.g. pol: M/Ж)
         const toggleState = {};
         Object.entries(opts.toggleGroups).forEach(([fieldName, groupId]) => {
             const group = document.getElementById(groupId);
             if (!group) return;
-            group.querySelectorAll(".toggle-button").forEach((btn) => {
+            group.querySelectorAll(".tab-group__item").forEach((btn) => {
                 btn.addEventListener("click", () => {
                     group
-                        .querySelectorAll(".toggle-button")
-                        .forEach((b) => b.classList.remove("active"));
-                    btn.classList.add("active");
+                        .querySelectorAll(".tab-group__item")
+                        .forEach((b) => b.classList.remove("is-active"));
+                    btn.classList.add("is-active");
                     toggleState[fieldName] = btn.dataset.value;
                 });
             });

--- a/crkva/registar/static/registar/components/osoba_create.js
+++ b/crkva/registar/static/registar/components/osoba_create.js
@@ -32,10 +32,10 @@
         if (defaultPol !== "М" && defaultPol !== "Ж") return;
         var group = document.getElementById("modal-pol-toggle");
         if (!group) return;
-        var buttons = group.querySelectorAll(".toggle-button");
+        var buttons = group.querySelectorAll(".tab-group__item");
         var matched = null;
         buttons.forEach(function (btn) {
-            btn.classList.remove("active");
+            btn.classList.remove("is-active");
             if (btn.dataset && btn.dataset.value === defaultPol) {
                 matched = btn;
             }

--- a/crkva/registar/static/registar/components/tabovi.css
+++ b/crkva/registar/static/registar/components/tabovi.css
@@ -1,94 +1,178 @@
 /* ==========================================================================
-   TABS COMPONENT
+   TAB GROUP — unified segmented control
    ==========================================================================
-   CSS-only tabs: sibling radio inputs drive selection. No JS, full keyboard
-   nav (arrow keys move between radios in the same group).
+   One component that covers three cases:
+     1. Two options, no panels      → used as a toggle/switch (e.g. Пол M/Ж)
+     2. Two-plus options, no panels → used as a filter/view-mode switcher
+     3. Two-plus options + panels   → used as tabs (opt-in via --with-panels)
 
    Markup:
-     <div class="tabs tabs--segmented">
-       <div class="tabs__nav">
-         <input id="tab-a" name="my-tabs" type="radio" class="tabs__radio" checked>
-         <label for="tab-a" class="tabs__tab">
-           <i class="tabs__icon fa-solid fa-list"></i> Подаци
-         </label>
-         <input id="tab-b" name="my-tabs" type="radio" class="tabs__radio">
-         <label for="tab-b" class="tabs__tab">
-           <i class="tabs__icon fa-solid fa-file"></i> Преглед
-           <span class="tabs__count">3</span>
-         </label>
-       </div>
-       <section class="tabs__panel">…</section>
-       <section class="tabs__panel">…</section>
+     <div class="tab-group" role="radiogroup">
+       <label class="tab-group__item">
+         <input type="radio" name="..." checked>
+         <span>Прва</span>
+       </label>
+       <label class="tab-group__item">
+         <input type="radio" name="...">
+         <span>Друга</span>
+       </label>
      </div>
 
-   Variants: tabs--segmented (default) | tabs--underline
+   With panels (tabs):
+     <div class="tab-group tab-group--with-panels">
+       <div class="tab-group__nav">
+         <label class="tab-group__item">
+           <input type="radio" name="..." checked>
+           <i class="tab-group__icon fa-solid fa-list"></i>
+           <span>Подаци</span>
+         </label>
+         …
+       </div>
+       <section class="tab-group__panel">…</section>
+       <section class="tab-group__panel">…</section>
+     </div>
 
-   The Nth radio (counted among <input> children of .tabs__nav) shows the Nth
-   panel (counted among <section> children of .tabs), so order matters but
-   you don't need any per-instance CSS.
+   Modifiers:
+     tab-group--with-panels  enables :has()-driven panel visibility
+     tab-group--underline    quieter underline variant (vs default segmented)
+     tab-group--sm           compact size for toolbars / dense lists
+
+   Slots inside .tab-group__item (all optional):
+     .tab-group__icon, .tab-group__count, plain text in a <span>
+
+   .tab-group__item works as <label> (wrapping a radio/checkbox) or <button>
+   (JS-driven, no input — apply .is-active on the active button).
    ========================================================================== */
 
-.tabs {
-    display: block;
-    width: 100%;
-    text-align: center;  /* centers the inline-flex nav horizontally */
-}
+/* ---------- container ----------------------------------------------------- */
 
-/* Radios: visually hidden but keep them focusable for keyboard nav. */
-.tabs__radio {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-}
-
-.tabs__nav {
+.tab-group {
     display: inline-flex;
-    margin: 0 0 var(--space-3);
+    align-items: stretch;
+    flex-wrap: wrap;
+    margin: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    overflow: hidden;
+    background: var(--color-surface-1);
+    line-height: 1;
+    vertical-align: top;
+}
+
+/* When panels are present we need an explicit nav wrapper so that the panels
+   can be siblings of the nav (the :has() rule below correlates them). */
+.tab-group--with-panels {
+    display: block;
+    border: 0;
+    border-radius: 0;
+    overflow: visible;
+    background: transparent;
+}
+
+.tab-group__nav {
+    display: inline-flex;
+    align-items: stretch;
+    flex-wrap: wrap;
     max-width: 100%;
     overflow-x: auto;
     scrollbar-width: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    overflow: hidden;
+    background: var(--color-surface-1);
+    line-height: 1;
+    vertical-align: top;
 }
-.tabs__nav::-webkit-scrollbar { display: none; }
+.tab-group__nav::-webkit-scrollbar { display: none; }
 
-.tabs__tab {
+/* ---------- item (label/button) ------------------------------------------ */
+
+.tab-group__item {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    padding: 0 18px;
-    min-height: 40px;
-    line-height: 20px;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--color-text);
+    margin: 0;
+    padding: 0 16px;
+    min-height: 36px;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 0;
+    border-radius: 0;
     cursor: pointer;
     user-select: none;
     white-space: nowrap;
-    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+    transition: background 0.15s ease, color 0.15s ease;
 }
 
-.tabs__tab[aria-disabled="true"],
-.tabs__tab.is-disabled {
-    opacity: 0.45;
+/* Joined separators between items */
+.tab-group__item + .tab-group__item {
+    border-left: 1px solid var(--color-border);
+}
+/* When items are siblings of hidden inputs (label/input/label/input/...),
+   we still need to separate consecutive labels. The next-sibling input is
+   between them so the simple + selector above misses; cover that case too. */
+.tab-group__nav .tab-group__item + .tab-group__item,
+.tab-group .tab-group__item + .tab-group__item {
+    border-left: 1px solid var(--color-border);
+}
+
+.tab-group__item:hover:not(.is-active):not(:disabled):not(:has(input:checked)) {
+    background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
+    color: var(--color-text);
+}
+
+.tab-group__item:focus-visible,
+.tab-group__item:focus-within {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+    z-index: 1;
+}
+
+.tab-group__item:disabled,
+.tab-group__item[aria-disabled="true"] {
+    opacity: 0.5;
     cursor: not-allowed;
 }
 
-.tabs__icon {
-    font-size: 14px;
+.tab-group__item.is-active,
+.tab-group__item:has(input:checked) {
+    color: #fff;
+    background: var(--color-primary);
+    font-weight: 600;
+}
+
+.tab-group__item:has(input:checked):hover {
+    background: var(--color-primary-700, var(--color-primary));
+    color: #fff;
+}
+
+/* Hide the underlying radio/checkbox when nested in a label-style item */
+.tab-group__item > input[type="radio"],
+.tab-group__item > input[type="checkbox"] {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+/* ---------- optional slots ----------------------------------------------- */
+
+.tab-group__icon {
+    font-size: 13px;
     line-height: 1;
 }
 
-.tabs__count {
+.tab-group__count {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     min-width: 20px;
-    height: 20px;
+    height: 18px;
     padding: 0 6px;
     font-size: 11px;
     font-weight: 600;
@@ -96,146 +180,98 @@
     border-radius: 999px;
     background: var(--color-surface-2);
     color: var(--color-text-muted);
-    transition: background-color 0.18s ease, color 0.18s ease;
+    transition: background 0.18s ease, color 0.18s ease;
 }
 
-/* ========================================================================
-   Panel visibility — show the Nth panel when the Nth radio is :checked.
-   Uses :has() (Chrome 105+, Safari 15.4+, Firefox 121+) for cross-container
-   correlation, plus :nth-of-type to pair radios with panels by position.
-   ======================================================================== */
-
-.tabs__panel {
-    display: none;
-    width: 100%;
-    text-align: left;
-    animation: tabs-fade-in 0.18s ease;
-}
-
-.tabs:has(.tabs__radio:nth-of-type(1):checked) > .tabs__panel:nth-of-type(1),
-.tabs:has(.tabs__radio:nth-of-type(2):checked) > .tabs__panel:nth-of-type(2),
-.tabs:has(.tabs__radio:nth-of-type(3):checked) > .tabs__panel:nth-of-type(3),
-.tabs:has(.tabs__radio:nth-of-type(4):checked) > .tabs__panel:nth-of-type(4),
-.tabs:has(.tabs__radio:nth-of-type(5):checked) > .tabs__panel:nth-of-type(5),
-.tabs:has(.tabs__radio:nth-of-type(6):checked) > .tabs__panel:nth-of-type(6) {
-    display: block;
-}
-
-@keyframes tabs-fade-in {
-    from { opacity: 0; transform: translateY(2px); }
-    to   { opacity: 1; transform: translateY(0); }
-}
-
-/* ==========================================================================
-   VARIANT: SEGMENTED (joined buttons, filled active)
-   Best for 2–3 short, mutually-exclusive choices (view modes, filters).
-   ========================================================================== */
-
-.tabs--segmented .tabs__nav {
-    display: inline-flex;
-    align-items: stretch;
-    vertical-align: top;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-2);
-    overflow: hidden;
-    background: var(--color-surface-1);
-    line-height: 1;
-}
-
-.tabs--segmented .tabs__tab {
-    box-sizing: border-box;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-weight: 500;
-    border-radius: 0;
-    padding: 0 18px;
-    min-height: 36px;
-    line-height: 1;
-    transition: background 0.15s ease, color 0.15s ease;
-}
-
-.tabs--segmented .tabs__tab + .tabs__radio + .tabs__tab,
-.tabs--segmented .tabs__radio:not(:first-of-type) + .tabs__tab {
-    border-left: 1px solid var(--color-border);
-}
-
-.tabs--segmented .tabs__tab:hover:not([aria-disabled="true"]) {
-    background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
-    color: var(--color-text);
-}
-
-/* Active tab — solid primary fill (mirrors .toggle-button.active) */
-.tabs--segmented .tabs__radio:checked + .tabs__tab {
-    background: var(--color-primary);
-    color: #fff;
-    font-weight: 600;
-    border-left-color: transparent;
-}
-
-.tabs--segmented .tabs__radio:checked + .tabs__tab + .tabs__radio + .tabs__tab {
-    border-left-color: transparent;
-}
-
-.tabs--segmented .tabs__radio:checked + .tabs__tab .tabs__count {
+.tab-group__item:has(input:checked) .tab-group__count,
+.tab-group__item.is-active .tab-group__count {
     background: rgba(255, 255, 255, 0.22);
     color: #fff;
 }
 
-.tabs--segmented .tabs__radio:focus-visible + .tabs__tab {
-    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--color-primary) 55%, transparent);
+/* ---------- panels (opt-in via --with-panels) ---------------------------- */
+
+.tab-group__panel {
+    display: none;
+    width: 100%;
+    text-align: left;
+    margin-top: var(--space-3);
+    animation: tab-group-fade-in 0.18s ease;
 }
 
-/* ==========================================================================
-   VARIANT: UNDERLINE (quieter, scales to many tabs)
-   Best for content sections with longer labels or 3+ tabs.
-   ========================================================================== */
+/* Correlate the Nth checked item with the Nth panel via :has() + :nth-of-type.
+   Items are <label>s inside .tab-group__nav, so :nth-of-type counts labels. */
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(1) input:checked) > .tab-group__panel:nth-of-type(1),
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(2) input:checked) > .tab-group__panel:nth-of-type(2),
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(3) input:checked) > .tab-group__panel:nth-of-type(3),
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(4) input:checked) > .tab-group__panel:nth-of-type(4),
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(5) input:checked) > .tab-group__panel:nth-of-type(5),
+.tab-group--with-panels:has(.tab-group__nav .tab-group__item:nth-of-type(6) input:checked) > .tab-group__panel:nth-of-type(6) {
+    display: block;
+}
 
-.tabs--underline .tabs__nav {
+@keyframes tab-group-fade-in {
+    from { opacity: 0; transform: translateY(2px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------- variant: underline ------------------------------------------- */
+
+.tab-group--underline,
+.tab-group--underline .tab-group__nav {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+
+.tab-group--underline .tab-group__nav {
     border-bottom: 1px solid var(--color-border);
     gap: 4px;
 }
 
-.tabs--underline .tabs__tab {
-    background: transparent;
+.tab-group--underline .tab-group__item {
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
     padding: 0 14px;
-    color: var(--color-text-muted);
-    font-weight: 500;
+    background: transparent;
 }
 
-.tabs--underline .tabs__tab:hover:not([aria-disabled="true"]) {
+.tab-group--underline .tab-group__item + .tab-group__item {
+    border-left: 0;
+}
+
+.tab-group--underline .tab-group__item:hover:not(.is-active):not(:has(input:checked)) {
+    background: transparent;
     color: var(--color-text);
     border-bottom-color: var(--color-border);
 }
 
-.tabs--underline .tabs__radio:checked + .tabs__tab {
+.tab-group--underline .tab-group__item.is-active,
+.tab-group--underline .tab-group__item:has(input:checked) {
+    background: transparent;
     color: var(--color-primary);
     border-bottom-color: var(--color-primary);
     font-weight: 600;
 }
 
-.tabs--underline .tabs__radio:checked + .tabs__tab .tabs__count {
+.tab-group--underline .tab-group__item:has(input:checked) .tab-group__count,
+.tab-group--underline .tab-group__item.is-active .tab-group__count {
     background: color-mix(in oklab, var(--color-primary) 12%, transparent);
     color: var(--color-primary);
 }
 
-.tabs--underline .tabs__radio:focus-visible + .tabs__tab {
-    color: var(--color-primary);
-    outline: 2px solid color-mix(in oklab, var(--color-primary) 35%, transparent);
-    outline-offset: 2px;
-    border-radius: 4px;
+/* ---------- variant: compact --------------------------------------------- */
+
+.tab-group--sm .tab-group__item {
+    padding: 5px 12px;
+    min-height: 30px;
+    font-size: 13px;
 }
 
-/* ==========================================================================
-   MOBILE
-   ========================================================================== */
+/* ---------- mobile -------------------------------------------------------- */
 
 @media (max-width: 640px) {
-    .tabs__nav {
-        margin-left: calc(-1 * var(--space-3));
-        margin-right: calc(-1 * var(--space-3));
-        padding: 0 var(--space-3);
+    .tab-group--with-panels .tab-group__nav {
         max-width: 100vw;
         justify-content: flex-start;
     }

--- a/crkva/registar/templates/registar/_modal_osoba.html
+++ b/crkva/registar/templates/registar/_modal_osoba.html
@@ -30,9 +30,9 @@ the click a silent no-op on every page that includes this partial.
       <div class="form-row">
         <div class="form-field">
           <label>Пол</label>
-          <div class="toggle-group" id="modal-pol-toggle">
-            <button type="button" class="toggle-button" data-value="М">мушки</button>
-            <button type="button" class="toggle-button" data-value="Ж">женски</button>
+          <div class="tab-group" id="modal-pol-toggle">
+            <button type="button" class="tab-group__item" data-value="М">мушки</button>
+            <button type="button" class="tab-group__item" data-value="Ж">женски</button>
           </div>
         </div>
       </div>

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -56,14 +56,18 @@
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}
 
   {% if krstenje %}
-  <div class="tabs tabs--segmented">
-    <div class="tabs__nav" data-show-mode="view">
-      <input type="radio" id="krst-tab-podaci" name="krst-view" class="tabs__radio" checked>
-      <label for="krst-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
-      <input type="radio" id="krst-tab-pregled" name="krst-view" class="tabs__radio">
-      <label for="krst-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Крштеница</label>
+  <div class="tab-group tab-group--with-panels">
+    <div class="tab-group__nav" data-show-mode="view" role="tablist">
+      <label class="tab-group__item">
+        <input type="radio" name="krst-view" checked>
+        <i class="tab-group__icon fa-solid fa-table-list"></i><span>Подаци</span>
+      </label>
+      <label class="tab-group__item">
+        <input type="radio" name="krst-view">
+        <i class="tab-group__icon fa-solid fa-file-lines"></i><span>Крштеница</span>
+      </label>
     </div>
-    <section class="tabs__panel">
+    <section class="tab-group__panel">
   {% endif %}
 
       {# ============ ЗАПИС ============ #}
@@ -181,7 +185,7 @@
     </section>
 
     {# ============ CERTIFICATE PREVIEW ============ #}
-    <section class="tabs__panel" data-show-mode="view">
+    <section class="tab-group__panel" data-show-mode="view">
       <div class="krstenica">
         <div class="krstenica-frame">
           <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -57,16 +57,16 @@
   <div class="info-section">
     <h2 class="info-section__title"><i class="fa-solid fa-user"></i> Лични подаци</h2>
     <ul class="info-rows">
-      {# Пол keeps raw markup — view-mode uses get_pol_display, edit-mode renders a custom toggle-group. #}
+      {# Пол keeps raw markup — view-mode uses get_pol_display, edit-mode renders a custom tab-group. #}
       <li class="info-row info-row--editable info-row--stacked">
         <div class="info-row__icon" data-tooltip="Пол"><i class="fa-solid fa-venus-mars"></i></div>
         <div class="info-row__body">
           <label class="info-row__label">Пол</label>
           <div class="info-row__value">
             <span class="info-row__static">{% if parohijan.pol %}{{ parohijan.get_pol_display }}{% else %}<span class="info-row__static--muted">—</span>{% endif %}</span>
-            <div class="toggle-group" role="radiogroup" aria-label="Пол">
+            <div class="tab-group" role="radiogroup" aria-label="Пол">
               {% for value, label in form.pol.field.choices %}{% if value %}
-                <label class="toggle-button">
+                <label class="tab-group__item">
                   <input type="radio" name="pol" value="{{ value }}"{% if form.pol.value == value %} checked{% endif %}>
                   <span>{{ label }}</span>
                 </label>

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -56,14 +56,18 @@
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}
 
   {% if vencanje %}
-  <div class="tabs tabs--segmented">
-    <div class="tabs__nav" data-show-mode="view">
-      <input type="radio" id="venc-tab-podaci" name="venc-view" class="tabs__radio" checked>
-      <label for="venc-tab-podaci" class="tabs__tab"><i class="tabs__icon fa-solid fa-table-list"></i> Подаци</label>
-      <input type="radio" id="venc-tab-pregled" name="venc-view" class="tabs__radio">
-      <label for="venc-tab-pregled" class="tabs__tab"><i class="tabs__icon fa-solid fa-file-lines"></i> Венчаница</label>
+  <div class="tab-group tab-group--with-panels">
+    <div class="tab-group__nav" data-show-mode="view" role="tablist">
+      <label class="tab-group__item">
+        <input type="radio" name="venc-view" checked>
+        <i class="tab-group__icon fa-solid fa-table-list"></i><span>Подаци</span>
+      </label>
+      <label class="tab-group__item">
+        <input type="radio" name="venc-view">
+        <i class="tab-group__icon fa-solid fa-file-lines"></i><span>Венчаница</span>
+      </label>
     </div>
-    <section class="tabs__panel">
+    <section class="tab-group__panel">
   {% endif %}
 
       {% if form %}
@@ -150,7 +154,7 @@
     </section>
 
     {# ============ CERTIFICATE PREVIEW ============ #}
-    <section class="tabs__panel" data-show-mode="view">
+    <section class="tab-group__panel" data-show-mode="view">
       <div class="vencanica">
         <div class="vencanica-frame">
           <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>


### PR DESCRIPTION
- opt-in modifiers: --with-panels (tabs), --underline, --sm
- slots: __nav, __item, __icon, __count, __panel
- toggle is just .tab-group with two .tab-group__item children
- swap call sites: parohijan/krstenje/vencanje/_modal_osoba templates
- swap JS: modal.js, osoba_create.js (active → is-active)
- info.css hook updated; old .toggle-group/.toggle-button CSS removed