### PR TITLE
- new _page_header.html: wraps the back-arrow + h1 (with optional · c…

### DIFF
--- a/crkva/registar/templates/registar/_page_header.html
+++ b/crkva/registar/templates/registar/_page_header.html
@@ -1,0 +1,20 @@
+{% comment %}
+Reusable page header: back arrow on the left, h1 title (with optional
+"· count") on the right. Used by all spisak_*.html templates and by
+several detail pages (duplikati_adresa, kalendar, profile, search_view,
+slava_domacinstva, unos_korisnika).
+
+Required:
+  title           h1 text (string)
+Optional:
+  back_url        URL string for the back arrow. Defaults to '/' (pocetna)
+  count           integer; if passed (incl 0), renders as "· N" after title
+  include_toolbar truthy to render {% templatetag openblock %} include "registar/_list_toolbar.html" {% templatetag closeblock %}
+{% endcomment %}
+<div class="u-page-header">
+    <a href="{{ back_url|default:'/' }}" class="back-button" aria-label="Назад" title="Назад">
+        <i class="fa-solid fa-arrow-left"></i>
+    </a>
+    <h1 class="u-page-title">{{ title }}{% if count or count == 0 %} <span class="u-page-title__count">· {{ count }}</span>{% endif %}</h1>
+    {% if include_toolbar %}{% include "registar/_list_toolbar.html" %}{% endif %}
+</div>

--- a/crkva/registar/templates/registar/_spisak.html
+++ b/crkva/registar/templates/registar/_spisak.html
@@ -1,0 +1,22 @@
+{% comment %}
+Full body for a paginated infinite-scroll list page. Used by all
+spisak_*.html entry-point templates - they each just {% templatetag openblock %} include {% templatetag closeblock %} this
+partial with the right title and stavka template name.
+
+Usage from a spisak template:
+  {% templatetag openblock %} extends "base.html" {% templatetag closeblock %}
+  {% templatetag openblock %} load marker_filter phone_filters {% templatetag closeblock %}  (whatever the stavka needs)
+  {% templatetag openblock %} block content {% templatetag closeblock %}
+    {% templatetag openblock %} include "registar/_spisak.html" with title="..." stavka_template="registar/_stavka_X.html" {% templatetag closeblock %}
+  {% templatetag openblock %} endblock {% templatetag closeblock %}
+
+Required:
+  title           h1 text
+  stavka_template path to the per-row partial (e.g. "registar/_stavka_parohijana.html")
+{% endcomment %}
+{% include "registar/_page_header.html" with title=title count=page_obj.paginator.count include_toolbar=True %}
+{% include "registar/_filter_chips.html" %}
+<ul class="spisak" id="spisak-list">
+    {% include stavka_template %}
+</ul>
+<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>

--- a/crkva/registar/templates/registar/duplikati_adresa.html
+++ b/crkva/registar/templates/registar/duplikati_adresa.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
-    <h1 class="u-page-title">Дупликати адреса <span class="u-page-title__count">· {{ total_groups }}</span></h1>
-</div>
+{% include "registar/_page_header.html" with title="Дупликати адреса" count=total_groups %}
 
 {% if messages %}
   {% for m in messages %}

--- a/crkva/registar/templates/registar/kalendar.html
+++ b/crkva/registar/templates/registar/kalendar.html
@@ -7,12 +7,7 @@
 {% block title %}Календар{% endblock %}
 
 {% block content %}
-<div class="u-page-header">
-  <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-    <i class="fa-solid fa-arrow-left"></i>
-  </a>
-<h1 class="u-page-title">Календар</h1>
-</div>
+{% include "registar/_page_header.html" with title="Календар" %}
 
 <!-- Single, centered navigation -->
 <div class="calendar-navigation">

--- a/crkva/registar/templates/registar/profile.html
+++ b/crkva/registar/templates/registar/profile.html
@@ -5,12 +5,7 @@
 {% block content %}
 <div class="info-page">
 
-  <div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-      <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Профил</h1>
-  </div>
+  {% include "registar/_page_header.html" with title="Профил" %}
 
   {% if messages %}
     <div class="form-messages u-message-strip">

--- a/crkva/registar/templates/registar/spisak_domacinstva.html
+++ b/crkva/registar/templates/registar/spisak_domacinstva.html
@@ -1,19 +1,5 @@
 {% extends "base.html" %}
-{% load marker_filter %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Домаћинства <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
-    {% include "registar/_list_toolbar.html" %}
-</div>
-
-{% include "registar/_filter_chips.html" %}
-<ul class="spisak" id="spisak-list">
-    {% include "registar/_stavka_domacinstva.html" %}
-</ul>
-<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
-
+{% include "registar/_spisak.html" with title="Домаћинства" stavka_template="registar/_stavka_domacinstva.html" %}
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_krstenja.html
+++ b/crkva/registar/templates/registar/spisak_krstenja.html
@@ -1,18 +1,5 @@
 {% extends "base.html" %}
-{% load marker_filter %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Крштења <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
-    {% include "registar/_list_toolbar.html" %}
-</div>
-
-{% include "registar/_filter_chips.html" %}
-<ul class="spisak" id="spisak-list">
-    {% include "registar/_stavka_krstenja.html" %}
-</ul>
-<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
+{% include "registar/_spisak.html" with title="Крштења" stavka_template="registar/_stavka_krstenja.html" %}
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_parohijana.html
+++ b/crkva/registar/templates/registar/spisak_parohijana.html
@@ -1,18 +1,5 @@
 {% extends "base.html" %}
-{% load marker_filter phone_filters %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Парохијани <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
-    {% include "registar/_list_toolbar.html" %}
-</div>
-
-{% include "registar/_filter_chips.html" %}
-<ul class="spisak" id="spisak-list">
-    {% include "registar/_stavka_parohijana.html" %}
-</ul>
-<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
+{% include "registar/_spisak.html" with title="Парохијани" stavka_template="registar/_stavka_parohijana.html" %}
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_svestenika.html
+++ b/crkva/registar/templates/registar/spisak_svestenika.html
@@ -1,18 +1,5 @@
 {% extends "base.html" %}
-{% load marker_filter %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Свештеници <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
-    {% include "registar/_list_toolbar.html" %}
-</div>
-
-{% include "registar/_filter_chips.html" %}
-<ul class="spisak" id="spisak-list">
-    {% include "registar/_stavka_svestenika.html" %}
-</ul>
-<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
+{% include "registar/_spisak.html" with title="Свештеници" stavka_template="registar/_stavka_svestenika.html" %}
 {% endblock %}

--- a/crkva/registar/templates/registar/spisak_vencanja.html
+++ b/crkva/registar/templates/registar/spisak_vencanja.html
@@ -1,18 +1,5 @@
 {% extends "base.html" %}
-{% load marker_filter %}
 
 {% block content %}
-<div class="u-page-header">
-    <a href="{% url 'pocetna' %}" class="back-button" aria-label="Назад" title="Назад">
-        <i class="fa-solid fa-arrow-left"></i>
-    </a>
-    <h1 class="u-page-title">Венчања <span class="u-page-title__count">· {{ page_obj.paginator.count }}</span></h1>
-    {% include "registar/_list_toolbar.html" %}
-</div>
-
-{% include "registar/_filter_chips.html" %}
-<ul class="spisak" id="spisak-list">
-    {% include "registar/_stavka_vencanja.html" %}
-</ul>
-<div id="scroll-sentinel" class="scroll-sentinel" aria-hidden="true"><span class="scroll-sentinel__spinner"><i class="fa-solid fa-spinner fa-spin"></i></span></div>
+{% include "registar/_spisak.html" with title="Венчања" stavka_template="registar/_stavka_vencanja.html" %}
 {% endblock %}


### PR DESCRIPTION
…ount) + optional list-toolbar block that was inlined across 8 templates. Accepts title (required), back_url (defaults to /), count (renders if passed, including 0), and include_toolbar

- new _spisak.html: full body of a paginated infinite-scroll list page - includes _page_header.html, _filter_chips.html, the spisak <ul>, and the scroll sentinel. Accepts title and stavka_template
- spisak_{parohijana,krstenja,vencanja,svestenika,domacinstva}.html: collapse from 18 lines of duplicated chrome to 5 lines that just {% include _spisak.html with title=X stavka_template=Y %}. The marker_filter / phone_filters {% load %} lines are no longer needed at the spisak level - each _stavka_* partial already loads what it consumes
- duplikati_adresa.html + kalendar.html + profile.html: migrate their page-header markup to the shared _page_header.html partial
- slava_domacinstva.html, search_view.html, unos_korisnika.html intentionally left as-is - they carry custom header chrome (custom back-button label, save-button in header, parens-formatted count) that does not fit the partial signature cleanly
- Net change: +50 lines for the two new partials, -104 lines across the 8 migrated templates = -54 lines and one place to change the page-header chrome going forward