### PR TITLE
perf: pg_trgm GIN trigram индекси за бржу претрагу (__icontains)

### DIFF
--- a/crkva/registar/migrations/0002_pg_trgm_search_indexes.py
+++ b/crkva/registar/migrations/0002_pg_trgm_search_indexes.py
@@ -1,0 +1,57 @@
+"""pg_trgm GIN trigram indexes for fast __icontains name/address search.
+
+Salvaged from the obsolete refactor/db-indexes-audit branch (PR #209): the
+model-level btree indexes from that audit already landed in main via the
+squashed 0001 migration, but the pg_trgm trigram indexes (originally its
+migration 0015) were never carried over.
+
+Django btree indexes cannot accelerate ILIKE '%foo%' (the SQL Django emits
+for __icontains, used heavily by the global search over osobe/adrese/hramovi).
+pg_trgm GIN indexes let the planner switch to a Bitmap Index Scan instead of a
+Seq Scan on those hot columns. Each statement is idempotent (IF NOT EXISTS)
+and reversible.
+
+registar is a TENANT app, so this runs once per tenant schema: the unqualified
+CREATE INDEX targets the tenant's own table, while the extension is created
+once in the shared public schema (IF NOT EXISTS makes repeats a no-op).
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "registar",
+            "0001_initial_squashed_0014_alter_svestenik_options_alter_adresa_mesto_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;",
+            # Dropping pg_trgm could break other databases sharing the cluster.
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS osoba_ime_trgm_idx ON osobe USING gin (ime public.gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS osoba_ime_trgm_idx;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS osoba_prezime_trgm_idx ON osobe USING gin (prezime public.gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS osoba_prezime_trgm_idx;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS adresa_ulica_trgm_idx ON adrese USING gin (ulica public.gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS adresa_ulica_trgm_idx;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS adresa_mesto_trgm_idx ON adrese USING gin (mesto public.gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS adresa_mesto_trgm_idx;",
+        ),
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS hram_naziv_trgm_idx ON hramovi USING gin (naziv public.gin_trgm_ops);",
+            reverse_sql="DROP INDEX IF EXISTS hram_naziv_trgm_idx;",
+        ),
+    ]


### PR DESCRIPTION
Спасава једини део PR-а #209 који **још не постоји** на `main`.

### Контекст
Ревизија индекса из гране `refactor/db-indexes-audit` (#209) је већ ушла у `main` кроз обједињену (squashed) `0001` миграцију — модели су идентични, а btree индекси (`krstenje_protocol_idx`, `osoba_created_idx`, …) су присутни. Грана је 16 commit-ова иза `main`, па се не може спојити без враћања новијег рада. Једино што недостаје јесу **pg_trgm trigram индекси** (некадашња миграција `0015`).

### Шта ради
Django btree индекси не убрзавају `ILIKE '%foo%'` (SQL који Django шаље за `__icontains`, а који глобална претрага интензивно користи). pg_trgm GIN индекси омогућавају планеру `Bitmap Index Scan` уместо `Seq Scan` на врућим колонама:
- `osobe(ime, prezime)`
- `adrese(ulica, mesto)`
- `hramovi(naziv)`

Нова миграција `registar/0002_pg_trgm_search_indexes.py`:
- `CREATE EXTENSION IF NOT EXISTS pg_trgm` (у `public` схеми, дељено),
- 5 GIN trigram индекса, сви `IF NOT EXISTS` (идемпотентно) и реверзибилни,
- пошто је `registar` tenant апликација, покреће се по свакој tenant схеми.

### Провере
- `makemigrations --check` — нема промена у моделима
- `showmigrations` — граф исправан (`0002` зависи од обједињене `0001`)
- DDL извршен у tenant схеми унутар трансакције са rollback-ом — пролази без грешке

### Напомена за деплој
Применити преко `python crkva/manage.py migrate_schemas` (тј. редовни деплој). Затвара потребу за PR-ом #209 — њега треба затворити као превазиђен.
