### PR TITLE
- move theme-agnostic tokens (--space-*, --radius-*, --font-*) from t…

### DIFF
--- a/crkva/registar/static/registar/base/globals.css
+++ b/crkva/registar/static/registar/base/globals.css
@@ -209,3 +209,30 @@ a:hover { color: var(--color-link-hover); text-decoration: underline; }
 @media (max-width: 768px) {
     .u-page-header { padding: 0 var(--space-3); }
 }
+
+
+/* ==========================================================================
+   THEME-AGNOSTIC TOKENS — same in every theme (spacing, radius, typography).
+   Live here instead of in svetla.css so a new theme that does not extend
+   the light :root still inherits these defaults.
+   ========================================================================== */
+:root {
+    /* ---------- Spacing ---------- */
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 24px;
+    --space-6: 32px;
+    /* ---------- Radius ---------- */
+    --radius-1: 3px;
+    --radius-2: 6px;
+    --radius-3: 10px;
+
+    /* ---------- Typography ---------- */
+    --font-display: 'Miroslavljeva Cirilica', 'PT Serif', Georgia, serif;
+    --font-serif:   'PT Serif', 'Source Serif Pro', Georgia, serif;
+    --font-sans:    'Source Sans Pro', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    --font-mono:    'JetBrains Mono', 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    --font-body:    var(--font-sans);
+}

--- a/crkva/registar/static/registar/themes/sepia.css
+++ b/crkva/registar/static/registar/themes/sepia.css
@@ -24,6 +24,7 @@
     --color-surface:        #F6EED7;   /* body / page bg = parchment base */
     --color-surface-2:      #FBF5E3;   /* cards lift via lighter cream */
     --color-surface-1:      #EBDFC1;   /* form controls / hover */
+    --color-surface-hover:  #FFF8E6;   /* row/card hover state */
     --color-border:         rgba(176, 132, 67, 0.30);
     --color-border-strong:  rgba(176, 132, 67, 0.50);
 
@@ -33,10 +34,10 @@
     --color-info:           #3D5878;
     --color-warning:        #8C6B2F;
 
-    /* ---------- Slava badge ---------- */
-    --color-slava-text:     #5A3F18;
-    --color-slava-bg:       #F1E5C9;
-    --color-slava-border:   #B08443;
+    /* ---------- Slava badge — aliased to warning tokens (collapsed M5) ---------- */
+    --color-slava-text:     var(--color-warning-text);
+    --color-slava-bg:       var(--color-warning-bg);
+    --color-slava-border:   var(--color-warning-border);
 
     /* ---------- Warning / info / error ---------- */
     --color-warning-text:   #5A3F18;
@@ -74,12 +75,7 @@
     --sidebar-scrollbar-thumb: rgba(176, 132, 67, 0.28);
     --sidebar-scrollbar-thumb-hover: rgba(176, 132, 67, 0.42);
 
-    /* ---------- Fasting cells (warm-tinted) ---------- */
-    --fasting-dairy-bg: rgba(176, 132, 67, 0.16);
-    --fasting-fish-bg:  rgba(61, 88, 120, 0.16);
-    --fasting-oil-bg:   rgba(176, 132, 67, 0.26);
-    --fasting-water-bg: rgba(61, 88, 120, 0.24);
-
+    /* Fasting cells now live in the parity block below to avoid duplicates. */
     /* ---------- Token parity (Move 7) — explicit values per theme ---------- */
 
     /* Accent: keep family, slightly cooler on sepia */
@@ -108,7 +104,9 @@
     --color-ink-700:     #262934;
     --color-ink-600:     #3A3E4C;
 
-    /* Greys — re-toned to warm so they fit sepia surfaces */
+    /* Greys (legacy name) — actually warm neutrals on sepia; values are
+       parchment / cream tones, NOT desaturated grey. Renaming would be a big
+       cross-codebase touch; the warm intent is documented here. */
     --color-gray-100: #FBF5E3;
     --color-gray-200: #F1E9D9;
     --color-gray-300: #E0D4B6;
@@ -138,19 +136,18 @@
     --fasting-oil-bg:   rgba(176, 132, 67, 0.28);
     --fasting-water-bg: rgba(61, 88, 120, 0.26);
 
+    /* Olive (used for domacin badge on warm themes — pairs with gold accent) */
+    --color-olive:         #4F5B1E;
+    --color-olive-bg:      #ECE7C9;
+    --color-olive-border:  #B7AE74;
+
     /* Other utility */
     --color-black-alpha-90: rgba(0, 0, 0, 0.9);
     --color-white-alpha-20: rgba(237, 230, 214, 0.18);
 
-    /* Legacy dark-* aliases (kept for back-compat) */
-    --color-dark-bg:            var(--color-ink-800);
-    --color-dark-bg-deep:       var(--color-ink-900);
-    --color-dark-border:        #2D3140;
-    --color-dark-text:          #EDE6D6;
-    --color-dark-text-secondary:#9C8E7D;
 
-    /* Secondary */
-    --color-secondary: #6E0F0E;
+    /* Secondary — cooler than primary-700, sits between primary and ink */
+    --color-secondary: #5C3F1E;
 
     /* Fasting cells — explicit values (Move 7b token parity) */
     --fasting-oil-cell:       #F1E5C9;
@@ -205,7 +202,7 @@
 [data-theme="sepia"] .action-item:hover,
 [data-theme="sepia"] .registry__card:hover,
 [data-theme="sepia"] .registry-card:hover {
-    background: #FFF8E6;
+    background: var(--color-surface-hover);
     border-color: var(--color-accent);
 }
 
