### PR TITLE
feat(layout): sticky page header so action buttons stay reachable

### DIFF
--- a/crkva/registar/static/registar/components/info.css
+++ b/crkva/registar/static/registar/components/info.css
@@ -514,3 +514,19 @@
     padding: 0;
     list-style: disc;
 }
+
+
+/* Sticky page header eats the top ~120px of viewport; give inputs that the
+   browser scrolls into view (TAB navigation, scrollIntoView from form-errors.js)
+   enough top breathing room that they land below the sticky header instead of
+   under it. */
+.info-row .info-row__value > input:not([type=checkbox]):not([type=radio]),
+.info-row .info-row__value > select,
+.info-row .info-row__value > textarea,
+.info-row .info-row__value > .select2,
+.info-row .info-row__value > .select2-container {
+    scroll-margin-top: 120px;
+}
+.info-row {
+    scroll-margin-top: 120px;
+}

--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -45,6 +45,16 @@
     gap: var(--space-4);
     margin: var(--space-5) 0 var(--space-3);
     width: 100%;
+    /* Stick to viewport top so back/edit/print/history stay reachable while
+       scrolling through long forms. Background is opaque (theme-aware) so
+       content scrolling underneath does not bleed through; a hairline
+       bottom shadow signals the elevation. */
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: var(--color-surface);
+    padding-bottom: var(--space-2);
+    box-shadow: 0 1px 0 var(--color-border);
 }
 
 .u-page-title {


### PR DESCRIPTION
- .u-page-header now position: sticky; top: 0 with theme-aware opaque background and a hairline bottom shadow for elevation
- back button + page title + action buttons (edit, print, history, save) remain visible while scrolling long forms (parohijan, vencanje, krstenje, etc.) and long lists
- scroll-margin-top: 120px on info-row inputs so TAB navigation and form-errors auto-scroll land the focused input below the sticky header rather than under it
- z-index 20 sits above content but below modals and select2 popovers