### PR TITLE
- close the 11 remaining token-parity gaps so svetla/sepia/tamna defi…

### DIFF
--- a/crkva/registar/static/registar/themes/sepia.css
+++ b/crkva/registar/static/registar/themes/sepia.css
@@ -25,6 +25,8 @@
     --color-surface-2:      #FBF5E3;   /* cards lift via lighter cream */
     --color-surface-1:      #EBDFC1;   /* form controls / hover */
     --color-surface-hover:  #FFF8E6;   /* row/card hover state */
+    --color-surface-3:      #FFF8E6;   /* highest-elevation surface (parity) */
+    --color-placeholder:    #9C8E7D;   /* input placeholder text */
     --color-border:         rgba(176, 132, 67, 0.30);
     --color-border-strong:  rgba(176, 132, 67, 0.50);
 

--- a/crkva/registar/static/registar/themes/svetla.css
+++ b/crkva/registar/static/registar/themes/svetla.css
@@ -42,6 +42,14 @@
     --color-surface-2:      #FAFAFA;
     --color-surface-1:      #F3F4F6;
     --color-surface-hover:  #FAFBFC;   /* row/card hover state */
+    /* Olive (parity with sepia/tamna; light theme uses primary-red on domacin
+       badge by default, but olive tokens exist for components that want the
+       same accent across all themes) */
+    --color-olive:          #4F5B1E;
+    --color-olive-bg:       #EEF1D5;
+    --color-olive-border:   #B7CC68;
+    --color-surface-3:      #FFFFFF;   /* highest-elevation surface */
+    --color-placeholder:    #9CA3AF;   /* input placeholder text */
     --color-border:         rgba(15, 22, 29, 0.10);
     --color-border-strong:  rgba(15, 22, 29, 0.18);
 
@@ -88,14 +96,6 @@
     /* ---------- Links ---------- */
     --color-link:        var(--color-primary);
     --color-link-hover:  var(--color-primary-700);
-
-    /* ---------- Dark theme defaults (overridden in themes/tamna.css) ---------- */
-    --color-dark-bg:            var(--color-ink-800);
-    --color-dark-bg-deep:       var(--color-ink-900);
-    --color-dark-border:        #2D3140;
-    --color-dark-text:          #EDE6D6;
-    --color-dark-text-secondary:#9C8E7D;
-
     /* ---------- Amber (today highlight) ---------- */
     --color-amber-500: #B08443;
     --color-amber-400: #C19A57;

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -25,6 +25,7 @@
     --color-surface-2: #1F212B;
     --color-surface-1: #2A2D3A;
     --color-surface-3: #383C4D;
+    --color-surface-hover: #2A2F3B;  /* row/card hover state */
 
     /* ---------- Text (parchment cream) ---------- */
     --color-text:        #EDE6D6;
@@ -161,14 +162,6 @@
     --color-olive:         #8DA055;
     --color-olive-bg:      #2F3A1F;
     --color-olive-border:  #4F5B1E;
-
-    /* Legacy dark-* aliases */
-    --color-dark-bg:            var(--color-ink-800);
-    --color-dark-bg-deep:       var(--color-ink-900);
-    --color-dark-border:        var(--color-border-strong);
-    --color-dark-text:          var(--color-text);
-    --color-dark-text-secondary:var(--color-text-muted);
-
     /* Secondary */
     --color-secondary: #B0302E;
 


### PR DESCRIPTION
…ne the same 110-token surface

- new tokens added to svetla: --color-surface-3, --color-placeholder, --color-olive, --color-olive-bg, --color-olive-border
- new tokens added to sepia: --color-surface-3, --color-placeholder
- new tokens added to tamna: --color-surface-hover
- legacy --color-dark-* aliases removed from svetla AND tamna (already gone from sepia in the prior audit, zero callers outside theme files verified again)
- audit confirms 110 tokens in each theme, 0 discrepancies