### PR TITLE
- login.html: add registar/themes/svetla.css to the {% compress css %…

### DIFF
--- a/crkva/registar/static/registar/components/akcije.css
+++ b/crkva/registar/static/registar/components/akcije.css
@@ -66,6 +66,17 @@
     line-height: 1.3;
 }
 
+.actions__count {
+    font-family: var(--font-mono);
+    font-size: 1.5rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+    color: var(--color-primary);
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
 @media (max-width: 1024px) {
     .actions,
     .action-grid { grid-template-columns: repeat(2, 1fr); }

--- a/crkva/registar/static/registar/components/kartice.css
+++ b/crkva/registar/static/registar/components/kartice.css
@@ -9,8 +9,7 @@
    lift for "act now" moments (quick actions, today's feast).
    ========================================================================== */
 .card,
-.quick-actions-card,
-.registry-overview {
+.quick-actions-card {
     background: var(--color-surface-2);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-3);
@@ -87,76 +86,6 @@
 
 .card__link:hover,
 .view-all-link:hover { color: var(--color-primary-700); text-decoration: none; }
-
-/* Registry Overview */
-.registry,
-.registry-overview { grid-column: 1 / -1; }
-
-.registry__grid,
-.registry-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: var(--space-3);
-}
-.registry__count,
-.registry-count {
-    font-family: var(--font-mono);
-    font-weight: 500;
-    font-variant-numeric: tabular-nums;
-    color: var(--color-text);
-    font-size: 1.5rem;
-    letter-spacing: -0.02em;
-}
-
-.registry__card,
-.registry-card {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    padding: 20px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
-    text-decoration: none;
-    color: var(--color-text);
-    transition: all 0.2s;
-}
-
-.registry__card:hover,
-.registry-card:hover {
-    background: var(--color-surface);
-    border-color: var(--color-accent);
-    box-shadow: inset 3px 0 0 var(--color-accent), var(--shadow-sm);
-    text-decoration: none;
-}
-
-.registry__icon,
-.registry-icon {
-    width: 48px;
-    height: 48px;
-    background: var(--color-accent-50);
-    color: var(--color-accent-700);
-    border-radius: var(--radius-2);
-    border: 1px solid var(--color-accent-200);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.5rem;
-}
-
-.registry__info,
-.registry-info { flex: 1; }
-
-.registry__title,
-.registry-title { font-weight: 600; margin-bottom: 4px; }
-
-.registry__desc,
-.registry-desc { font-size: 0.875rem; color: var(--color-muted); }
-
-@media (max-width: 768px) {
-    .registry__grid,
-    .registry-grid { grid-template-columns: 1fr; }
-}
 
 /* Main Grid Layout — fills main edge-to-edge (no max-width cap).
    On wide monitors content used to sit in a centered 1440 box,
@@ -237,66 +166,13 @@
     border-radius: 4px;
 }
 
-.registry__count {
-    font-size: 24px;
-    font-weight: 700;
-    color: var(--color-primary);
-    margin-left: auto;
-    flex-shrink: 0;
-}
-
-/* Registry as compact info-strip (used on home page below actions) */
-.registry--compact .registry__grid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--space-2);
-}
-.registry--compact .registry__card {
-    padding: var(--space-3);
-    gap: var(--space-3);
-}
-.registry--compact .registry__icon {
-    width: 36px;
-    height: 36px;
-    font-size: 1.05rem;
-    border-radius: var(--radius-1);
-}
-.registry--compact .registry__count {
-    font-size: 1.25rem;
-}
-.registry--compact .registry__desc {
-    display: none;
-}
-@media (max-width: 768px) {
-    .registry--compact .registry__grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-@media (max-width: 480px) {
-    .registry--compact .registry__grid {
-        grid-template-columns: 1fr;
-    }
-}
-
 
 /* Move 6 — tablet tuning for action and registry cards */
 @media (max-width: 1024px) {
     .actions__title, .action-title { font-size: 0.9rem; }
     .actions__desc,  .action-desc  { font-size: 0.78rem; }
-    .registry__card { padding: var(--space-3); gap: var(--space-3); }
-    .registry__icon { width: 40px; height: 40px; font-size: 1.15rem; }
 }
 @media (max-width: 640px) {
     .card, .card--elevated, .card--hero { padding: var(--space-3); }
     .card__header { margin-bottom: var(--space-3); padding-bottom: var(--space-2); }
-    /* On phones the Регистри cards mirror Брзе акције (horizontal icon+text,
-       compact chrome) so the two sections read as the same component. */
-    .registry__card {
-        padding: var(--space-3) var(--space-4);
-        gap: var(--space-3);
-        background: var(--color-surface-2);
-        border-radius: var(--radius-2);
-    }
-    .registry__icon { width: 36px; height: 36px; font-size: 1.1rem; }
-    .registry__title { font-size: 0.95rem; }
-    .registry__desc  { font-size: 0.8rem; }
 }

--- a/crkva/registar/static/registar/themes/sepia.css
+++ b/crkva/registar/static/registar/themes/sepia.css
@@ -174,8 +174,6 @@
 /* The "click" of the redesign: body sits on parchment, cards float as lighter
    cream sheets with a hairline of aged gold. */
 [data-theme="sepia"] .card,
-[data-theme="sepia"] .registry,
-[data-theme="sepia"] .registry-overview,
 [data-theme="sepia"] .quick-actions-card {
     background: var(--color-surface-2);
     border-color: var(--color-border);
@@ -194,16 +192,12 @@
 
 /* Action items + registry cards: lift above parchment body */
 [data-theme="sepia"] .actions__item,
-[data-theme="sepia"] .action-item,
-[data-theme="sepia"] .registry__card,
-[data-theme="sepia"] .registry-card {
+[data-theme="sepia"] .action-item {
     background: var(--color-surface-2);
     border-color: var(--color-border);
 }
 [data-theme="sepia"] .actions__item:hover,
-[data-theme="sepia"] .action-item:hover,
-[data-theme="sepia"] .registry__card:hover,
-[data-theme="sepia"] .registry-card:hover {
+[data-theme="sepia"] .action-item:hover {
     background: var(--color-surface-hover);
     border-color: var(--color-accent);
 }

--- a/crkva/registar/templates/registar/index.html
+++ b/crkva/registar/templates/registar/index.html
@@ -154,37 +154,35 @@
     <div class="card__header">
       <h3><i class="fa-solid fa-box-archive"></i> Регистри</h3>
     </div>
-    <div class="registry registry--compact">
-    <div class="registry__grid">
-      <a href="{% url 'parohijani' %}" class="registry__card">
-        <div class="registry__icon"><i class="fa-solid fa-users"></i></div>
-        <div class="registry__count">{{ stats.parohijani }}</div>
-        <div class="registry__info">
-          <div class="registry__title">Парохијани</div>
+    <div class="actions">
+      <a href="{% url 'parohijani' %}" class="actions__item">
+        <div class="actions__icon"><i class="fa-solid fa-users"></i></div>
+        <div class="actions__text">
+          <div class="actions__title">Парохијани</div>
         </div>
+        <div class="actions__count">{{ stats.parohijani }}</div>
       </a>
-      <a href="{% url 'krstenja' %}" class="registry__card">
-        <div class="registry__icon"><i class="fa-solid fa-droplet"></i></div>
-        <div class="registry__count">{{ stats.krstenja }}</div>
-        <div class="registry__info">
-          <div class="registry__title">Крштења</div>
+      <a href="{% url 'krstenja' %}" class="actions__item">
+        <div class="actions__icon"><i class="fa-solid fa-droplet"></i></div>
+        <div class="actions__text">
+          <div class="actions__title">Крштења</div>
         </div>
+        <div class="actions__count">{{ stats.krstenja }}</div>
       </a>
-      <a href="{% url 'vencanja' %}" class="registry__card">
-        <div class="registry__icon"><i class="icon-rings"></i></div>
-        <div class="registry__count">{{ stats.vencanja }}</div>
-        <div class="registry__info">
-          <div class="registry__title">Венчања</div>
+      <a href="{% url 'vencanja' %}" class="actions__item">
+        <div class="actions__icon"><i class="icon-rings"></i></div>
+        <div class="actions__text">
+          <div class="actions__title">Венчања</div>
         </div>
+        <div class="actions__count">{{ stats.vencanja }}</div>
       </a>
-      <a href="{% url 'svestenici' %}" class="registry__card">
-        <div class="registry__icon"><i class="fa-solid fa-id-badge"></i></div>
-        <div class="registry__count">{{ stats.svestenici }}</div>
-        <div class="registry__info">
-          <div class="registry__title">Свештеници</div>
+      <a href="{% url 'svestenici' %}" class="actions__item">
+        <div class="actions__icon"><i class="fa-solid fa-id-badge"></i></div>
+        <div class="actions__text">
+          <div class="actions__title">Свештеници</div>
         </div>
+        <div class="actions__count">{{ stats.svestenici }}</div>
       </a>
-    </div>
     </div>
   </div>
 

--- a/crkva/registar/templates/registar/login.html
+++ b/crkva/registar/templates/registar/login.html
@@ -25,6 +25,7 @@
       <link rel="stylesheet" href="{% static 'registar/base/fonts.css' %}">
       <link rel="stylesheet" href="{% static 'registar/base/globals.css' %}">
       <link rel="stylesheet" href="{% static 'registar/pages/prijava.css' %}">
+      <link rel="stylesheet" href="{% static 'registar/themes/svetla.css' %}">
       <link rel="stylesheet" href="{% static 'registar/themes/sepia.css' %}">
       <link rel="stylesheet" href="{% static 'registar/themes/tamna.css' %}">
     {% endcompress %}


### PR DESCRIPTION
…} block. Without it the default light-theme tokens (--color-primary, --color-surface, --color-text, ...) were undefined and the login page rendered with broken/missing styles. svetla.css is the default theme that defines the base :root color palette - it has to be loaded alongside sepia + tamna

- index.html: switch the Регистри card from .registry__card markup to .actions__item so the section visually matches the Брзе акције block directly above (same icon-left + text + count layout). Adds a new .actions__count slot for the prominent numeric value
- akcije.css: add .actions__count rule (mono font, 1.5rem, primary color, mono digits) - styling identical to the old .registry__count so the big count number is preserved
- kartice.css: drop ~3.2 KB of .registry / .registry-overview / .registry__* / .registry-* CSS that no template emits any more. The class disappeared from every template after the .actions__item migration. Includes the .registry--compact variant and its responsive overrides, the .registry-overview .card alias, and the two responsive @media blocks tweaking .registry__card / .registry__icon / .registry__title / .registry__desc
- themes/sepia.css: drop the four [data-theme=sepia] .registry__card / .registry-card / .registry / .registry-overview overrides for the same reason