### PR TITLE
- slava_domacinstva.html: card header shows family prezime only (was …

### DIFF
--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -372,7 +372,7 @@
    EMPTY STATE – nicer look when no records
    ========================================================================== */
 
-.spisak li:only-child:not(.stavka) {
+.spisak > li:only-child:not(.stavka) {
     text-align: center;
     padding: 40px 20px;
     color: var(--color-text-muted);
@@ -990,16 +990,7 @@ body.history-open {
 .u-page-header { flex-wrap: wrap; gap: var(--space-2); }
 .u-page-header .u-page-title { margin-right: auto; }
 
-/* Stack columns on narrow screens */
-@media (max-width: 720px) {
-  .stavka__roster { grid-template-columns: 1fr; gap: var(--space-3); }
-  .stavka__roster-col--deceased {
-    border-left: 0;
-    padding-left: 0;
-    padding-top: var(--space-2);
-    border-top: 1px dashed var(--color-border);
-  }
-}
+
 
 /* Slava-page header needs the title + meta + button on one row */
 .u-page-header { flex-wrap: wrap; gap: var(--space-2); }
@@ -1018,15 +1009,21 @@ body.history-open {
 .stavka--slava .stavka-veza { display: block; }
 
 .stavka__roster {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
   margin-top: var(--space-3);
   padding-top: var(--space-3);
   border-top: 1px solid var(--color-border);
 }
 
-.stavka__roster-col { min-width: 0; }
+.stavka__roster-col {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-3);
+  min-width: 0;
+}
 
 .stavka__roster-head {
   font-family: var(--font-sans);
@@ -1034,8 +1031,9 @@ body.history-open {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-text-muted);
-  margin-bottom: var(--space-2);
+  margin-bottom: 0;
   font-weight: 600;
+  min-width: 6.5em;
 }
 .stavka__roster-head .stavka__roster-count {
   font-weight: 400;
@@ -1045,6 +1043,9 @@ body.history-open {
 
 .stavka__roster-list {
   list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
   padding: 0;
   margin: 0;
 }
@@ -1053,7 +1054,14 @@ body.history-open {
   font-size: 0.875rem;
   line-height: 1.6;
   color: var(--color-text);
-  padding: 1px 0;
+  padding: 0;
+  display: inline;
+}
+.stavka__roster-list li.stavka__roster-item--domacin {
+  padding: 0 8px;
+  background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+  color: var(--color-primary);
+  border-radius: 999px;
 }
 .stavka__roster-col--deceased .stavka__roster-list li {
   color: var(--color-text-muted);
@@ -1068,38 +1076,6 @@ body.history-open {
   font-size: 0.85rem;
   color: var(--color-text-muted);
   opacity: 0.6;
-}
-
-/* Single-column variant: when one side is empty (or both fit naturally
-   on one column), drop the 2-col grid so the lone column doesn't sit
-   isolated in a half-width box. */
-/* Single-column variant: flow header + names inline so a list of one or two
-   members renders compactly ("Живи  Никола Поповић  Марија Поповић") instead
-   of stretching across a full-width column with empty space below.
-   .stavka__roster-col wraps the header + ul and needs display: contents so
-   its children participate directly in the parent flex layout. */
-.stavka__roster--single {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: var(--space-1) var(--space-3);
-}
-.stavka__roster--single .stavka__roster-col {
-  display: contents;
-}
-.stavka__roster--single .stavka__roster-head {
-  margin-bottom: 0;
-}
-.stavka__roster--single .stavka__roster-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-1) var(--space-3);
-  margin: 0;
-  padding: 0;
-}
-.stavka__roster--single .stavka__roster-list li {
-  padding: 0;
-  display: inline;
 }
 
 /* Stack columns on narrow screens */

--- a/crkva/registar/templates/registar/slava_domacinstva.html
+++ b/crkva/registar/templates/registar/slava_domacinstva.html
@@ -27,7 +27,7 @@
       <li class="stavka stavka--slava">
         <a href="{% url 'domacinstvo_detail' uid=domacinstvo.uid %}" class="stavka-veza">
           <span class="stavka__primary">
-            {% if domacinstvo.domacin %}{{ domacinstvo.domacin.ime|title }} {{ domacinstvo.domacin.prezime|title }}
+            {% if domacinstvo.domacin and domacinstvo.domacin.prezime %}{{ domacinstvo.domacin.prezime|title }}
             {% else %}<span class="muted">Непознат домаћин</span>{% endif %}
           </span>
           <span class="stavka__secondary">
@@ -42,12 +42,12 @@
               domacinstvo.zivi_clanovi / .preminuli_clanovi. Render only
               columns that have content; lone column takes natural width.
             {% endcomment %}
-            <div class="stavka__roster{% if not domacinstvo.zivi_clanovi or not domacinstvo.preminuli_clanovi %} stavka__roster--single{% endif %}">
+            <div class="stavka__roster">
               {% if domacinstvo.zivi_clanovi %}
                 <div class="stavka__roster-col">
                   <div class="stavka__roster-head">Живи</div>
                   <ul class="stavka__roster-list">
-                    {% for u in domacinstvo.zivi_clanovi %}<li>{% if u.osoba %}{{ u.osoba.ime|title }} {{ u.osoba.prezime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
+                    {% for u in domacinstvo.zivi_clanovi %}<li{% if u.osoba and domacinstvo.domacin and u.osoba.uid == domacinstvo.domacin.uid %} class="stavka__roster-item--domacin"{% endif %}>{% if u.osoba %}{{ u.osoba.ime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
                   </ul>
                 </div>
               {% endif %}
@@ -55,7 +55,7 @@
                 <div class="stavka__roster-col stavka__roster-col--deceased">
                   <div class="stavka__roster-head">Преминули</div>
                   <ul class="stavka__roster-list">
-                    {% for u in domacinstvo.preminuli_clanovi %}<li>{% if u.osoba %}{{ u.osoba.ime|title }} {{ u.osoba.prezime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
+                    {% for u in domacinstvo.preminuli_clanovi %}<li{% if u.osoba and domacinstvo.domacin and u.osoba.uid == domacinstvo.domacin.uid %} class="stavka__roster-item--domacin"{% endif %}>{% if u.osoba %}{{ u.osoba.ime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
                   </ul>
                 </div>
               {% endif %}


### PR DESCRIPTION
…first+last), drop .stavka__roster--single conditional (one layout for both 1- and 2-row cases)

- roster lists show only first names (was first+last) and tag the domacin item with .stavka__roster-item--domacin
- spiskovi.css: rewrite .stavka__roster as stacked horizontal rows (flex-direction: column, each row is header + names inline via flex-wrap)
- highlight domacin name as a primary-tinted pill (color-mix bg + border-radius 999px, no font-weight change so other names stay regular)
- fix .spisak li:only-child:not(.stavka) empty-state selector → scope to direct child (was wrongly hitting any single-li deep in the tree, including roster lists with one member; thats what made single-item rows render as a boxed centered panel)