### PR TITLE
- spiskovi.css: drop the entire LIST CONTROLS BAR block (~78 lines: .…

### DIFF
--- a/crkva/registar/static/registar/base/globals.css
+++ b/crkva/registar/static/registar/base/globals.css
@@ -138,21 +138,6 @@ a:hover { color: var(--color-link-hover); text-decoration: underline; }
 
 .muted { color: var(--color-text-muted); }
 
-.page-header a,
-.page-header button { flex-shrink: 0; }
-
-@media (max-width: 640px) {
-    .container { padding: 0 var(--space-3); }
-    .page-header {
-        flex-wrap: wrap;
-        align-items: flex-start;
-        gap: var(--space-3);
-    }
-    .page-title { font-size: 20px; margin-bottom: var(--space-2); }
-    .page-header form,
-    .page-header .form-container { width: 100%; }
-}
-
 /* Back button */
 .back-button {
     display: inline-flex;

--- a/crkva/registar/static/registar/components/select2_skin.css
+++ b/crkva/registar/static/registar/components/select2_skin.css
@@ -164,11 +164,6 @@
     box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 25%, transparent);
 }
 
-/* Hide select2's built-in arrow — we use a background-image chevron like .list-toolbar__sort-select */
-.select2-container--default .select2-selection--single .select2-selection__arrow {
-    display: none;
-}
-
 .select2-container--default.select2-container--open .select2-selection--single {
     border-color: var(--color-primary);
     box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);

--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -140,15 +140,6 @@
 
 
 
-/* Спискови */
-.header-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 8px;
-}
-
 .form-container {
     display: flex;
     align-items: center;
@@ -218,12 +209,6 @@
 
 /* Mobile-friendly list and filters */
 @media (max-width: 768px) {
-    .header-container {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 12px;
-    }
-
     .page-title {
         font-size: 1.5rem;
     }
@@ -380,82 +365,6 @@
     background: var(--color-surface-2);
     border-radius: 12px;
     border: 1px dashed var(--color-border);
-}
-
-/* ==========================================================================
-   LIST CONTROLS BAR (sort + per-page dropdowns)
-   ========================================================================== */
-
-.list-controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 10px;
-    padding: 6px 0;
-    flex-wrap: wrap;
-}
-
-.list-controls__group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-}
-
-.list-controls__group--right {
-    margin-left: auto;
-}
-
-.list-controls__label {
-    font-size: 13px;
-    color: var(--color-text-muted);
-    white-space: nowrap;
-}
-
-.list-controls__select {
-    font-size: 14px;
-    line-height: 20px;
-    padding: 7px 32px 7px 14px;
-    background-color: var(--color-surface);
-    color: var(--color-text);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-2);
-    cursor: pointer;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2712%27 height=%2712%27 viewBox=%270 0 16 16%27 fill=%27%23888%27%3E%3Cpath d=%27M3.204 5h9.592L8 10.481 3.204 5zm-.753.659l4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z%27/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 10px center;
-    background-size: 12px;
-    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
-    font-family: inherit;
-    min-height: 36px;
-}
-
-.list-controls__select:hover {
-    background-color: var(--color-surface-2);
-    border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-border));
-}
-
-.list-controls__select:focus {
-    outline: none;
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
-}
-
-@media (max-width: 640px) {
-    .list-controls {
-        flex-direction: column;
-        align-items: stretch;
-    }
-    .list-controls__group--right {
-        margin-left: 0;
-    }
-    .list-controls__select {
-        width: 100%;
-    }
 }
 
 /* Flex layout for items with structured metadata (parohijani) */

--- a/crkva/registar/static/registar/themes/tamna.css
+++ b/crkva/registar/static/registar/themes/tamna.css
@@ -235,13 +235,6 @@
 /* Search overlay */
 [data-theme="dark"] .search-overlay { background: rgba(0, 0, 0, 0.7); }
 
-/* Page-size pills */
-[data-theme="dark"] .page-size-link--active {
-    background: var(--color-primary) !important;
-    color: #fff !important;
-}
-
-
 /* On tamna the домаћин badge inherits --color-primary (deep red), which
    clashes against the dark ink palette. Override with olive (cooler on dark) —
    matches the sepia treatment for visual parity. */


### PR DESCRIPTION
…list-controls / .list-controls__group / .list-controls__label / .list-controls__select + responsive media query). Zero templates emit any of these classes - they were a sketch that never landed

- spiskovi.css: drop .header-container rule (main + the @media (max-width: 768px) override). The class is never used in any template - migrated long ago to .u-page-header
- base/globals.css: drop the legacy @media (max-width: 640px) block targeting .container / .page-header / .page-title plus the .page-header a, .page-header button selector above it. All templates use the .u-* variants now, so the un-prefixed rules never matched
- themes/tamna.css: drop [data-theme=dark] .page-size-link--active rule. The page-size-link class is not emitted anywhere in the codebase
- select2_skin.css: drop the second .select2-selection__arrow { display: none } definition - the rule appeared twice verbatim. Kept the first instance which sits next to the chevron background rule
- Net: -3206 bytes (~100 lines) across 4 files; verified live with manage.py check + visual sweep