### PR TITLE
- domacinstva: secondary line shows address (icon) + phones; drop sla…

### DIFF
--- a/crkva/registar/templates/registar/_stavka_domacinstva.html
+++ b/crkva/registar/templates/registar/_stavka_domacinstva.html
@@ -1,12 +1,37 @@
-{% load marker_filter %}
+{% load marker_filter phone_filters %}
 {% for domacinstvo in domacinstva %}
-<li class="stavka" data-id="{{ domacinstvo.uid }}">
+<li class="stavka stavka--slava" data-id="{{ domacinstvo.uid }}">
     <a href="{% url 'domacinstvo_detail' uid=domacinstvo.uid %}" class="stavka-veza">
-        {# safe-ok: markiraj filter escapes input before adding <span> highlight wrapping — see marker_filter.py for the contract #}
-        <span class="stavka__primary">{{ domacinstvo.domacin.ime|markiraj:upit|safe }} {{ domacinstvo.domacin.prezime|markiraj:upit|safe }}</span>
-        <span class="stavka__secondary">
-            {% if domacinstvo.slava %}{{ domacinstvo.slava }} &middot; {% endif %}{% if domacinstvo.adresa %}{{ domacinstvo.adresa }} &middot; {% endif %}{{ domacinstvo.ukucani.count }} чл.
+        <span class="stavka__primary">
+            {% if domacinstvo.domacin and domacinstvo.domacin.prezime %}{{ domacinstvo.domacin.prezime|markiraj:upit|safe }}
+            {% else %}<span class="muted">Непознат домаћин</span>{% endif %}
         </span>
+        <span class="stavka__secondary">
+            {% if domacinstvo.adresa %}<i class="fa-solid fa-location-dot"></i> {{ domacinstvo.adresa }}{% endif %}
+            {% if domacinstvo.tel_fiksni %}{% if domacinstvo.adresa %} &middot; {% endif %}<i class="fa-solid {{ domacinstvo.tel_fiksni|phone_icon }}"></i> {{ domacinstvo.tel_fiksni|format_phone }}{% endif %}
+            {% if domacinstvo.tel_mobilni %}{% if domacinstvo.adresa or domacinstvo.tel_fiksni %} &middot; {% endif %}<i class="fa-solid {{ domacinstvo.tel_mobilni|phone_icon }}"></i> {{ domacinstvo.tel_mobilni|format_phone }}{% endif %}
+        </span>
+
+        {% if domacinstvo.ukucani.all %}
+            <div class="stavka__roster">
+                {% if domacinstvo.zivi_clanovi %}
+                    <div class="stavka__roster-col">
+                        <div class="stavka__roster-head">Живи</div>
+                        <ul class="stavka__roster-list">
+                            {% for u in domacinstvo.zivi_clanovi %}<li{% if u.osoba and domacinstvo.domacin and u.osoba.uid == domacinstvo.domacin.uid %} class="stavka__roster-item--domacin"{% endif %}>{% if u.osoba %}{{ u.osoba.ime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+                {% if domacinstvo.preminuli_clanovi %}
+                    <div class="stavka__roster-col stavka__roster-col--deceased">
+                        <div class="stavka__roster-head">Преминули</div>
+                        <ul class="stavka__roster-list">
+                            {% for u in domacinstvo.preminuli_clanovi %}<li{% if u.osoba and domacinstvo.domacin and u.osoba.uid == domacinstvo.domacin.uid %} class="stavka__roster-item--domacin"{% endif %}>{% if u.osoba %}{{ u.osoba.ime|title }}{% else %}{{ u.ime_ukucana|title|default:"—" }}{% endif %}{% if u.uloga and u.uloga != "остало" %}<span class="stavka__roster-role">{{ u.get_uloga_display }}</span>{% endif %}</li>{% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+            </div>
+        {% endif %}
     </a>
 </li>
 {% empty %}

--- a/crkva/registar/templates/registar/_stavka_krstenja.html
+++ b/crkva/registar/templates/registar/_stavka_krstenja.html
@@ -5,7 +5,7 @@
         {# safe-ok: markiraj filter escapes input before adding <span> highlight wrapping — see marker_filter.py for the contract #}
         <span class="stavka__primary">{{ krstenje.ime_deteta|markiraj:upit|safe }} {{ krstenje.prezime_oca|markiraj:upit|safe }}</span>
         {# safe-ok: markiraj filter escapes input before adding <span> highlight wrapping — see marker_filter.py for the contract #}
-        <span class="stavka__secondary">{{ krstenje.datum }} &middot; {{ krstenje.ime_oca|markiraj:upit|safe }} и {{ krstenje.ime_majke|markiraj:upit|safe }} {{ krstenje.prezime_majke|markiraj:upit|safe }}</span>
+        <span class="stavka__secondary"><i class="fa-solid fa-calendar-day"></i> {{ krstenje.datum }}{% if krstenje.hram %} &middot; <i class="fa-solid fa-church"></i> {{ krstenje.hram }}{% endif %} &middot; <i class="fa-solid fa-people-group"></i> {{ krstenje.ime_oca|markiraj:upit|safe }} и {{ krstenje.ime_majke|markiraj:upit|safe }} {{ krstenje.prezime_majke|markiraj:upit|safe }}</span>
     </a>
     <a href="{% url 'krstenje_pdf' uid=krstenje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
 </li>

--- a/crkva/registar/templates/registar/_stavka_parohijana.html
+++ b/crkva/registar/templates/registar/_stavka_parohijana.html
@@ -4,7 +4,7 @@
     <a href="{% url 'parohijan_detail' uid=parohijan.uid %}" class="stavka-veza">
         {# safe-ok: markiraj filter escapes input before adding <span> highlight wrapping — see marker_filter.py for the contract #}
         <span class="stavka__primary">{{ parohijan.ime|markiraj:upit|safe }} {{ parohijan.prezime|markiraj:upit|safe }}</span>
-        <span class="stavka__secondary">{% if parohijan.datum_rodjenja %}{{ parohijan.datum_rodjenja }}{% endif %}{% if parohijan.adresa %}{% if parohijan.datum_rodjenja %} &middot; {% endif %}{{ parohijan.adresa }}{% endif %}</span>
+        <span class="stavka__secondary">{% if parohijan.datum_rodjenja %}<i class="fa-solid fa-cake-candles"></i> {{ parohijan.datum_rodjenja }}{% endif %}{% if parohijan.adresa %}{% if parohijan.datum_rodjenja %} &middot; {% endif %}<i class="fa-solid fa-location-dot"></i> {{ parohijan.adresa }}{% endif %}</span>
         {% if parohijan.domacinstvo %}
         <span class="stavka__meta">
             <span class="stavka__meta-badge stavka__meta-badge--domacin">домаћин</span>

--- a/crkva/registar/templates/registar/_stavka_svestenika.html
+++ b/crkva/registar/templates/registar/_stavka_svestenika.html
@@ -3,7 +3,7 @@
 <li class="stavka">
     <a href="{% url 'svestenik_detail' uid=svestenik.uid %}" class="stavka-veza">
         <span class="stavka__primary">{{ svestenik.ime|markiraj:upit }} {{ svestenik.prezime|markiraj:upit }}</span>
-        <span class="stavka__secondary">{{ svestenik.zvanje }}{% if svestenik.parohija %} &middot; {{ svestenik.parohija }}{% endif %}</span>
+        <span class="stavka__secondary"><i class="fa-solid fa-id-badge"></i> {{ svestenik.zvanje }}{% if svestenik.parohija %} &middot; <i class="fa-solid fa-church"></i> {{ svestenik.parohija }}{% endif %}</span>
     </a>
     <a href="{% url 'svestenik_pdf' uid=svestenik.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
 </li>

--- a/crkva/registar/templates/registar/_stavka_vencanja.html
+++ b/crkva/registar/templates/registar/_stavka_vencanja.html
@@ -4,7 +4,7 @@
     <a href="{% url 'vencanje_detail' uid=vencanje.uid %}" class="stavka-veza">
         {# safe-ok: markiraj filter escapes input before adding <span> highlight wrapping — see marker_filter.py for the contract #}
         <span class="stavka__primary">{{ vencanje.ime_zenika|markiraj:upit|safe }} и {{ vencanje.ime_neveste|markiraj:upit|safe }} {{ vencanje.prezime_zenika|markiraj:upit|safe }}</span>
-        <span class="stavka__secondary">{{ vencanje.datum }}</span>
+        <span class="stavka__secondary"><i class="fa-solid fa-calendar-day"></i> {{ vencanje.datum }}{% if vencanje.hram %} &middot; <i class="fa-solid fa-church"></i> {{ vencanje.hram }}{% endif %}</span>
     </a>
     <a href="{% url 'vencanje_pdf' uid=vencanje.uid %}" target="_blank" class="button button--primary" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></a>
 </li>

--- a/crkva/registar/views/domacinstvo_view.py
+++ b/crkva/registar/views/domacinstvo_view.py
@@ -42,10 +42,12 @@ class SpisakDomacinsta(
     paginate_by = 20
     search_fields = ["domacin__ime", "domacin__prezime", "adresa__ulica"]
     sort_options = [
+        ("adresa__ulica", "Адреса А-Ш"),
+        ("-adresa__ulica", "Адреса Ш-А"),
         ("domacin__prezime", "Презиме А-Ш"),
         ("-domacin__prezime", "Презиме Ш-А"),
     ]
-    ordering = ["domacin__prezime", "domacin__ime"]
+    ordering = ["adresa__ulica", "adresa__broj", "domacin__prezime", "domacin__ime"]
 
     def get_queryset(self):
         return self.get_search_queryset(
@@ -53,6 +55,14 @@ class SpisakDomacinsta(
             .prefetch_related("ukucani", "ukucani__osoba")
             .all()
         )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        for d in context["domacinstva"]:
+            members = list(d.ukucani.all())
+            d.zivi_clanovi = [u for u in members if not u.preminuo]
+            d.preminuli_clanovi = [u for u in members if u.preminuo]
+        return context
 
 
 class PrikazDomacinstva(LoginRequiredMixin, DetailView):

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -16,7 +16,12 @@ def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
         Domacinstvo.objects.filter(slava=slava)
         .select_related("domacin", "adresa")
         .prefetch_related("ukucani", "ukucani__osoba")
-        .order_by("domacin__prezime", "domacin__ime")
+        .order_by(
+            "adresa__ulica",
+            "adresa__broj",
+            "domacin__prezime",
+            "domacin__ime",
+        )
     )
 
     # Attach partitioned lists so the template can render living vs.


### PR DESCRIPTION
…va from secondary

- domacinstva: sort by adresa.ulica → adresa.broj → prezime; add Адреса A-Ш/Ш-А sort options
- slava-page: sort households by address (was prezime)
- 5 list partials (parohijani/krstenja/vencanja/svestenici/domacinstva): icons on secondary metadata