### PR TITLE
fix: Место рођења dropdown — select2 стил и унос нове вредности

### DIFF
--- a/crkva/registar/forms/distinct_lookup.py
+++ b/crkva/registar/forms/distinct_lookup.py
@@ -229,7 +229,11 @@ class DistinctValuesSelect2Widget(ModelSelect2Widget):
         attrs.setdefault("data-tags", "true")
         attrs.setdefault("data-token-separators", "[]")
         attrs["data-minimum-input-length"] = 0
-        attrs.setdefault("data-placeholder", "Изабери или унеси ново…")
+        # Set directly (not setdefault): the parent build_attrs already
+        # puts data-placeholder="" in attrs, and select2 with allow-clear
+        # fails to initialise on an empty placeholder — it falls back to a
+        # bare <select> with no tags UI. A non-empty placeholder fixes both.
+        attrs["data-placeholder"] = "Изабери или унеси ново…"
         return attrs
 
     def optgroups(self, name, value, attrs=None):


### PR DESCRIPTION
Решава #232.

### Узрок
`DistinctValuesSelect2Widget` (`registar/forms/distinct_lookup.py`) је рендеровао `data-placeholder=""` (празно): `build_attrs` је користио `setdefault`, али је родитељски `build_attrs` већ поставио тај атрибут на празан стринг, па подразумевана вредност никад није примењена.

select2 са укљученим `allow-clear` се **не иницијализује** када је placeholder празан, па је поље падало на обичан `<select>` — без select2 стила и без `tags` уноса нове вредности, за разлику од лукап dropdown-ова (Занимање/Вероисповест/Народност).

### Исправка
Поставити `data-placeholder` директно (не `setdefault`). Након измене поље се рендерује са истим атрибутима као исправни dropdown-ови:
- `data-placeholder="Изабери или унеси ново…"`
- `data-tags="true"`, класа `django-select2`

Потврђено да AJAX извор већ ради (враћа нпр. „Београд"). Користи се на формама парохијана и свештеника (`mesto_rodjenja`).

### Напомена
Препоручује се визуелна потврда у прегледачу на живој инстанци након деплоја.
