### PR TITLE
fix: 0002_create_default_tenant uses historical model

### DIFF
--- a/crkva/tenants/migrations/0002_create_default_tenant.py
+++ b/crkva/tenants/migrations/0002_create_default_tenant.py
@@ -1,8 +1,11 @@
 """Create the default Tenant + provision its Postgres schema.
 
-Uses the LIVE Tenant class (not the historical model) so we get
-`auto_create_schema = True` behaviour — saving a Tenant triggers
-schema creation and runs TENANT_APPS migrations against it.
+Uses the historical Tenant model (via apps.get_model) so the INSERT only
+references fields that exist at this point in the migration history — the
+live model has fields added by later migrations (e.g. default_phone_region
+in 0005) that would otherwise blow up a fresh migrate_schemas run on an
+empty DB. The Postgres schema is created with a raw CREATE SCHEMA IF NOT
+EXISTS; the subsequent migrate_schemas pass migrates TENANT_APPS into it.
 """
 
 from django.conf import settings
@@ -10,32 +13,36 @@ from django.db import migrations
 
 
 def create_default_tenant(apps, schema_editor):
-    # Live model: we need its TenantMixin save() to auto-create the schema.
-    from tenants.models import Tenant
-
+    Tenant = apps.get_model("tenants", "Tenant")
     UserMembership = apps.get_model("tenants", "UserMembership")
     User = apps.get_model(
         settings.AUTH_USER_MODEL.split(".")[0],
         settings.AUTH_USER_MODEL.split(".")[1],
     )
 
-    if Tenant.objects.filter(schema_name="crkva_sv_petke_cukarica").exists():
-        tenant = Tenant.objects.get(schema_name="crkva_sv_petke_cukarica")
-    else:
-        # save() triggers create_schema() because auto_create_schema=True.
-        tenant = Tenant(
-            schema_name="crkva_sv_petke_cukarica",
-            naziv="Парохија Чукарица",
-            parohija_naziv="Парохија Чукарица",
-            is_active=True,
-            is_default=True,
-        )
-        tenant.save()
+    tenant, _ = Tenant.objects.get_or_create(
+        schema_name="crkva_sv_petke_cukarica",
+        defaults={
+            "naziv": "Парохија Чукарица",
+            "parohija_naziv": "Парохија Чукарица",
+            "is_active": True,
+            "is_default": True,
+        },
+    )
 
     if not tenant.is_default:
         Tenant.objects.exclude(pk=tenant.pk).update(is_default=False)
         tenant.is_default = True
         tenant.save()
+
+    # Provision the Postgres schema. The live Tenant model would have done
+    # this via auto_create_schema=True during save(); the historical model
+    # does not have that override, so we issue the CREATE explicitly. The
+    # ongoing migrate_schemas pass then applies TENANT_APPS migrations into
+    # the new schema, so we do not migrate it inline here.
+    schema_editor.execute(
+        "CREATE SCHEMA IF NOT EXISTS crkva_sv_petke_cukarica"
+    )
 
     for user in User.objects.filter(is_active=True, is_staff=True):
         UserMembership.objects.get_or_create(
@@ -46,9 +53,11 @@ def create_default_tenant(apps, schema_editor):
 
 
 def remove_default_tenant(apps, schema_editor):
-    from tenants.models import Tenant
-
+    Tenant = apps.get_model("tenants", "Tenant")
     Tenant.objects.filter(schema_name="crkva_sv_petke_cukarica").delete()
+    schema_editor.execute(
+        "DROP SCHEMA IF EXISTS crkva_sv_petke_cukarica CASCADE"
+    )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Migration 0002 imported the LIVE Tenant class to get auto_create_schema behaviour. But live Tenant has fields added by later migrations (default_phone_region landed in 0005), so a fresh migrate_schemas against an empty DB blew up — tenant.save() generated an INSERT referencing a column that does not exist yet at this point in the history.

Switch to apps.get_model("tenants", "Tenant") and create the Postgres schema with a raw CREATE SCHEMA IF NOT EXISTS via schema_editor.execute(). The same migrate_schemas pass then applies TENANT_APPS migrations into the new schema, so we do not migrate it inline.

The reverse migration also drops the schema cleanly so a rollback test does not leak Postgres state.

Verified end-to-end: dropped crkva_db, recreated, migrate_schemas + load_dbf + unos_* + importuj_dbf ran clean, all six headline counts match the docs (~1850 parohijani, 3536 krstenja, 233 vencanja, etc.).