### PR TITLE
fix: вишелинијски {# #} коментар у заглављу + pre-commit заштита

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,3 +115,14 @@ repos:
         stages: [commit-msg]
         args: [--multiline]
         entry: '(?i)^[ \t]*co-authored-by:'
+
+  # Catch multi-line Django {# ... #} comments. Django {# #} comments are
+  # single-line only; a multi-line one is NOT treated as a comment and its
+  # text leaks into the rendered page (regressed once in _view_actions.html).
+  - repo: local
+    hooks:
+      - id: no-multiline-django-comment
+        name: no multi-line Django {# #} comment
+        language: pygrep
+        entry: '{#(?![^\n]*#\})'
+        files: \.html$

--- a/crkva/registar/templates/registar/_view_actions.html
+++ b/crkva/registar/templates/registar/_view_actions.html
@@ -44,8 +44,7 @@
       <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
     </span>
     {% else %}
-    {# Add mode: no object yet — render the save button in the same
-       right-aligned .view-actions layout as edit mode (issue #231). #}
+    {# Add mode (no object yet): save button in the same right-aligned layout as edit — issue #231. #}
     <button type="submit" class="button button--primary button--icon" data-tooltip="Сачувај"><i class="fa-solid fa-floppy-disk"></i></button>
     {% endif %}
   </span>


### PR DESCRIPTION
Хитна исправка регресије из #238 + заштита да се не понови.

### Багова
Django `{# ... #}` коментари су **једнолинијски**. Вишелинијски коментар уведен у `_view_actions.html` (#238) није био препознат као коментар, па се његов текст **исписивао у заглављу** форми за додавање/измену. Сведено на једну линију. (Потврђено: пре — текст цурио на `/unos/...`; после — не цури, распоред нетакнут.)

### Заштита (pre-commit)
Додат локални `pygrep` hook `no-multiline-django-comment` на `*.html` који обара commit када `{# ... #}` није затворен у истој линији. djLint (већ конфигурисан) не покрива овај случај.

- Regex: `{#(?![^\n]*#\})` — „{# без #} до краја линије".
- Проверено на 6 случајева (једнолинијски �“, вишелинијски ✗, `{% comment %}` блок ✓, две затворене инлајн ✓, само таг/променљива ✓, неуграђени мид-текст ✗).
- `pre-commit run no-multiline-django-comment --all-files` → **Passed** (нема постојећих прекршаја).

### Напомена
Hook ради тек након `pre-commit install` код програмера (тренутно није инсталиран у git hooks).
