### PR TITLE
fix: Поравнање Сачувај дугмета на формама за додавање (#231)

### DIFF
--- a/crkva/registar/templates/registar/_view_actions.html
+++ b/crkva/registar/templates/registar/_view_actions.html
@@ -7,16 +7,19 @@
     RIGHT → mode-aware buttons:
               view: print → edit → history
               edit: cancel → save
+              add (no obj): save only
 
   Required:
-    obj                  model instance with .uid
+    obj                  model instance with .uid — OR falsy/None on the
+                         "add new" forms, which renders just the save button
+                         in the same right-aligned layout (issue #231).
 
   Optional:
     pdf_url_name         named URL for print (positional uid)
     edit_url_name        named URL for the edit form (uid kwarg)
     can_edit             falsy hides the edit button
     show_history         default True; pass False to suppress history toggle
-    back_list_url_name   list URL (view-mode back target)
+    back_list_url_name   list URL (view-mode / add-mode back target)
     back_detail_url_name detail URL (edit-mode back target)
 {% endcomment %}
 <div class="view-actions">
@@ -24,6 +27,7 @@
     <a href="{% if is_edit and obj %}{% url back_detail_url_name uid=obj.uid %}{% else %}{% url back_list_url_name %}{% endif %}" class="back-button" aria-label="Назад" title="Назад"><i class="fa-solid fa-arrow-left"></i></a>
   {% endif %}
   <span class="view-actions__right">
+    {% if obj %}
     <span data-show-mode="view">
       {% if pdf_url_name %}
         <button type="button" onclick="window.print()" class="button button--neutral button--icon" data-tooltip="Штампај"><i class="fa-solid fa-print"></i></button>
@@ -39,5 +43,10 @@
       <button type="button" data-action="cancel-edit" class="button button--secondary button--icon" data-tooltip="Откажи"><i class="fa-solid fa-xmark"></i></button>
       <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
     </span>
+    {% else %}
+    {# Add mode: no object yet — render the save button in the same
+       right-aligned .view-actions layout as edit mode (issue #231). #}
+    <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
+    {% endif %}
   </span>
 </div>

--- a/crkva/registar/templates/registar/domacinstvo.html
+++ b/crkva/registar/templates/registar/domacinstvo.html
@@ -20,11 +20,7 @@
       {% elif is_edit %}Измена домаћинства{% if domacinstvo.domacin %}<span class="u-page-title__subtitle">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</span>{% endif %}
       {% else %}Домаћинство{% if domacinstvo.domacin %}<span class="u-page-title__subtitle">{{ domacinstvo.domacin.ime }} {{ domacinstvo.domacin.prezime }}</span>{% endif %}{% endif %}
     </h1>
-    {% if domacinstvo %}
       {% include "registar/_view_actions.html" with back_list_url_name="domacinstva" back_detail_url_name="domacinstvo_detail" obj=domacinstvo edit_url_name="izmena_domacinstva" can_edit=can_edit_domacinstvo %}
-    {% else %}
-      <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
-    {% endif %}
   </div>
 
   {% if form.errors %}{% include "registar/_form_errors.html" %}{% endif %}

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -37,11 +37,7 @@
       {% elif is_edit %}Измена крштења{% if krstenje %}<span class="u-page-title__subtitle">{{ krstenje.ime_deteta }}</span>{% endif %}
       {% else %}Крштење<span class="u-page-title__subtitle">{{ krstenje.ime_deteta }} {{ krstenje.prezime_oca }}</span>{% endif %}
     </h1>
-    {% if krstenje %}
       {% include "registar/_view_actions.html" with back_list_url_name="krstenja" back_detail_url_name="krstenje_detail" obj=krstenje edit_url_name="izmena_krstenja" can_edit=can_edit_krstenje pdf_url_name="krstenje_pdf" %}
-    {% else %}
-      <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
-    {% endif %}
   </div>
 
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}

--- a/crkva/registar/templates/registar/parohijan.html
+++ b/crkva/registar/templates/registar/parohijan.html
@@ -34,11 +34,7 @@
       {% elif is_edit %}Измена парохијана{% if parohijan %}<span class="u-page-title__subtitle">{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime and parohijan.pol == "Ж" %} <span class="osoba__devojacko">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}</span>{% endif %}
       {% else %}Парохијан<span class="u-page-title__subtitle">{{ parohijan.ime }} {{ parohijan.prezime }}{% if parohijan.devojacko_prezime and parohijan.pol == "Ж" %} <span class="osoba__devojacko">(рођ. {{ parohijan.devojacko_prezime }})</span>{% endif %}</span>{% endif %}
     </h1>
-    {% if parohijan %}
       {% include "registar/_view_actions.html" with back_list_url_name="parohijani" back_detail_url_name="parohijan_detail" obj=parohijan edit_url_name="izmena_parohijana" can_edit=can_edit_osoba %}
-    {% else %}
-      <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
-    {% endif %}
   </div>
 
   {% if form.errors %}{% include "registar/_form_errors.html" %}{% endif %}

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -19,11 +19,7 @@
       {% elif is_edit %}Измена свештеника{% if svestenik %}<span class="u-page-title__subtitle">{{ svestenik.ime }} {{ svestenik.prezime }}</span>{% endif %}
       {% else %}Свештеник<span class="u-page-title__subtitle">{{ svestenik.ime }} {{ svestenik.prezime }}</span>{% endif %}
     </h1>
-    {% if svestenik %}
       {% include "registar/_view_actions.html" with back_list_url_name="svestenici" back_detail_url_name="svestenik_detail" obj=svestenik edit_url_name="izmena_svestenika" can_edit=can_edit_svestenik %}
-    {% else %}
-      <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
-    {% endif %}
   </div>
 
   {% if form.errors %}{% include "registar/_form_errors.html" %}{% endif %}

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -37,11 +37,7 @@
       {% elif is_edit %}Измена венчања{% if vencanje %}<span class="u-page-title__subtitle">{{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</span>{% endif %}
       {% else %}Венчање<span class="u-page-title__subtitle">{{ vencanje.ime_zenika }} и {{ vencanje.ime_neveste }} {{ vencanje.prezime_zenika }}</span>{% endif %}
     </h1>
-    {% if vencanje %}
       {% include "registar/_view_actions.html" with back_list_url_name="vencanja" back_detail_url_name="vencanje_detail" obj=vencanje edit_url_name="izmena_vencanja" can_edit=can_edit_vencanje pdf_url_name="vencanje_pdf" %}
-    {% else %}
-      <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
-    {% endif %}
   </div>
 
   {% if form.errors %}{% include 'registar/_form_errors.html' %}{% endif %}


### PR DESCRIPTION
Решава #231.

### Узрок
На формама за **додавање** дугме Сачувај је било голо `<button type="submit">` директно у `u-page-header`, док режими прегледа/измене користе `_view_actions.html` — ред `.view-actions` са стрелицом „Назад" лево и десно поравнатом групом, „закачен" за доњу ивицу sticky заглавља. Отуда неусклађен изглед и позиција.

### Исправка
- `_view_actions.html` сада подржава и режим **додавања** (без објекта): рендерује стрелицу „Назад" (ка листи) + десно поравнато „Сачувај" у истом `.view-actions` распореду.
- obj-зависна дугмад (штампа / измени / историја / откажи) су заштићена са `{% if obj %}` да не би изазивала `NoReverseMatch` на add страни.
- Свих пет форми (парохијан, домаћинство, крштење, венчање, свештеник) сада увек укључују партиал уместо `{% if obj %}…{% else %}голо дугме{% endif %}`.

### Провере
- `manage.py check` — без проблема
- Свих 5 `/unos/...` страна → `200`, садрже `.view-actions`, десно „Сачувај" и стрелицу „Назад"
- Регресија: `/parohijan/<uid>/` (преглед) и `/izmena/parohijan/<uid>/` (измена) → `200`, и даље имају пуну `.view-actions` групу (Измени/Штампа/Историја)

### Напомена
Финално визуелно поравнање потврдити у прегледачу на живој инстанци.
