### PR TITLE
- spisak_{parohijana,domacinstva,krstenja,vencanja,svestenika}.html: …

### DIFF
--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -45,6 +45,8 @@
     gap: var(--space-4);
     margin: var(--space-5) 0 var(--space-3);
     width: 100%;
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
     /* Stick to viewport top so back/edit/print/history stay reachable while
        scrolling through long forms. Background is opaque (theme-aware) so
        content scrolling underneath does not bleed through; a hairline
@@ -204,4 +206,13 @@
 .osoba__devojacko {
     color: var(--color-text-muted);
     font-weight: 400;
+}
+
+
+/* When the list toolbar (search + sort) is rendered inside a u-page-header,
+   wrap it to a full-width second row below the title. Keeps the toolbar
+   sticky with the header instead of scrolling away with the list. */
+.u-page-header > .list-toolbar {
+    flex-basis: 100%;
+    margin: 0;
 }

--- a/crkva/registar/templates/registar/spisak_domacinstva.html
+++ b/crkva/registar/templates/registar/spisak_domacinstva.html
@@ -7,8 +7,9 @@
         <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Домаћинства <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+    {% include "registar/_list_toolbar.html" %}
 </div>
-{% include "registar/_list_toolbar.html" %}
+
 {% include "registar/_filter_chips.html" %}
 <ul class="spisak" id="spisak-list">
     {% include "registar/_stavka_domacinstva.html" %}

--- a/crkva/registar/templates/registar/spisak_krstenja.html
+++ b/crkva/registar/templates/registar/spisak_krstenja.html
@@ -7,8 +7,9 @@
         <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Крштења <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+    {% include "registar/_list_toolbar.html" %}
 </div>
-{% include "registar/_list_toolbar.html" %}
+
 {% include "registar/_filter_chips.html" %}
 <ul class="spisak" id="spisak-list">
     {% include "registar/_stavka_krstenja.html" %}

--- a/crkva/registar/templates/registar/spisak_parohijana.html
+++ b/crkva/registar/templates/registar/spisak_parohijana.html
@@ -7,8 +7,9 @@
         <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Парохијани <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+    {% include "registar/_list_toolbar.html" %}
 </div>
-{% include "registar/_list_toolbar.html" %}
+
 {% include "registar/_filter_chips.html" %}
 <ul class="spisak" id="spisak-list">
     {% include "registar/_stavka_parohijana.html" %}

--- a/crkva/registar/templates/registar/spisak_svestenika.html
+++ b/crkva/registar/templates/registar/spisak_svestenika.html
@@ -7,8 +7,9 @@
         <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Свештеници <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+    {% include "registar/_list_toolbar.html" %}
 </div>
-{% include "registar/_list_toolbar.html" %}
+
 {% include "registar/_filter_chips.html" %}
 <ul class="spisak" id="spisak-list">
     {% include "registar/_stavka_svestenika.html" %}

--- a/crkva/registar/templates/registar/spisak_vencanja.html
+++ b/crkva/registar/templates/registar/spisak_vencanja.html
@@ -7,8 +7,9 @@
         <i class="fa-solid fa-arrow-left"></i>
     </a>
     <h1 class="u-page-title">Венчања <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
+    {% include "registar/_list_toolbar.html" %}
 </div>
-{% include "registar/_list_toolbar.html" %}
+
 {% include "registar/_filter_chips.html" %}
 <ul class="spisak" id="spisak-list">
     {% include "registar/_stavka_vencanja.html" %}


### PR DESCRIPTION
…move _list_toolbar include inside the u-page-header div so search + sort stay together with the title in the sticky block (was a separate row below that scrolled away with the list)

- pomocno.css: u-page-header gets flex-wrap + row-gap; .u-page-header > .list-toolbar takes flex-basis: 100% and drops its own margin so it renders as a full-width second row inside the header