### PR TITLE
header + calendar polish bundle

### DIFF
--- a/crkva/registar/static/registar/base/globals.css
+++ b/crkva/registar/static/registar/base/globals.css
@@ -149,22 +149,22 @@ a:hover { color: var(--color-link-hover); text-decoration: underline; }
     min-height: 36px;
     border-radius: var(--radius-2);
     border: 1px solid var(--color-border);
-    background-color: var(--color-surface-2);
+    background-color: var(--color-surface);
     color: var(--color-text);
     text-decoration: none;
     cursor: pointer;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
 }
 .back-button:hover {
-    background-color: var(--color-surface);
+    background-color: var(--color-surface-2);
     color: var(--color-primary);
     border-color: var(--color-accent);
     box-shadow: var(--shadow-sm);
 }
-.back-button i { font-size: 18px; }
+.back-button i { font-size: 14px; line-height: 1; }
 
 @media (max-width: 768px) {
-    .back-button { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+    .back-button { width: 40px; height: 40px; min-width: 40px; min-height: 40px; }
     body { font-size: 16px; line-height: 1.5; }
     h1 { font-size: 1.75rem; }
     h2 { font-size: 1.5rem; }
@@ -188,9 +188,44 @@ a:hover { color: var(--color-link-hover); text-decoration: underline; }
     gap: var(--space-3);
     padding: 0 var(--space-5);
     margin-top: var(--space-3);
+    /* Clearance for the absolutely-positioned buttons that straddle the
+       header bottom edge via translateY(50%): .back-button (left side),
+       .view-actions on detail pages (right side), .u-page-header__right
+       (kalendar). 28px is slightly more than half the mobile button (44/2)
+       so a visible gap remains before the first content row. Applies to
+       EVERY header - list/detail/kalendar - not just pages that use the
+       _page_header.html partial. */
+    margin-bottom: 28px;
+    position: relative;
     width: 100%;
     box-sizing: border-box;
 }
+/* Anchor the optional right-side icon button (e.g. crkvenikalendar.rs link
+   in the kalendar page header) to the far-right edge of the header, mirror
+   of the .back-button on the left. Inherits the .back-button visual chrome
+   AND its translateY(50%) bottom-straddle positioning from pomocno.css,
+   but overrides left:0 -> right:0 so it lands on the opposite edge. */
+.u-page-header > .back-button.u-page-header__right {
+    left: auto;
+    right: 0;
+}
+
+/* The spacer DIV is now redundant - the clearance moved onto
+   .u-page-header { margin-bottom: 28px } so every page (list, detail,
+   kalendar) gets the same gap regardless of whether the _page_header.html
+   partial was used. Left as a 0-height pass-through so removing it from
+   the partial is a separate cleanup. */
+.u-page-header__spacer {
+    height: 0;
+    pointer-events: none;
+}
+
+/* The slava-domacinstva page packs 4 items into the header (back, title with
+   subtitle, meta date pill, print button) - allow them to wrap on narrow
+   viewports and let the title push the meta+button to the right edge. Scoped
+   so the default page header keeps a clean single-row no-wrap layout. */
+.u-page-header--wrap { flex-wrap: wrap; gap: var(--space-2); }
+.u-page-header--wrap .u-page-title { margin-right: auto; }
 @media (max-width: 768px) {
     .u-page-header { padding: 0 var(--space-3); }
 }

--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -894,15 +894,7 @@ body.history-open {
 }
 
 
-/* Slava-page header needs the title + meta + button on one row */
-.u-page-header { flex-wrap: wrap; gap: var(--space-2); }
-.u-page-header .u-page-title { margin-right: auto; }
 
-
-
-/* Slava-page header needs the title + meta + button on one row */
-.u-page-header { flex-wrap: wrap; gap: var(--space-2); }
-.u-page-header .u-page-title { margin-right: auto; }
 
 /* ===== Slava page — household roster (unified sans style) ===== */
 .slava-meta {
@@ -991,9 +983,6 @@ body.history-open {
   .stavka__roster { grid-template-columns: 1fr; gap: var(--space-3); }
 }
 
-/* Slava-page header: title + meta + button on one row */
-.u-page-header { flex-wrap: wrap; gap: var(--space-2); }
-.u-page-header .u-page-title { margin-right: auto; }
 
 
 /* Move 8 — preminuli marker (the small cross beside deceased members) */

--- a/crkva/registar/static/registar/pages/kalendar.css
+++ b/crkva/registar/static/registar/pages/kalendar.css
@@ -318,38 +318,37 @@
 }
 
 @media (max-width: 768px) {
-  /* keep grid-template-columns from base (7 cols) — only relax cell sizing */
+  /* On mobile + tablet portrait we ditch the 7-col grid and stack each
+     day full-width (rule further down). Type sizes scale UP since each
+     row has the whole viewport to itself. */
   .calendar-cell {
     height: auto;
-    min-height: 110px;
-    padding: 10px;
-    font-size: 0.9rem;
+    min-height: 90px;
+    padding: var(--space-3) var(--space-4);
   }
   .calendar-cell .date {
-    font-size: 1.125rem;
+    font-family: var(--font-mono);
+    font-size: 1.5rem;
     font-weight: 700;
   }
   .calendar-cell .weekday {
-    font-size: 0.75rem;
+    font-size: 0.95rem;
+    margin-top: 2px;
   }
   .calendar-cell .slavas {
-    font-size: 0.85rem;
-    line-height: 1.3;
-    margin-top: 8px;
+    font-size: 1.0625rem;
+    line-height: 1.45;
+    margin-top: var(--space-2);
   }
+  .calendar-cell .no-slavas-text { font-size: 0.95rem; }
+  .slava-link__count { font-size: 12px; padding: 1px 6px; }
   .calendar-navigation {
     padding: 12px;
     margin: 15px 0;
   }
-  .current-month {
-    min-width: 150px;
-  }
-  .month-name {
-    font-size: 1.125rem;
-  }
-  .year-label {
-    font-size: 0.875rem;
-  }
+  .current-month { min-width: 150px; }
+  .month-name { font-size: 1.125rem; }
+  .year-label { font-size: 0.875rem; }
   .nav-arrow {
     width: 40px;
     height: 40px;
@@ -358,47 +357,13 @@
   }
 }
 
-@media (max-width: 600px) {
-  /* grid switches to single-column stack via the dedicated rule further down */
-  .calendar-cell {
-    min-height: 90px;
-    padding: var(--space-2);
-  }
-  .calendar-cell .date { font-size: 1rem; }
-  .calendar-cell .weekday { font-size: 0.7rem; }
-  .calendar-cell .slavas { font-size: 0.78rem; line-height: 1.25; margin-top: 6px; }
-  .slava-link__count { font-size: 10px; padding: 0 4px; }
-}
-
-/* Small mobile — covered by the single-column stack rule below */
+/* Small mobile - calendar-cell font sizes inherit from the 768px
+   single-column rule above (which makes them BIGGER); the 480px block
+   used to override them smaller, which defeated the purpose. Only
+   layout / nav-arrow tweaks remain here. */
 @media (max-width: 480px) {
   .calendar-grid {
     gap: var(--space-1);
-  }
-  .calendar-cell {
-    height: auto;
-    min-height: 90px;
-    padding: 14px;
-  }
-  .calendar-cell.placeholder { display: none; }
-  .calendar-cell .cell-header {
-    margin-bottom: 10px;
-  }
-  .calendar-cell .date {
-    font-size: 1.375rem;
-    font-weight: 700;
-  }
-  .calendar-cell .weekday {
-    font-size: 0.875rem;
-    margin-top: 2px;
-  }
-  .calendar-cell .slavas {
-    font-size: 1rem;
-    line-height: 1.5;
-    margin-top: 8px;
-  }
-  .calendar-cell .no-slavas-text {
-    font-size: 0.875rem;
   }
   .calendar-navigation {
     padding: 14px 10px;
@@ -850,8 +815,11 @@
     .dashboard-upcoming__feast { font-size: 0.88rem; }
 }
 
-/* Narrow viewport: drop the 7-col grid and stack days as a list */
-@media (max-width: 600px) {
+/* Narrow viewport (mobile + tablet portrait): drop the 7-col grid and
+   stack days as a single-column list. The 7-col view kept too little room
+   per cell, so type was tiny - the vertical stack gives each day the full
+   row width with comfortable type sizes (rule above for fonts). */
+@media (max-width: 768px) {
   .calendar-grid {
     grid-template-columns: 1fr;
     gap: var(--space-1);

--- a/crkva/registar/static/registar/utilities/pomocno.css
+++ b/crkva/registar/static/registar/utilities/pomocno.css
@@ -184,6 +184,22 @@
     }
 }
 
+/* On mobile the fixed hamburger button covers the left edge of the header.
+   Move the absolute back-button to the RIGHT edge instead so it sits next
+   to the other right-side buttons (u-page-header__right, view-actions).
+   When a .u-page-header__right exists too, push the PLAIN back-button
+   (not the right one - the :not() excludes it) further left so both fit
+   side by side on the bottom edge (mobile back-button is 40px). */
+@media (max-width: 768px) {
+    .u-page-header > .back-button:not(.u-page-header__right) {
+        left: auto;
+        right: 0;
+    }
+    .u-page-header:has(.u-page-header__right) > .back-button:not(.u-page-header__right) {
+        right: calc(40px + var(--space-2));
+    }
+}
+
 
 /* Move 8 — inline-style cleanup utilities */
 
@@ -280,12 +296,8 @@
     z-index: 30;
 }
 
-/* On phones the absolute back-button overlapped the wrapped list-toolbar
-   (search + sort) row. Revert to inline flex order on narrow screens so
-   the back-arrow sits beside the title like the rest of the chrome. */
-@media (max-width: 640px) {
-    .u-page-header > .back-button {
-        position: static;
-        transform: none;
-    }
-}
+/* (Previously: @media (max-width: 640px) reset .back-button to position:static
+   so it would not collide with a wrapping list-toolbar. Removed because the
+   button now stays absolutely anchored to the header edge at every width and
+   the .u-page-header__spacer below the header gives clearance for the
+   translateY(50%) overhang.) */

--- a/crkva/registar/templates/registar/_page_header.html
+++ b/crkva/registar/templates/registar/_page_header.html
@@ -1,8 +1,7 @@
 {% comment %}
-Reusable page header: back arrow on the left, h1 title (with optional
-"· count") on the right. Used by all spisak_*.html templates and by
-several detail pages (duplikati_adresa, kalendar, profile, search_view,
-slava_domacinstva, unos_korisnika).
+Reusable page header: back arrow on the left, h1 title, optional toolbar,
+optional right-side icon button (used by the calendar to link out to
+crkvenikalendar.rs).
 
 Required:
   title           h1 text (string)
@@ -10,6 +9,10 @@ Optional:
   back_url        URL string for the back arrow. Defaults to '/' (pocetna)
   count           integer; if passed (incl 0), renders as "· N" after title
   include_toolbar truthy to render {% templatetag openblock %} include "registar/_list_toolbar.html" {% templatetag closeblock %}
+  right_url       URL for an icon button anchored at the far right of the header
+  right_icon      Font Awesome class string (e.g. "fa-solid fa-up-right-from-square")
+  right_label     accessible label (used as aria-label + title tooltip)
+  right_external  truthy to add target="_blank" rel="noopener"
 {% endcomment %}
 <div class="u-page-header">
     <a href="{{ back_url|default:'/' }}" class="back-button" aria-label="Назад" title="Назад">
@@ -17,4 +20,6 @@ Optional:
     </a>
     <h1 class="u-page-title">{{ title }}{% if count or count == 0 %} <span class="u-page-title__count">· {{ count }}</span>{% endif %}</h1>
     {% if include_toolbar %}{% include "registar/_list_toolbar.html" %}{% endif %}
+    {% if right_url %}<a href="{{ right_url }}" class="back-button u-page-header__right" aria-label="{{ right_label }}" title="{{ right_label }}"{% if right_external %} target="_blank" rel="noopener"{% endif %}><i class="{{ right_icon }}"></i></a>{% endif %}
 </div>
+<div class="u-page-header__spacer" aria-hidden="true"></div>

--- a/crkva/registar/templates/registar/kalendar.html
+++ b/crkva/registar/templates/registar/kalendar.html
@@ -7,7 +7,7 @@
 {% block title %}Календар{% endblock %}
 
 {% block content %}
-{% include "registar/_page_header.html" with title="Календар" %}
+{% include "registar/_page_header.html" with title="Календар" right_url=source_url right_icon="fa-solid fa-up-right-from-square" right_label="Извор: crkvenikalendar.rs" right_external=True %}
 
 <!-- Single, centered navigation -->
 <div class="calendar-navigation">

--- a/crkva/registar/templates/registar/slava_domacinstva.html
+++ b/crkva/registar/templates/registar/slava_domacinstva.html
@@ -4,7 +4,7 @@
 {% block title %}{{ slava.naziv }} - Домаћинства{% endblock %}
 
 {% block content %}
-<div class="u-page-header">
+<div class="u-page-header u-page-header--wrap">
   <a href="{% url 'kalendar' %}" class="back-button" aria-label="Назад на календар" title="Назад на календар">
     <i class="fa-solid fa-arrow-left"></i>
   </a>

--- a/crkva/registar/views/kalendar_view.py
+++ b/crkva/registar/views/kalendar_view.py
@@ -15,6 +15,21 @@ from registar.utils import MESECI
 from registar.utils_fasting import get_fasting_type
 
 
+# crkvenikalendar.rs uses Cyrillic-month-name spelled in Latin script in the URL.
+# Map our 1..12 to the slug they use:
+CRKVENIKALENDAR_MONTH_SLUG = {
+    1: "januar", 2: "februar", 3: "mart", 4: "april",
+    5: "maj", 6: "jun", 7: "jul", 8: "avgust",
+    9: "septembar", 10: "oktobar", 11: "novembar", 12: "decembar",
+}
+
+
+def crkvenikalendar_url(year: int, month: int) -> str:
+    """URL of the month page on crkvenikalendar.rs (Serbian Orthodox calendar)."""
+    slug = CRKVENIKALENDAR_MONTH_SLUG.get(month)
+    return f"https://crkvenikalendar.rs/{slug}-{year}/" if slug else ""
+
+
 @login_required
 def kalendar(
     request: HttpRequest, year: int | None = None, month: int | None = None
@@ -132,6 +147,7 @@ def kalendar(
         "year": year,
         "month": month,
         "month_name": MESECI.get(month, str(month)),
+        "source_url": crkvenikalendar_url(year, month),
         "weekday_labels": weekday_labels,
         "cells": cells,
         "prev_year": prev_year,


### PR DESCRIPTION
- kalendar: external-link icon button (back-button styled) on top right linking to crkvenikalendar.rs/{month}-{year}/
- kalendar: single-column big-type layout on mobile (≤768px)
- _page_header: optional right_url/right_icon/right_label slot
- .u-page-header: margin-bottom: 28px so all pages (incl. detail) get clearance below the buttons that straddle the header edge
- mobile (≤768px): plain .back-button moves to right edge; with a right-side button present it shifts left to stack flush
- align .back-button to .button.button--neutral.button--icon: mobile 40×40 (was 44), icon 14px (was 18), bg surface (was surface-2)
- scope flex-wrap to .u-page-header--wrap modifier (used by slava_domacinstva) instead of leaking globally from spiskovi.css