### PR TITLE
- LoginRequiredMixin on all read CBVs (Spisak/Prikaz/PDF for parohija…

### DIFF
--- a/crkva/registar/tests/test_bug2_domacinstvo_list_empty_state.py
+++ b/crkva/registar/tests/test_bug2_domacinstvo_list_empty_state.py
@@ -2,9 +2,12 @@
 
 # pylint: disable=missing-function-docstring
 
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 from registar.models import Domacinstvo, Osoba
+
+User = get_user_model()
 
 
 class DomacinstvoListEmptyStateTests(TestCase):
@@ -12,6 +15,8 @@ class DomacinstvoListEmptyStateTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
 
     def test_empty_list_renders_empty_state(self):
         Domacinstvo.objects.all().delete()

--- a/crkva/registar/tests/test_bug4_anagraph_and_gradjansko_ime.py
+++ b/crkva/registar/tests/test_bug4_anagraph_and_gradjansko_ime.py
@@ -18,6 +18,13 @@ class KrstenjeAnagraphDisplayTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_anagraph_fields_render_on_detail(self):
         dete = Osoba.objects.create(ime="Беба", prezime="Тест", pol="М")

--- a/crkva/registar/tests/test_integration.py
+++ b/crkva/registar/tests/test_integration.py
@@ -236,6 +236,13 @@ class SearchIntegrationTest(TestCase):
             dete_blizanac=False,
             dete_sa_telesnom_manom=False,
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_search_functionality(self):
         """Тест функционалности претраге"""

--- a/crkva/registar/tests/test_izmena.py
+++ b/crkva/registar/tests/test_izmena.py
@@ -370,6 +370,13 @@ class PrikazKrstenjaDeteSectionTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def _create_krstenje(self, **overrides):
         defaults = dict(

--- a/crkva/registar/tests/test_list_sort_dropdown.py
+++ b/crkva/registar/tests/test_list_sort_dropdown.py
@@ -8,9 +8,12 @@ old segmented radio toggle. Submission of the parent form keeps the existing
 import datetime
 import re
 
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 from registar.models import Hram, Krstenje, Osoba, Svestenik, Vencanje
+
+User = get_user_model()
 
 
 class ListSortDropdownRendersAsSelectTests(TestCase):
@@ -18,6 +21,8 @@ class ListSortDropdownRendersAsSelectTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
         # A handful of parohijani so the list has rows to render.
         Osoba.objects.create(ime="Ана", prezime="Андрић", parohijan=True)
         Osoba.objects.create(ime="Бојан", prezime="Бркић", parohijan=True)
@@ -134,6 +139,8 @@ class ListSortDropdownAcrossAllListPagesTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
         self.hram = Hram.objects.create(naziv="Тест Храм")
         # parohijani
         Osoba.objects.create(ime="Петар", prezime="Петровић", parohijan=True)
@@ -198,6 +205,8 @@ class ListSortDropdownStillSortsTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
         # Three parohijani with surnames that have a deterministic order.
         Osoba.objects.create(ime="А", prezime="Аврамовић", parohijan=True)
         Osoba.objects.create(ime="Б", prezime="Бабић", parohijan=True)

--- a/crkva/registar/tests/test_lookup_gender_filter.py
+++ b/crkva/registar/tests/test_lookup_gender_filter.py
@@ -11,28 +11,14 @@ import re
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
-
-from registar.forms.krstenje_form import (
-    FemaleOsobaSelect2Widget as KrstFemale,
-)
-from registar.forms.krstenje_form import (
-    KrstenjeForm,
-)
-from registar.forms.krstenje_form import (
-    MaleOsobaSelect2Widget as KrstMale,
-)
-from registar.forms.krstenje_form import (
-    OsobaSelect2Widget as KrstUnfiltered,
-)
-from registar.forms.vencanje_form import (
-    FemaleOsobaSelect2Widget as VencFemale,
-)
-from registar.forms.vencanje_form import (
-    MaleOsobaSelect2Widget as VencMale,
-)
+from registar.forms.krstenje_form import FemaleOsobaSelect2Widget as KrstFemale
+from registar.forms.krstenje_form import KrstenjeForm
+from registar.forms.krstenje_form import MaleOsobaSelect2Widget as KrstMale
+from registar.forms.krstenje_form import OsobaSelect2Widget as KrstUnfiltered
+from registar.forms.vencanje_form import FemaleOsobaSelect2Widget as VencFemale
+from registar.forms.vencanje_form import MaleOsobaSelect2Widget as VencMale
 from registar.forms.vencanje_form import VencanjeForm
 from registar.models import Osoba
-
 
 FIELD_ID_RE = re.compile(
     r'<select[^>]*name="(?P<name>[a-z_]+)"[^>]*data-field_id="(?P<fid>[^"]+)"'
@@ -307,9 +293,7 @@ class Select2AjaxGenderFilterTests(TestCase):
         ids = self._field_ids("unos_vencanja")
         for name in ("svekar", "tast", "stari_svat"):
             results = self._ajax_ids(ids[name], term="Тест")
-            self.assertIn(
-                self.male.pk, results, msg=f"male missing from {name} lookup"
-            )
+            self.assertIn(self.male.pk, results, msg=f"male missing from {name} lookup")
             self.assertNotIn(
                 self.female.pk, results, msg=f"female leaked into {name} lookup"
             )
@@ -372,5 +356,5 @@ class OsobaCreateJsWiringTests(TestCase):
         self.assertIn("data-osoba-default-pol", js)
         self.assertIn("modal-pol-toggle", js)
         # Sanity: the helper that flips the toggle must reference the
-        # .toggle-button class so it matches the modal markup.
-        self.assertIn("toggle-button", js)
+        # .tab-group__item class so it matches the modal markup.
+        self.assertIn("tab-group__item", js)

--- a/crkva/registar/tests/test_parohijan_related.py
+++ b/crkva/registar/tests/test_parohijan_related.py
@@ -1,8 +1,11 @@
 """Tests for parent / extended-role surfacing on parohijan detail."""
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from registar.models import Hram, Krstenje, Osoba, Vencanje
+
+User = get_user_model()
 
 
 class ParohijanRelatedRecordsTest(TestCase):
@@ -44,6 +47,10 @@ class ParohijanRelatedRecordsTest(TestCase):
             otac=cls.parent,
             hram=cls.hram,
         )
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
 
     def test_vencanje_link_appears_for_svekrva_role(self):
         response = self.client.get(

--- a/crkva/registar/tests/test_parohijani_filter.py
+++ b/crkva/registar/tests/test_parohijani_filter.py
@@ -1,8 +1,11 @@
 """Test that /parohijani/ only shows Osobe with parohijan=True."""
 
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 from registar.models import Osoba
+
+User = get_user_model()
 
 
 class SpisakParohijanaFiltersByParohijanFlag(TestCase):
@@ -10,6 +13,8 @@ class SpisakParohijanaFiltersByParohijanFlag(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
         Osoba.objects.create(ime="Парохијан", prezime="Прави", parohijan=True)
         Osoba.objects.create(ime="Мати", prezime="Из крштења", parohijan=False)
         Osoba.objects.create(

--- a/crkva/registar/tests/test_select2_skin.py
+++ b/crkva/registar/tests/test_select2_skin.py
@@ -1,7 +1,10 @@
 """Smoke test: select2 skin CSS is bundled and active on edit pages."""
 
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+
+User = get_user_model()
 
 
 @override_settings(COMPRESS_ENABLED=False)
@@ -10,6 +13,8 @@ class Select2SkinTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
 
     def test_select2_skin_css_present_on_pages_with_select2(self):
         """The select2_skin.css link tag must appear on at least one page."""

--- a/crkva/registar/tests/test_slava_page.py
+++ b/crkva/registar/tests/test_slava_page.py
@@ -23,6 +23,15 @@ class SlavaAddressRenderTest(TestCase):
             domacin=cls.domacin, adresa=cls.adresa, slava=cls.slava
         )
 
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
+
     def test_address_renders_full_text(self):
         """The list must include the street name, not only the broj."""
         response = self.client.get(

--- a/crkva/registar/tests/test_slava_view.py
+++ b/crkva/registar/tests/test_slava_view.py
@@ -1,10 +1,13 @@
 """Basic tests for the slava-households view (slava_view)."""
+
 from __future__ import annotations
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-
 from kalendar.models import Slava
+
+User = get_user_model()
 
 
 class SlavaDomacinstvaViewTests(TestCase):
@@ -18,6 +21,10 @@ class SlavaDomacinstvaViewTests(TestCase):
             dan=15,
             pokretni=False,
         )
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="x")
+        self.client.force_login(self.user)
 
     def test_renders_for_existing_slava(self):
         url = reverse("slava_detail", kwargs={"uid": self.slava.uid})

--- a/crkva/registar/tests/test_tabs_data_show_mode.py
+++ b/crkva/registar/tests/test_tabs_data_show_mode.py
@@ -2,7 +2,7 @@
 
 Background
 ----------
-The outer ``<div class="tabs tabs--segmented">`` wrapper on ``krstenje.html`` and
+The outer ``<div class="tab-group tab-group--with-panels">`` wrapper on ``krstenje.html`` and
 ``vencanje.html`` was twice tagged ``data-show-mode="view"``. Under the CSS rule
 
     [data-mode="edit"] [data-show-mode="view"] { display: none !important; }
@@ -11,10 +11,10 @@ that hid the entire editable form when the user clicked "Измени" (the form
 ``data-mode`` flipped to ``edit`` and the whole tabs wrapper, including the
 data-panel with the editable info-row inputs, disappeared).
 
-The fix: only the ``.tabs__nav`` (the segmented tab switcher) and the
-certificate-preview ``<section class="tabs__panel">`` may carry
+The fix: only the ``.tab-group__nav`` (the segmented tab switcher) and the
+certificate-preview ``<section class="tab-group__panel">`` may carry
 ``data-show-mode="view"``. The outer wrapper must NOT, and the data-panel
-``<section class="tabs__panel">`` (which hosts the editable info-section panels)
+``<section class="tab-group__panel">`` (which hosts the editable info-section panels)
 must NOT either.
 
 History:
@@ -177,11 +177,11 @@ class TabsDataShowModeRegressionTests(TestCase):
     # ------------------------------------------------------------------
     def test_krstenje_outer_tabs_wrapper_is_not_view_gated(self):
         # Regression guard for PR #140 / PR #143: the outer
-        # `<div class="tabs tabs--segmented">` must NOT carry data-show-mode,
+        # `<div class="tab-group tab-group--with-panels">` must NOT carry data-show-mode,
         # otherwise [data-mode="edit"] hides the whole editable form.
         body = KRSTENJE_TEMPLATE.read_text(encoding="utf-8")
         self.assertNotIn(
-            'class="tabs tabs--segmented" data-show-mode',
+            'class="tab-group tab-group--with-panels" data-show-mode',
             body,
             "Outer tabs wrapper on krstenje.html must not be view-gated; "
             "would re-introduce the PR #140 / #143 regression hiding the edit form.",
@@ -191,7 +191,7 @@ class TabsDataShowModeRegressionTests(TestCase):
         # Same regression guard for vencanje.html — see PR #140 / PR #143.
         body = VENCANJE_TEMPLATE.read_text(encoding="utf-8")
         self.assertNotIn(
-            'class="tabs tabs--segmented" data-show-mode',
+            'class="tab-group tab-group--with-panels" data-show-mode',
             body,
             "Outer tabs wrapper on vencanje.html must not be view-gated; "
             "would re-introduce the PR #140 / #143 regression hiding the edit form.",
@@ -199,22 +199,22 @@ class TabsDataShowModeRegressionTests(TestCase):
 
     def test_krstenje_tabs_nav_is_view_gated(self):
         # Positive half of the PR #140 / #143 contract: the segmented tab
-        # switcher (`.tabs__nav`) must be hidden in edit mode, otherwise the
+        # switcher (`.tab-group__nav`) must be hidden in edit mode, otherwise the
         # tab radios bleed into the editable form.
         body = KRSTENJE_TEMPLATE.read_text(encoding="utf-8")
         self.assertIn(
-            'class="tabs__nav" data-show-mode="view"',
+            'class="tab-group__nav" data-show-mode="view"',
             body,
-            ".tabs__nav on krstenje.html must carry data-show-mode='view'.",
+            ".tab-group__nav on krstenje.html must carry data-show-mode='view'.",
         )
 
     def test_vencanje_tabs_nav_is_view_gated(self):
         # Same positive half of the PR #140 / #143 contract for vencanje.
         body = VENCANJE_TEMPLATE.read_text(encoding="utf-8")
         self.assertIn(
-            'class="tabs__nav" data-show-mode="view"',
+            'class="tab-group__nav" data-show-mode="view"',
             body,
-            ".tabs__nav on vencanje.html must carry data-show-mode='view'.",
+            ".tab-group__nav on vencanje.html must carry data-show-mode='view'.",
         )
 
     # ------------------------------------------------------------------
@@ -239,13 +239,15 @@ class TabsDataShowModeRegressionTests(TestCase):
             "form must render with data-mode='edit' on /izmena/",
         )
 
-        # The outer `<div class="tabs tabs--segmented">` opening tag (which can
+        # The outer `<div class="tab-group tab-group--with-panels">` opening tag (which can
         # span multiple lines) must not carry data-show-mode anywhere in its
         # attribute list. Match the literal tag opener and consume until '>'.
-        tabs_open = re.search(r'<div\b[^>]*class="tabs tabs--segmented"[^>]*>', body)
+        tabs_open = re.search(
+            r'<div\b[^>]*class="tab-group tab-group--with-panels"[^>]*>', body
+        )
         self.assertIsNotNone(
             tabs_open,
-            "outer <div class='tabs tabs--segmented'> not found in rendered HTML",
+            "outer <div class='tab-group tab-group--with-panels'> not found in rendered HTML",
         )
         self.assertNotIn(
             "data-show-mode",

--- a/crkva/registar/tests/test_template_audit.py
+++ b/crkva/registar/tests/test_template_audit.py
@@ -131,6 +131,15 @@ class SlavaUkucaninFallbackTests(TestCase):
             preminuo=True,
         )
 
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
+
     def test_fallback_name_renders(self):
         url = reverse("slava_detail", kwargs={"uid": self.slava.uid})
         response = self.client.get(url)

--- a/crkva/registar/tests/test_unos_krstenje_audit.py
+++ b/crkva/registar/tests/test_unos_krstenje_audit.py
@@ -557,6 +557,15 @@ class OsobaCreateInlineFlowTests(_BaseUnosKrstenjeAuditTest):
       * POSTing to brzi_unos_osobe creates an Osoba and returns id+text
     """
 
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
+
     def test_modal_markup_is_included_on_page(self):
         html = self._get_html()
         self.assertIn('id="osoba-modal"', html)

--- a/crkva/registar/tests/test_views.py
+++ b/crkva/registar/tests/test_views.py
@@ -15,6 +15,13 @@ class IndexViewTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_index_returns_200(self):
         """Почетна страница враћа статус 200."""
@@ -51,6 +58,13 @@ class SpisakKrstenjaViewTestCase(TestCase):
             dete_sa_telesnom_manom=False,
             hram=self.hram,
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_spisak_krstenja_returns_200(self):
         """Списак крштења враћа статус 200."""
@@ -98,6 +112,13 @@ class PrikazKrstenjaViewTestCase(TestCase):
             dete_sa_telesnom_manom=False,
             hram=self.hram,
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_prikaz_krstenja_returns_200(self):
         """Приказ крштења враћа статус 200."""
@@ -139,6 +160,13 @@ class SpisakParohijanaViewTestCase(TestCase):
             prezime="Јовановић",
             parohijan=True,
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_spisak_parohijana_returns_200(self):
         """Списак парохијана враћа статус 200."""
@@ -161,6 +189,13 @@ class SearchViewTestCase(TestCase):
             prezime="Николић",
             parohijan=True,
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_search_returns_200(self):
         """Претрага враћа статус 200."""
@@ -189,6 +224,13 @@ class KalendarViewTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_kalendar_returns_200(self):
         """Календар враћа статус 200."""
@@ -208,6 +250,13 @@ class CalibrateViewsTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_calibrate_krstenje_returns_200(self):
         """Калибрација крштенице враћа статус 200."""
@@ -254,6 +303,13 @@ class ListSortTestCase(TestCase):
         Osoba.objects.create(ime="Ана", prezime="Аћимовић", parohijan=True)
         Osoba.objects.create(ime="Марко", prezime="Марковић", parohijan=True)
         Osoba.objects.create(ime="Зорица", prezime="Шушић", parohijan=True)
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def _first_primary(self, response):
         import re
@@ -289,6 +345,13 @@ class SpisakParohijanaListTests(TestCase):
         self.adresa = Adresa.objects.create(
             ulica="Поручника Спасића", broj="12", mesto="Београд"
         )
+        from django.contrib.auth import get_user_model
+
+        _U = get_user_model()
+        self.user = _U.objects.create_superuser(
+            username="auto-test", email="a@a.test", password="x"
+        )
+        self.client.force_login(self.user)
 
     def test_domacin_badge_renders(self):
         """Парохијан који је домаћин има значку 'домаћин' и адресу домаћинства."""

--- a/crkva/registar/views/brzi_view.py
+++ b/crkva/registar/views/brzi_view.py
@@ -1,8 +1,8 @@
 """AJAX endpoints за брзе акције из модала (особа + адреса)."""
 
 from django.http import JsonResponse
-
-from registar.models import Adresa
+from django.shortcuts import get_object_or_404
+from registar.models import Adresa, Osoba
 from tenants.permissions import tenant_role_required
 
 
@@ -19,7 +19,7 @@ def brzi_unos_osobe(request):
     if not ime or not prezime:
         return JsonResponse({"error": "Име и презиме су обавезни"}, status=400)
 
-    osoba = Parohijan.objects.create(
+    osoba = Osoba.objects.create(
         ime=ime, prezime=prezime, pol=pol or None, parohijan=True
     )
     return JsonResponse({"id": osoba.uid, "text": str(osoba)})

--- a/crkva/registar/views/domacinstvo_view.py
+++ b/crkva/registar/views/domacinstvo_view.py
@@ -2,6 +2,7 @@
 Модул за приказ домаћинстава и њихових чланова.
 """
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import DetailView, ListView
@@ -29,7 +30,9 @@ def unos_domacinstva(request):
     )
 
 
-class SpisakDomacinsta(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
+class SpisakDomacinsta(
+    LoginRequiredMixin, SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
+):
     """Приказује списак домаћинстава са могућношћу претраге и пагинације."""
 
     model = Domacinstvo
@@ -52,7 +55,7 @@ class SpisakDomacinsta(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
         )
 
 
-class PrikazDomacinstva(DetailView):
+class PrikazDomacinstva(LoginRequiredMixin, DetailView):
     """Приказује детаљне информације о одређеном домаћинству."""
 
     model = Domacinstvo

--- a/crkva/registar/views/home_view.py
+++ b/crkva/registar/views/home_view.py
@@ -3,19 +3,14 @@
 import datetime as dt
 from collections import defaultdict
 
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
-
-from registar.models import (
-    Krstenje,
-    Parohijan,
-    Slava,
-    Svestenik,
-    Vencanje,
-)
+from registar.models import Krstenje, Parohijan, Slava, Svestenik, Vencanje
 from registar.utils_fasting import get_fasting_type
 
 
+@login_required
 def index(request) -> HttpResponse:
     """
     Приказ почетне странице са календарским приказом актуелних слава (-1 до +5 дана).
@@ -115,7 +110,13 @@ def index(request) -> HttpResponse:
                 "day_label": day_label,
                 "is_fasting": fasting_info["is_fasting"],
                 "fasting_type": fasting_info["type"],
-                "fasting_class": {"вода":"water","уље":"oil","риба":"fish","бели_мрс":"dairy"}.get(fasting_info["type"]) or "",
+                "fasting_class": {
+                    "вода": "water",
+                    "уље": "oil",
+                    "риба": "fish",
+                    "бели_мрс": "dairy",
+                }.get(fasting_info["type"])
+                or "",
                 "fasting_display": fasting_info["display"],
                 "fasting_description": fasting_info["description"],
                 "slave": day_slavas,
@@ -147,4 +148,3 @@ def index(request) -> HttpResponse:
     }
 
     return render(request, "registar/index.html", context)
-

--- a/crkva/registar/views/kalendar_view.py
+++ b/crkva/registar/views/kalendar_view.py
@@ -6,6 +6,7 @@ import calendar
 import datetime as dt
 from collections import defaultdict
 
+from django.contrib.auth.decorators import login_required
 from django.db.models import Count
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
@@ -14,6 +15,7 @@ from registar.utils import MESECI
 from registar.utils_fasting import get_fasting_type
 
 
+@login_required
 def kalendar(
     request: HttpRequest, year: int | None = None, month: int | None = None
 ) -> HttpResponse:
@@ -102,7 +104,13 @@ def kalendar(
                 "weekday_label": weekday_labels[d.weekday()],
                 "is_fasting": fasting_info["is_fasting"],
                 "fasting_type": fasting_info["type"],
-                "fasting_class": {"вода":"water","уље":"oil","риба":"fish","бели_мрс":"dairy"}.get(fasting_info["type"]) or "",
+                "fasting_class": {
+                    "вода": "water",
+                    "уље": "oil",
+                    "риба": "fish",
+                    "бели_мрс": "dairy",
+                }.get(fasting_info["type"])
+                or "",
                 "fasting_display": fasting_info["display"],
                 "fasting_description": fasting_info["description"],
                 "slave": day_slavas,

--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -2,6 +2,7 @@
 Модул за приказ, унос и генерисање PDF докумената за крштења.
 """
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
@@ -41,7 +42,9 @@ def unos_krstenja(request):
     )
 
 
-class SpisakKrstenja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
+class SpisakKrstenja(
+    LoginRequiredMixin, SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
+):
     """Приказује списак крштења са могућностима претраге и пагинације."""
 
     model = Krstenje
@@ -71,7 +74,7 @@ class SpisakKrstenja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
         )
 
 
-class KrstenjePDF(DetailView):
+class KrstenjePDF(LoginRequiredMixin, DetailView):
     """Генерише PDF документ за одређено крштење."""
 
     model = Krstenje
@@ -124,7 +127,7 @@ class KrstenjePDF(DetailView):
         return self.render_to_response(context)
 
 
-class PrikazKrstenja(DetailView):
+class PrikazKrstenja(LoginRequiredMixin, DetailView):
     """Приказује детаљне информације о појединачном крштењу."""
 
     model = Krstenje
@@ -147,7 +150,7 @@ class PrikazKrstenja(DetailView):
         return context
 
 
-# @login_required
+@tenant_role_required("krstenje")
 def calibrate_krstenje(request):
     """Калибрациона страница за подешавање позиција поља на крштеници."""
     return render(request, "registar/calibrate_krstenje.html")

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -2,6 +2,7 @@
 Модул за приказ, додавање и генерисање PDF докумената за парохијане.
 """
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -37,7 +38,9 @@ def unos_parohijana(request):
     )
 
 
-class SpisakParohijana(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
+class SpisakParohijana(
+    LoginRequiredMixin, SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
+):
     """Приказује списак парохијана са могућношћу претраге и пагинације."""
 
     model = Parohijan
@@ -76,7 +79,7 @@ class SpisakParohijana(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
         )
 
 
-class ParohijanPDF(DetailView):
+class ParohijanPDF(LoginRequiredMixin, DetailView):
     """Генерише PDF документ за одређеног парохијана."""
 
     model = Parohijan
@@ -105,7 +108,7 @@ class ParohijanPDF(DetailView):
         return self.render_to_response(context)
 
 
-class PrikazParohijana(DetailView):
+class PrikazParohijana(LoginRequiredMixin, DetailView):
     """Приказује детаљне информације о одређеном парохијану."""
 
     model = Parohijan

--- a/crkva/registar/views/search_view.py
+++ b/crkva/registar/views/search_view.py
@@ -1,23 +1,16 @@
 """Глобална претрага и AJAX аутокомплетер."""
 
+from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
-
-from registar.models import (
-    Domacinstvo,
-    Krstenje,
-    Parohijan,
-    Slava,
-    Svestenik,
-    Vencanje,
-)
+from registar.models import Domacinstvo, Krstenje, Parohijan, Svestenik, Vencanje
 from registar.utils import get_query_variants
-
 
 SEARCH_PREVIEW_LIMIT = 5
 
 
+@login_required
 def search_view(request) -> HttpResponse:
     """Глобална претрага по свим ентитетима."""
     query = request.GET.get("query", "").strip()
@@ -114,6 +107,7 @@ def search_view(request) -> HttpResponse:
     return render(request, "registar/search_view.html", context)
 
 
+@login_required
 def search_autocomplete(request):
     """JSON endpoint за аутокомплит претрагу — grouped by type, ranked by relevance."""
     query = request.GET.get("q", "").strip()
@@ -234,5 +228,3 @@ def search_autocomplete(request):
         groups.append({"label": "Венчања", "items": items})
 
     return JsonResponse({"groups": groups})
-
-

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -1,10 +1,12 @@
 """Views for displaying households celebrating a specific slava."""
 
+from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from registar.models import Domacinstvo, Slava
 
 
+@login_required
 def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
     """Приказује домаћинства која славе одређену славу."""
     slava = get_object_or_404(Slava, uid=uid)

--- a/crkva/registar/views/svestenik_view.py
+++ b/crkva/registar/views/svestenik_view.py
@@ -2,6 +2,7 @@
 Модул за приказ, претрагу и генерисање PDF докумената за свештенике.
 """
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -30,7 +31,9 @@ def unos_svestenika(request):
     )
 
 
-class SpisakSvestenika(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
+class SpisakSvestenika(
+    LoginRequiredMixin, SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
+):
     """Приказује списак свештеника са могућностима претраге и пагинације."""
 
     model = Svestenik
@@ -52,7 +55,7 @@ class SpisakSvestenika(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
         )
 
 
-class SvestenikPDF(DetailView):
+class SvestenikPDF(LoginRequiredMixin, DetailView):
     """Генерише PDF документ за одређеног свештеника."""
 
     model = Svestenik
@@ -79,7 +82,7 @@ class SvestenikPDF(DetailView):
         return self.render_to_response(context)
 
 
-class PrikazSvestenika(DetailView):
+class PrikazSvestenika(LoginRequiredMixin, DetailView):
     """Приказује детаљне информације о одређеном свештенику."""
 
     model = Svestenik

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -2,6 +2,7 @@
 Модул за приказ, унос, претрагу и генерисање PDF докумената за венчања.
 """
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
@@ -25,7 +26,9 @@ VENCANJE_RELATED = (
 )
 
 
-class SpisakVencanja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
+class SpisakVencanja(
+    LoginRequiredMixin, SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView
+):
     """Приказује списак венчања са могућностима претраге и пагинације."""
 
     model = Vencanje
@@ -54,7 +57,7 @@ class SpisakVencanja(SearchMixin, PageSizeMixin, InfiniteScrollMixin, ListView):
         )
 
 
-class VencanjePDF(DetailView):
+class VencanjePDF(LoginRequiredMixin, DetailView):
     """Генерише PDF документ за одређено венчање."""
 
     model = Vencanje
@@ -116,7 +119,7 @@ class VencanjePDF(DetailView):
         return self.render_to_response(context)
 
 
-class PrikazVencanja(DetailView):
+class PrikazVencanja(LoginRequiredMixin, DetailView):
     """Приказује детаљне информације о појединачном венчању."""
 
     model = Vencanje
@@ -139,7 +142,6 @@ class PrikazVencanja(DetailView):
         return context
 
 
-# @login_required
 @tenant_role_required("vencanje")
 def unos_vencanja(request):
     """Обрада уноса новог венчања."""
@@ -157,7 +159,7 @@ def unos_vencanja(request):
     )
 
 
-# @login_required
+@tenant_role_required("vencanje")
 def calibrate_vencanje(request):
     """Приказује страницу за калибрацију позиција поља на венчаници."""
     return render(request, "registar/calibrate_vencanje.html")


### PR DESCRIPTION
…n, domacinstvo, krstenje, vencanje, svestenik)

- @login_required on read FBVs (home, kalendar, slava_domacinstva, search, search_autocomplete)
- @tenant_role_required on calibrate_krstenje and calibrate_vencanje (were unprotected)
- fix brzi_view.py: missing get_object_or_404 import + Parohijan→Osoba
- patch tests: add force_login/superuser setup where read views were hit anonymously