@@ -233,6 +230,26 @@
     border-color: var(--color-border);
 }
 [data-theme="sepia"] .stavka:hover {
-    background: #FFF8E6;
+    background: var(--color-surface-hover);
     border-color: var(--color-accent);
+}
+
+
+/* On sepia the домаћин badge inherits --color-primary (deep red), which
+   clashes with the warm parchment palette. Override with olive — pairs
+   with the existing aged-gold accent. */
+[data-theme="sepia"] .stavka__meta-badge--domacin {
+    color: var(--color-olive);
+    background: var(--color-olive-bg);
+    border-color: var(--color-olive-border);
+}
+
+/* Item 7: sepia parity for select2 selection chrome. forme.css gives select2
+   the same surface-1 light bg as text inputs by default; sepia's input rule
+   above deepens text inputs but does not include select2-selection, so the
+   select2 widget rendered with the wrong (light) bg. Match it here. */
+[data-theme="sepia"] .select2-container--default .select2-selection--single {
+    background-color: var(--color-surface-2);
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
 }

--- a/crkva/registar/static/registar/themes/svetla.css
+++ b/crkva/registar/static/registar/themes/svetla.css
@@ -41,6 +41,7 @@
     --color-surface:        #FFFFFF;
     --color-surface-2:      #FAFAFA;
     --color-surface-1:      #F3F4F6;
+    --color-surface-hover:  #FAFBFC;   /* row/card hover state */
     --color-border:         rgba(15, 22, 29, 0.10);
     --color-border-strong:  rgba(15, 22, 29, 0.18);
 
@@ -135,18 +136,6 @@
     --fasting-water-cell-end: color-mix(in oklab, var(--color-info) 20%, var(--color-surface-2));
     --fasting-water-border:   color-mix(in oklab, var(--color-info) 45%, var(--color-surface-2));
 
-    /* ---------- Spacing ---------- */
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 16px;
-    --space-5: 24px;
-    --space-6: 32px;
-
-    /* ---------- Radius ---------- */
-    --radius-1: 3px;
-    --radius-2: 6px;
-    --radius-3: 10px;
 
     /* ---------- Shadows ---------- */
     --shadow-sm:    0 1px 2px rgba(15, 22, 29, 0.05);
@@ -169,10 +158,5 @@
     --sidebar-scrollbar-thumb: rgba(255, 255, 255, 0.22);
     --sidebar-scrollbar-thumb-hover: rgba(255, 255, 255, 0.38);
 
-    /* ---------- Typography ---------- */
-    --font-display: 'Miroslavljeva Cirilica', 'PT Serif', Georgia, serif;
-    --font-serif:   'PT Serif', 'Source Serif Pro', Georgia, serif;
-    --font-sans:    'Source Sans Pro', system-ui, -apple-system, 'Segoe UI', sans-serif;
-    --font-mono:    'JetBrains Mono', 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-    --font-body:    var(--font-sans);
+
 }

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -157,6 +157,11 @@
     --color-black-alpha-90: rgba(0, 0, 0, 0.95);
     --color-white-alpha-20: rgba(237, 230, 214, 0.14);
 
+    /* Olive — warm theme accent, used for domacin badge to avoid red clash */
+    --color-olive:         #8DA055;
+    --color-olive-bg:      #2F3A1F;
+    --color-olive-border:  #4F5B1E;
+
     /* Legacy dark-* aliases */
     --color-dark-bg:            var(--color-ink-800);
     --color-dark-bg-deep:       var(--color-ink-900);
@@ -241,4 +246,14 @@
 [data-theme="dark"] .page-size-link--active {
     background: var(--color-primary) !important;
     color: #fff !important;
+}
+
+
+/* On tamna the домаћин badge inherits --color-primary (deep red), which
+   clashes against the dark ink palette. Override with olive (cooler on dark) —
+   matches the sepia treatment for visual parity. */
+[data-theme="dark"] .stavka__meta-badge--domacin {
+    color: var(--color-olive);
+    background: var(--color-olive-bg);
+    border-color: var(--color-olive-border);
 }


### PR DESCRIPTION
…hemes/svetla.css → base/globals.css under a fresh :root rule. Sepia + tamna previously inherited these via the :root cascade, but a future 4th theme that does not extend svetla would silently lose them. globals.css is the right home (theme-agnostic content)

- themes/sepia.css cleanup:
  * --color-secondary bumped from #6E0F0E (== primary-700) to #5C3F1E so the secondary token actually defines a distinct color
  * new --color-surface-hover (#FFF8E6) replaces the hardcoded hex on .actions__item:hover, .stavka:hover, .registry__card:hover (was 3 raw literal repeats)
  * new --color-olive / --color-olive-bg / --color-olive-border token family; .stavka__meta-badge--domacin override now reads from tokens (was 3 raw hex literals)
  * --color-slava-text / -bg / -border now alias --color-warning-text / -bg / -border (same values, collapse)
  * delete legacy --color-dark-* aliases (5 vars marked back-compat) — verified zero callers outside theme files
  * de-duplicate --fasting-{dairy,fish,oil,water}-bg tokens (were declared twice with different opacities; second block wins, kept that one)
  * --color-gray-* comment updated to note these are warm-neutral parchment tones, not desaturated grey (rename is too big a cross-codebase touch)
  * new sepia override for .select2-container--default .select2-selection--single (item #7): forme.css base gave select2 the wrong light surface-1 bg on sepia; matches the deepened text-input chrome now
- themes/tamna.css: matching --color-olive / -bg / -border tokens + .stavka__meta-badge--domacin override so the badge color also escapes the deep-red primary on dark theme
- themes/svetla.css: matching --color-surface-hover for parity across themes