### PR TITLE
- kartice.css: on phones the .registry__card mirrors .actions__item —…

### DIFF
--- a/crkva/registar/static/registar/components/kartice.css
+++ b/crkva/registar/static/registar/components/kartice.css
@@ -288,5 +288,15 @@
 @media (max-width: 640px) {
     .card, .card--elevated, .card--hero { padding: var(--space-3); }
     .card__header { margin-bottom: var(--space-3); padding-bottom: var(--space-2); }
-    .registry__card { flex-direction: column; align-items: flex-start; text-align: left; }
+    /* On phones the Регистри cards mirror Брзе акције (horizontal icon+text,
+       compact chrome) so the two sections read as the same component. */
+    .registry__card {
+        padding: var(--space-3) var(--space-4);
+        gap: var(--space-3);
+        background: var(--color-surface-2);
+        border-radius: var(--radius-2);
+    }
+    .registry__icon { width: 36px; height: 36px; font-size: 1.1rem; }
+    .registry__title { font-size: 0.95rem; }
+    .registry__desc  { font-size: 0.8rem; }
 }

--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -720,16 +720,15 @@ select.list-toolbar__sort-select option {
 }
 
 @media (max-width: 640px) {
+    /* Keep search + sort on a single row so the toolbar stays one row tall
+       instead of taking up half the viewport. Search grows, sort shrinks. */
     .list-toolbar {
-        flex-direction: column;
-        align-items: stretch;
+        flex-wrap: nowrap;
+        gap: var(--space-2);
     }
-    .list-toolbar__search,
-    .list-toolbar__select,
+    .list-toolbar__search { flex: 1 1 0; min-width: 0; }
     .list-toolbar__sort,
-    .list-toolbar__sort-select {
-        width: 100%;
-    }
+    .list-toolbar__sort-select { flex: 0 0 auto; width: auto; }
 }
 
 /* ==========================================================================

--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -171,6 +171,19 @@
     .u-page-header { gap: var(--space-3); flex-wrap: wrap; }
 }
 
+/* On mobile a fixed hamburger button sits at top:15/left:15 over the page;
+   reserve left padding on the header so the back-button + title don't sit
+   underneath it. */
+@media (max-width: 768px) {
+    .u-page-header {
+        padding-left: 60px;
+        margin-top: var(--space-2);
+        margin-bottom: var(--space-2);
+        padding-bottom: var(--space-1);
+        row-gap: var(--space-1);
+    }
+}
+
 
 /* Move 8 — inline-style cleanup utilities */
 
@@ -265,4 +278,14 @@
     bottom: 0;
     transform: translateY(50%);
     z-index: 30;
+}
+
+/* On phones the absolute back-button overlapped the wrapped list-toolbar
+   (search + sort) row. Revert to inline flex order on narrow screens so
+   the back-arrow sits beside the title like the rest of the chrome. */
+@media (max-width: 640px) {
+    .u-page-header > .back-button {
+        position: static;
+        transform: none;
+    }
 }

--- a/crkva/registar/templates/registar/_stavka_parohijana.html
+++ b/crkva/registar/templates/registar/_stavka_parohijana.html
@@ -6,9 +6,9 @@
         <span class="stavka__primary">{{ parohijan.ime|markiraj:upit|safe }} {{ parohijan.prezime|markiraj:upit|safe }}</span>
         <span class="stavka__secondary">{% if parohijan.datum_rodjenja %}<i class="fa-solid fa-cake-candles"></i> {{ parohijan.datum_rodjenja }}{% endif %}{% if parohijan.adresa %}{% if parohijan.datum_rodjenja %} &middot; {% endif %}<i class="fa-solid fa-location-dot"></i> {{ parohijan.adresa }}{% endif %}</span>
         {% if parohijan.domacinstvo %}
+        {# For домаћин the address is the same as the household address already shown in stavka__secondary above — surface only the role badge. #}
         <span class="stavka__meta">
             <span class="stavka__meta-badge stavka__meta-badge--domacin">домаћин</span>
-            {% if parohijan.domacinstvo.adresa %}<span class="stavka__meta-text">{{ parohijan.domacinstvo.adresa }}</span>{% endif %}
         </span>
         {% elif parohijan.prefetched_ukucanstva.0 %}
         {% with uk=parohijan.prefetched_ukucanstva.0 %}


### PR DESCRIPTION
… horizontal icon+text, compact padding (var(--space-3) var(--space-4)), surface-2 background, smaller icon (36px). Was switching to flex-direction: column at \u2264640px which read as a different component vs the Брзе акције row above

- pomocno.css: stand-alone .u-page-header > .back-button reverts to position: static at \u2264640px (was absolute bottom-left, which overlapped the wrapped list-toolbar row). Adds 60px left padding to .u-page-header at \u2264768px so the fixed hamburger button (top:15 left:15) does not sit on top of the back-arrow or title. Tightens header margins/paddings on mobile (var(--space-2) top+bottom, var(--space-1) padding-bottom + row-gap) so the title row + toolbar row no longer eat half the viewport
- spiskovi.css: at \u2264640px the .list-toolbar drops the flex-direction: column rule and stays a single row (search grows, sort sits beside it). Was stacking search + sort vertically, doubling the toolbar height
- _stavka_parohijana.html: drop duplicate household address from the домаћин badge meta-text. The address was already rendered in stavka__secondary above (parohijan.adresa). For домаћин these are the same value, so it printed twice. Член badge still shows the household-head name (distinct info)