### PR TITLE
- select2_skin.css: pencil baseline opacity 0.5 -> 0 so the icon only…

### DIFF
--- a/crkva/registar/static/registar/components/adresa_edit.js
+++ b/crkva/registar/static/registar/components/adresa_edit.js
@@ -174,6 +174,10 @@
                     modal.dataset.adresaUid = uid;
                     if (sel && sel.length) modal.dataset.targetFieldId = sel.attr("id");
                 }
+                // Open the modal BEFORE filling: Modal.open() clears every
+                // input[type=text] in the overlay, so filling first then opening
+                // wipes the pre-fill we just put in place.
+                if (window.Modal) Modal.open("adresa-modal");
                 var map = {
                     ulica: "modal-adresa-ulica",
                     broj: "modal-adresa-broj",
@@ -185,8 +189,7 @@
                     if (el) el.value = (data && data[k]) || "";
                 });
                 var err = document.querySelector("#adresa-modal .error-text");
-                if (err) { err.style.display = "none"; err.textContent = ""; }
-                if (window.Modal) Modal.open("adresa-modal");
+                if (err) { err.style.display = "none"; err.textContent = ""; err.setAttribute("hidden", ""); }
             });
     }
 

--- a/crkva/registar/static/registar/components/select2_skin.css
+++ b/crkva/registar/static/registar/components/select2_skin.css
@@ -203,7 +203,7 @@
     background: var(--color-surface);
     color: var(--color-text-muted);
     cursor: pointer;
-    opacity: 0.5;
+    opacity: 0;
     transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
     font-size: 13px;
     z-index: 2;


### PR DESCRIPTION
… appears on the row that is currently hovered or keyboard-highlighted. The faded-but-always-visible style was distracting on long dropdowns - adresa_edit.js openEditModal: call Modal.open("adresa-modal") BEFORE filling the modal fields. Modal.open() clears every input[type=text] in the overlay as part of its reset, so the previous order (fill -> open) was wiping the pre-fill we had just put in place and the user saw an empty modal. Also re-add err.setAttribute("hidden", "") in the clear path to keep the error-text discipline consistent with the rest of the modal API