### PR TITLE
- bump specificity on .list-toolbar__search-input so the 42px left-pa…

### DIFF
--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -595,7 +595,7 @@
     pointer-events: none;
 }
 
-input.list-toolbar__search-input {
+.list-toolbar__search input.list-toolbar__search-input {
     appearance: none;
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -614,7 +614,7 @@ input.list-toolbar__search-input {
     margin: 0;
 }
 
-input.list-toolbar__search-input::-webkit-search-cancel-button {
+.list-toolbar__search input.list-toolbar__search-input::-webkit-search-cancel-button {
     -webkit-appearance: none;
     appearance: none;
     height: 14px;
@@ -626,17 +626,17 @@ input.list-toolbar__search-input::-webkit-search-cancel-button {
     opacity: 0.7;
 }
 
-input.list-toolbar__search-input::-webkit-search-cancel-button:hover {
+.list-toolbar__search input.list-toolbar__search-input::-webkit-search-cancel-button:hover {
     opacity: 1;
 }
 
-input.list-toolbar__search-input:focus {
+.list-toolbar__search input.list-toolbar__search-input:focus {
     outline: none;
     border-color: var(--color-primary);
     box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
 }
 
-input.list-toolbar__search-input::placeholder {
+.list-toolbar__search input.list-toolbar__search-input::placeholder {
     color: var(--color-text-muted);
 }
 


### PR DESCRIPTION
…dding wins over the global input[type=search] rule in forme.css that loads later and was resetting padding to 10px (caused placeholder text to overlap the magnifying-glass icon)