### PR TITLE
- rename crkva/registar/static/registar/base/tokens.css → base/global…

### DIFF
--- a/crkva/registar/static/registar/base/globals.css
+++ b/crkva/registar/static/registar/base/globals.css
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   GLOBAL RESET + TYPOGRAPHY + UTILITIES (theme-agnostic)
+   GLOBALS — reset + typography + utilities (theme-agnostic)
    --------------------------------------------------------------------------
    Color tokens live in the three theme files under registar/themes/:
      • svetla.css — Light (default)

--- a/crkva/registar/static/registar/components/dugmad.css
+++ b/crkva/registar/static/registar/components/dugmad.css
@@ -218,7 +218,7 @@
     left: 50%;
     transform: translateX(-50%);
     padding: 6px 10px;
-    /* Theme-aware via dedicated tokens — see base/tokens.css + themes/tamna.css.
+    /* Theme-aware via dedicated tokens — see themes/svetla.css + themes/tamna.css.
        Never use --color-surface / --color-text here: they invert in dark mode
        and produce dark-on-dark bubbles. */
     background: var(--tooltip-bg);

--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -509,7 +509,7 @@
   right: 0;
   margin-top: 8px;
   padding: 8px 12px;
-  /* Theme-aware tooltip tokens — see base/tokens.css + themes/tamna.css.
+  /* Theme-aware tooltip tokens — see themes/svetla.css + themes/tamna.css.
      Using --color-surface for text breaks dark mode (text == page bg). */
   background: var(--tooltip-bg);
   color: var(--tooltip-text);

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -40,7 +40,7 @@
       <!-- Centralized local fonts (must be loaded before components for correct metrics) -->
       <link rel="stylesheet" href="{% static 'registar/base/fonts.css' %}">
       <!-- Base tokens and globals -->
-      <link rel="stylesheet" href="{% static 'registar/base/tokens.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/base/globals.css' %}">
       <!-- Utilities -->
       <link rel="stylesheet" href="{% static 'registar/utilities/pomocno.css' %}">
       <!-- Layout and components -->

--- a/crkva/registar/templates/registar/login.html
+++ b/crkva/registar/templates/registar/login.html
@@ -23,7 +23,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&family=PT+Serif:wght@400;700&family=JetBrains+Mono:wght@400;500&&subset=cyrillic,cyrillic-ext,latin&display=swap" rel="stylesheet">
     {% compress css %}
       <link rel="stylesheet" href="{% static 'registar/base/fonts.css' %}">
-      <link rel="stylesheet" href="{% static 'registar/base/tokens.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/base/globals.css' %}">
       <link rel="stylesheet" href="{% static 'registar/pages/prijava.css' %}">
       <link rel="stylesheet" href="{% static 'registar/themes/sepia.css' %}">
       <link rel="stylesheet" href="{% static 'registar/themes/tamna.css' %}">


### PR DESCRIPTION
…s.css: PR #188 stripped the :root token block out of this file, leaving only the box-sizing reset + html/body + h1-h6 + .u-* utilities. The filename no longer matched the content, so this rename closes that gap

- update header comment to GLOBALS (was GLOBAL RESET + TYPOGRAPHY + UTILITIES) and keep the pointer to themes/svetla.css|sepia.css|tamna.css for color tokens
- 4 link-site updates: base.html + registar/login.html now load base/globals.css; comment refs in pages/kalendar.css and components/dugmad.css that previously said see base/tokens.css now correctly point at themes/svetla.css + themes/tamna.css (since the actual tooltip tokens live in the theme files, not in globals.css)
- test_tooltip_dark_contrast.py was retargeted at themes/svetla.css in the prior #189 fix; nothing to touch here