### PR TITLE
feat: Додавање новог храма из dropdown-а (део #233)

### DIFF
--- a/crkva/registar/forms/select2.py
+++ b/crkva/registar/forms/select2.py
@@ -165,6 +165,12 @@ class HramSelect2Widget(ScriptAwareModelSelect2Widget):
     search_fields = ["naziv__icontains"]
     attrs = {"data-minimum-input-length": 0}
 
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-create-modal"] = "hram-create-modal"
+        attrs["data-create-label"] = "Додај нови храм"
+        return attrs
+
 
 class AdresaSelect2Widget(ScriptAwareModelSelect2Widget):
     """Autocomplete widget for Adresa.

--- a/crkva/registar/static/registar/components/quick_create.js
+++ b/crkva/registar/static/registar/components/quick_create.js
@@ -1,0 +1,81 @@
+/* ==========================================================================
+   QUICK-CREATE — generic "+ Додај ново" footer for select2 widgets
+   ==========================================================================
+   Attaches a create-new row to any select2 whose underlying <select> carries
+   `data-create-modal="<modalId>"` (and optional `data-create-label`). The
+   named modal must be bound via Modal.bindForm and registered in
+   window.quickModals[<modalId>] (see _modal_hram.html / _modal_adresa_create).
+
+   Mirrors osoba_create.js, but model-agnostic: on click it just opens the
+   modal targeting the originating <select>, so Modal's default onSuccess
+   appends the freshly-created {id,text} option and selects it.
+   ========================================================================== */
+(function ($) {
+    "use strict";
+    if (!$) return;
+
+    function attach($select) {
+        if ($select.data("quickCreateBound")) return;
+        $select.data("quickCreateBound", true);
+
+        var modalId = $select.attr("data-create-modal");
+        var label = $select.attr("data-create-label") || "Додај ново";
+
+        $select.on("select2:open.quickCreate", function () {
+            requestAnimationFrame(function () {
+                var $dropdown = $(".select2-container--open .select2-dropdown");
+                if (!$dropdown.length) return;
+                if ($dropdown.find(".select2-create-new").length) return;
+
+                var $footer = $(
+                    '<div class="select2-create-new" role="button" tabindex="0">' +
+                        '<i class="fa-solid fa-plus" aria-hidden="true"></i> ' +
+                        '<span class="select2-create-new__label"></span>' +
+                    "</div>"
+                );
+                $dropdown.append($footer);
+
+                var $search = $dropdown.find(".select2-search__field");
+
+                function refresh() {
+                    var q = ($search.val() || "").trim();
+                    $footer.find(".select2-create-new__label").text(
+                        q ? 'Додај "' + q + '"' : label
+                    );
+                }
+                refresh();
+                $search.on("input.quickCreate", refresh);
+
+                $footer.on("mousedown touchstart", function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var q = ($search.val() || "").trim();
+                    $select.select2("close");
+                    var inst = window.quickModals && window.quickModals[modalId];
+                    if (!inst || typeof inst.open !== "function") return;
+                    inst.open($select.attr("id"));
+                    // Prefill the modal's first text input with the typed query.
+                    setTimeout(function () {
+                        var overlay = document.getElementById(modalId);
+                        var first = overlay && overlay.querySelector("input[type=text]");
+                        if (first && q) {
+                            first.value = q;
+                            first.focus();
+                            try { first.setSelectionRange(q.length, q.length); } catch (e) {}
+                        }
+                    }, 60);
+                });
+            });
+        });
+    }
+
+    function init() {
+        $("select[data-create-modal]").each(function () { attach($(this)); });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})(window.jQuery);

--- a/crkva/registar/templates/base.html
+++ b/crkva/registar/templates/base.html
@@ -185,6 +185,7 @@
     {# osoba_create.js must follow so it can hook .on('select2:open') AFTER select2 is loaded. #}
     {% block extra_js %}{% endblock %}
     <script src="{% static 'registar/components/osoba_create.js' %}"></script>
+    <script src="{% static 'registar/components/quick_create.js' %}"></script>
     <script src="{% static 'registar/components/edit_toggle.js' %}"></script>
     <script src="{% static 'registar/components/form-errors.js' %}"></script>
       <script src="{% static 'registar/components/print_cert.js' %}"></script>

--- a/crkva/registar/templates/registar/_modal_hram.html
+++ b/crkva/registar/templates/registar/_modal_hram.html
@@ -1,0 +1,52 @@
+{% comment %}
+Quick-add Hram modal. Uses the generic Modal.bindForm helper (modal.js) and
+the generic quick_create.js footer. Registered in window.quickModals so the
+"+ Додај нови храм" footer on Hram select2 dropdowns can open it.
+{% endcomment %}
+<div id="hram-create-modal" class="modal-overlay" hidden>
+  <div class="modal">
+    <div class="modal__header">
+      <h3><i class="fa-solid fa-church"></i> Нови храм</h3>
+      <button type="button" class="modal__close" onclick="Modal.close('hram-create-modal')">&times;</button>
+    </div>
+    <div class="modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-naziv">Назив *</label>
+          <input type="text" id="modal-naziv" autocomplete="off" required>
+        </div>
+        <div class="form-field">
+          <label for="modal-mesto">Место</label>
+          <input type="text" id="modal-mesto" autocomplete="off">
+        </div>
+      </div>
+      <div class="error-text" hidden></div>
+    </div>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('hram-create-modal')">Откажи</button>
+      <button type="button" class="button button--primary" onclick="window.quickModals && window.quickModals['hram-create-modal'] && window.quickModals['hram-create-modal'].save()">
+        <i class="fa-solid fa-check"></i> Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    function init() {
+      var inst = Modal.bindForm("hram-create-modal", {
+        url: "{% url 'brzi_unos_hrama' %}",
+        fields: ["naziv", "mesto"],
+        requiredFields: ["naziv"],
+        requiredMessage: "Назив храма је обавезан.",
+      });
+      window.quickModals = window.quickModals || {};
+      window.quickModals["hram-create-modal"] = inst;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -205,6 +205,7 @@
   {% endif %}
 
   {% include 'registar/_modal_osoba.html' %}
+  {% include 'registar/_modal_hram.html' %}
 </form>
 {% if krstenje %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -172,6 +172,7 @@
   {% endif %}
 
   {% include 'registar/_modal_osoba.html' %}
+  {% include 'registar/_modal_hram.html' %}
 </form>
 {% if vencanje %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path("search/", views.search_view, name="search_view"),
     path("api/search/", views.search_autocomplete, name="search_autocomplete"),
     path("api/brzi-unos-osobe/", views.brzi_unos_osobe, name="brzi_unos_osobe"),
+    path("api/brzi-unos-hrama/", views.brzi_unos_hrama, name="brzi_unos_hrama"),
     path(
         "api/brzi-izmena-adrese/<uuid:uid>/",
         views.brzi_izmena_adrese,

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -6,7 +6,7 @@ vencanje_view, ...) и по намени (home_view, search_view, brzi_view).
 """
 
 from .adresa_view import duplikati_adresa, spoji_adresu
-from .brzi_view import brzi_izmena_adrese, brzi_unos_osobe
+from .brzi_view import brzi_izmena_adrese, brzi_unos_hrama, brzi_unos_osobe
 from .domacinstvo_view import (
     PrikazDomacinstva,
     SpisakDomacinsta,

--- a/crkva/registar/views/brzi_view.py
+++ b/crkva/registar/views/brzi_view.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import DatabaseError, IntegrityError
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-from registar.models import Adresa, Osoba
+from registar.models import Adresa, Hram, Osoba
 from tenants.permissions import tenant_role_required
 
 logger = logging.getLogger(__name__)
@@ -83,3 +83,20 @@ def brzi_izmena_adrese(request, uid):
         logger.exception("DatabaseError saving Adresa uid=%s", uid)
         return JsonResponse({"error": "Грешка у бази података."}, status=500)
     return JsonResponse({"id": str(adresa.uid), "text": str(adresa)})
+
+
+@tenant_role_required("krstenje")
+def brzi_unos_hrama(request):
+    """AJAX endpoint за брзо креирање храма из модалног дијалога."""
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    naziv = request.POST.get("naziv", "").strip()
+    mesto = request.POST.get("mesto", "").strip()
+    if not naziv:
+        return JsonResponse({"error": "Назив храма је обавезан"}, status=400)
+
+    # get_or_create on (naziv, mesto) so repeated quick-adds of the same temple
+    # return the existing row instead of piling up duplicates.
+    hram, _ = Hram.objects.get_or_create(naziv=naziv, mesto=mesto)
+    return JsonResponse({"id": str(hram.uid), "text": str(hram)})


### PR DESCRIPTION
Део #233 — поље **Храм** (на формама крштења и венчања) сада нуди „+ Додај нови храм" директно из dropdown-а.

### Шта је додато
- **Endpoint** `brzi_unos_hrama` (`api/brzi-unos-hrama/`): POST `naziv`/`mesto`, `get_or_create` (без дупликата), дозвола `tenant_role_required("krstenje")`.
- **Генерички footer** `quick_create.js`: качи „+ Додај ново" на сваки select2 са `data-create-modal` и отвара именовани модал (преко `Modal.bindForm`) циљајући то поље; учитан глобално у `base.html` после `osoba_create.js`. (Реупотребиво за будуће dropdown-ове.)
- `HramSelect2Widget` добија `data-create-modal` / `data-create-label`.
- Нов партиал `_modal_hram.html` (поља назив/место), укључен на `krstenje.html` и `vencanje.html`; региструје се у `window.quickModals`.

### Провере
- `manage.py check` — без проблема
- Endpoint: валидан POST → `200` са `{id, text}`; празан назив → `400`; GET → `405`
- `hram` виџет се рендерује са `data-create-modal="hram-create-modal"`
- `/unos/krstenje/` и `/unos/vencanje/` враћају `200` и садрже модал + `quick_create.js`

### Напомена
Интеракцију у прегледачу (footer → модал → чување → избор нове опције) треба визуелно потврдити на живој инстанци.

Преостаје у #233: Адреса (следећи PR), Свештеник, Парохија.
