### PR TITLE
feat: Додавање нове адресе из dropdown-а (део #233)

### DIFF
--- a/crkva/registar/forms/select2.py
+++ b/crkva/registar/forms/select2.py
@@ -191,4 +191,6 @@ class AdresaSelect2Widget(ScriptAwareModelSelect2Widget):
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
         attrs["data-adresa-edit"] = "1"
+        attrs["data-create-modal"] = "adresa-create-modal"
+        attrs["data-create-label"] = "Додај нову адресу"
         return attrs

--- a/crkva/registar/templates/registar/_modal_adresa_create.html
+++ b/crkva/registar/templates/registar/_modal_adresa_create.html
@@ -1,0 +1,62 @@
+{% comment %}
+Quick-add Adresa modal (create-new, distinct from _modal_adresa.html which
+edits the selected address in place). Uses the generic Modal.bindForm helper
+and the quick_create.js footer; registered in window.quickModals so the
+"+ Додај нову адресу" footer on Adresa select2 dropdowns can open it.
+{% endcomment %}
+<div id="adresa-create-modal" class="modal-overlay" hidden>
+  <div class="modal">
+    <div class="modal__header">
+      <h3><i class="fa-solid fa-location-dot"></i> Нова адреса</h3>
+      <button type="button" class="modal__close" onclick="Modal.close('adresa-create-modal')">&times;</button>
+    </div>
+    <div class="modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-ulica">Улица</label>
+          <input type="text" id="modal-ulica" autocomplete="off">
+        </div>
+        <div class="form-field">
+          <label for="modal-broj">Број</label>
+          <input type="text" id="modal-broj" autocomplete="off">
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-broj_stana">Број стана</label>
+          <input type="text" id="modal-broj_stana" autocomplete="off">
+        </div>
+        <div class="form-field">
+          <label for="modal-mesto">Место</label>
+          <input type="text" id="modal-mesto" autocomplete="off">
+        </div>
+      </div>
+      <div class="error-text" hidden></div>
+    </div>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('adresa-create-modal')">Откажи</button>
+      <button type="button" class="button button--primary" onclick="window.quickModals && window.quickModals['adresa-create-modal'] && window.quickModals['adresa-create-modal'].save()">
+        <i class="fa-solid fa-check"></i> Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    function init() {
+      var inst = Modal.bindForm("adresa-create-modal", {
+        url: "{% url 'brzi_unos_adrese' %}",
+        fields: ["ulica", "broj", "broj_stana", "mesto"],
+        requiredFields: [],
+      });
+      window.quickModals = window.quickModals || {};
+      window.quickModals["adresa-create-modal"] = inst;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -156,6 +156,7 @@
   {% endif %}
 
   {% if form %}{% include "registar/_modal_adresa.html" %}{% include "registar/_modal_osoba.html" %}{% endif %}
+  {% if form %}{% include "registar/_modal_adresa_create.html" %}{% endif %}
 </form>
 {% if domacinstvo %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -237,6 +237,7 @@
 </script>
 {% endif %}
   {% if form %}{% include "registar/_modal_adresa.html" %}{% endif %}
+  {% if form %}{% include "registar/_modal_adresa_create.html" %}{% endif %}
 </form>
 {% if parohijan %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -62,6 +62,7 @@
   {% endif %}
 
   {% if form %}{% include "registar/_modal_adresa.html" %}{% endif %}
+  {% if form %}{% include "registar/_modal_adresa_create.html" %}{% endif %}
 </form>
 {% if svestenik %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path("search/", views.search_view, name="search_view"),
     path("api/search/", views.search_autocomplete, name="search_autocomplete"),
     path("api/brzi-unos-osobe/", views.brzi_unos_osobe, name="brzi_unos_osobe"),
+    path("api/brzi-unos-adrese/", views.brzi_unos_adrese, name="brzi_unos_adrese"),
     path("api/brzi-unos-hrama/", views.brzi_unos_hrama, name="brzi_unos_hrama"),
     path(
         "api/brzi-izmena-adrese/<uuid:uid>/",

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -6,7 +6,12 @@ vencanje_view, ...) и по намени (home_view, search_view, brzi_view).
 """
 
 from .adresa_view import duplikati_adresa, spoji_adresu
-from .brzi_view import brzi_izmena_adrese, brzi_unos_hrama, brzi_unos_osobe
+from .brzi_view import (
+    brzi_izmena_adrese,
+    brzi_unos_adrese,
+    brzi_unos_hrama,
+    brzi_unos_osobe,
+)
 from .domacinstvo_view import (
     PrikazDomacinstva,
     SpisakDomacinsta,

--- a/crkva/registar/views/brzi_view.py
+++ b/crkva/registar/views/brzi_view.py
@@ -100,3 +100,49 @@ def brzi_unos_hrama(request):
     # return the existing row instead of piling up duplicates.
     hram, _ = Hram.objects.get_or_create(naziv=naziv, mesto=mesto)
     return JsonResponse({"id": str(hram.uid), "text": str(hram)})
+
+
+@tenant_role_required("domacinstvo")
+def brzi_unos_adrese(request):
+    """AJAX endpoint за брзо креирање нове адресе из модалног дијалога.
+
+    Permission mirrors brzi_izmena_adrese ("domacinstvo"). Адреса се дели
+    међу особама/домаћинствима, па се исти нормализовани унос не дуплира —
+    ако постоји, враћа се постојећи ред.
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    ulica = request.POST.get("ulica", "").strip()
+    broj = request.POST.get("broj", "").strip()
+    broj_stana = request.POST.get("broj_stana", "").strip()
+    mesto = request.POST.get("mesto", "").strip()
+    if not ulica and not mesto:
+        return JsonResponse({"error": "Унесите бар улицу или место."}, status=400)
+
+    # Match the unique_adresa_normalized constraint columns case-insensitively
+    # and reuse an existing row instead of erroring on a duplicate.
+    existing = Adresa.objects.filter(
+        ulica__iexact=ulica,
+        broj__iexact=broj,
+        broj_stana__iexact=broj_stana,
+        mesto__iexact=mesto,
+    ).first()
+    if existing:
+        return JsonResponse({"id": str(existing.uid), "text": str(existing)})
+
+    adresa = Adresa(ulica=ulica, broj=broj, broj_stana=broj_stana, mesto=mesto)
+    try:
+        adresa.full_clean()
+        adresa.save()
+    except ValidationError as exc:
+        return JsonResponse(
+            {"error": "Невалидни подаци адресе.", "detail": exc.message_dict},
+            status=400,
+        )
+    except IntegrityError:
+        logger.exception("IntegrityError creating Adresa")
+        return JsonResponse(
+            {"error": "Адреса се не може сачувати због конфликта."}, status=400
+        )
+    return JsonResponse({"id": str(adresa.uid), "text": str(adresa)})


### PR DESCRIPTION
Део #233 — поље **Адреса** (форме парохијана, домаћинства, свештеника) сада нуди „+ Додај нову адресу" из dropdown-а, поред постојеће оловке за измену.

### Шта је додато
- **Endpoint** `brzi_unos_adrese` (`api/brzi-unos-adrese/`): POST `ulica/broj/broj_stana/mesto`, дозвола `tenant_role_required("domacinstvo")` (исто као `brzi_izmena_adrese`). Нормализовани дупликат се не прави — враћа се постојећи ред.
- `AdresaSelect2Widget` добија `data-create-modal`/`data-create-label` (поред постојећег `data-adresa-edit`).
- Нов партиал `_modal_adresa_create.html` (`Modal.bindForm`), укључен на `parohijan/domacinstvo/svestenik`. Користи генерички `quick_create.js` (већ у `main` из #236).

### Провере
- `manage.py check` — без проблема
- Endpoint: ново→`200 {id,text}`; дупликат→постојећи ред (без новог); празно→`400`; GET→`405`
- `adresa` виџет рендерује `data-create-modal="adresa-create-modal"`
- `/unos/parohijan|domacinstvo|svestenik/` садрже модал (домаћинство задржава и `_modal_osoba`)

### Напомена
- Интеракцију у прегледачу (footer → модал → чување) потврдити визуелно.
- Дозвола `domacinstvo`: на форми свештеника корисници са улогом само „Свештенство" не могу да креирају адресу (исто ограничење као постојећи `brzi_izmena_adrese`) — шире право за адресе је засебно питање.

Преостаје у #233: Свештеник, Парохија (богати модели — договорено „касније").
