### PR TITLE
- rename registar.0009_alter_historicalsvestenik_zvanje_and_more → 00…

### DIFF
--- a/crkva/registar/migrations/0010_alter_historicalsvestenik_zvanje_and_more.py
+++ b/crkva/registar/migrations/0010_alter_historicalsvestenik_zvanje_and_more.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("registar", "0008_alter_domacinstvo_tel_fiksni_and_more"),
+        ("registar", "0009_alter_domacinstvo_options_alter_krstenje_options_and_more"),
     ]
 
     operations = [


### PR DESCRIPTION
…10 (it landed on main as a second sibling of 0009 because PR-2 and PR-4 both auto-generated 0009 in parallel; this resolves the multi-head into a linear history)

- update dependencies to depend on 0009_alter_domacinstvo_options_alter_krstenje_options_and_more (the indexes/ordering migration)
- both migrations apply cleanly across tenant schemas (cukarica + amsterdam test runs OK)