### PR TITLE
- index.html: wrap the Регистри section in <div class="card card--ele…

### DIFF
--- a/crkva/registar/templates/registar/index.html
+++ b/crkva/registar/templates/registar/index.html
@@ -150,10 +150,11 @@
   </div>
 
   {# ---------- Registry counts (compact strip) ---------- #}
-  <div class="registry registry--compact">
+  <div class="card card--elevated">
     <div class="card__header">
       <h3><i class="fa-solid fa-box-archive"></i> Регистри</h3>
     </div>
+    <div class="registry registry--compact">
     <div class="registry__grid">
       <a href="{% url 'parohijani' %}" class="registry__card">
         <div class="registry__icon"><i class="fa-solid fa-users"></i></div>
@@ -183,6 +184,7 @@
           <div class="registry__title">Свештеници</div>
         </div>
       </a>
+    </div>
     </div>
   </div>
 


### PR DESCRIPTION
…vated"> so it picks up the same elevated-card chrome (background, padding, border, header divider) as the Брзе акције section directly above. Both sections now read as the same component on desktop. CSS untouched - this is a markup-only change