### PR TITLE
feat: Додавање нове особе из Домаћин/Укућанин dropdown-а (део #233)

### DIFF
--- a/crkva/registar/forms/domacinstvo_form.py
+++ b/crkva/registar/forms/domacinstvo_form.py
@@ -5,10 +5,10 @@ from django.forms import inlineformset_factory
 from registar.forms.phone import TenantPhoneField
 from registar.forms.select2 import (
     AdresaSelect2Widget,
+    OsobaSelect2Widget,
     PublicSchemaModelSelect2Widget,
-    ScriptAwareModelSelect2Widget,
 )
-from registar.models import Adresa, Domacinstvo, Osoba, Slava, Ukucanin
+from registar.models import Adresa, Domacinstvo, Slava, Ukucanin
 
 
 class DomacinstvoForm(forms.ModelForm):
@@ -30,11 +30,7 @@ class DomacinstvoForm(forms.ModelForm):
             "napomena",
         ]
         widgets = {
-            "domacin": ScriptAwareModelSelect2Widget(
-                model=Osoba,
-                search_fields=["ime__icontains", "prezime__icontains"],
-                attrs={"data-minimum-input-length": 0},
-            ),
+            "domacin": OsobaSelect2Widget(),
             "adresa": AdresaSelect2Widget(),
             # Slava lives in the public schema (shared model); the dedicated
             # widget wraps every SQL call in schema_context("public") so the
@@ -55,11 +51,7 @@ class UkucaninForm(forms.ModelForm):
         model = Ukucanin
         fields = ["osoba", "ime_ukucana", "uloga", "preminuo"]
         widgets = {
-            "osoba": ScriptAwareModelSelect2Widget(
-                model=Osoba,
-                search_fields=["ime__icontains", "prezime__icontains"],
-                attrs={"data-minimum-input-length": 0},
-            ),
+            "osoba": OsobaSelect2Widget(),
             "ime_ukucana": forms.TextInput(
                 attrs={"placeholder": "Име ако особа није у бази"}
             ),

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -155,7 +155,7 @@
     {% endif %}
   {% endif %}
 
-  {% if form %}{% include "registar/_modal_adresa.html" %}{% endif %}
+  {% if form %}{% include "registar/_modal_adresa.html" %}{% include "registar/_modal_osoba.html" %}{% endif %}
 </form>
 {% if domacinstvo %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}


### PR DESCRIPTION
Део #233 — поље **Домаћин** (и **Укућанин.особа**) сада нуди „+ Додај нову особу" из dropdown-а, као особа-поља на формама крштења/венчања.

### Измена
- `domacin` и `Ukucanin.osoba` пребачени са обичног `ScriptAwareModelSelect2Widget(model=Osoba)` на `OsobaSelect2Widget` (који додаје `data-osoba-create`).
- `domacinstvo.html` сада укључује `_modal_osoba.html` (глобални `osoba_create.js` отвара тај модал).
- Уклоњени сада некоришћени import-и (`ScriptAwareModelSelect2Widget`, `Osoba`).

### Провере
- `manage.py check` — без проблема
- `domacin` се рендерује са `data-osoba-create="1"` и класом `django-select2`
- `/unos/domacinstvo/` враћа 200 и садржи `#osoba-modal`

### Преостало у #233
Адреса, Храм, Свештеник, Парохија и даље немају „додај ново" (видети чек-листу у #233).
