### PR TITLE
chore: алат за мерење покривености тестовима (#222)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+[run]
+# Measured from the crkva/ working dir (where manage.py test discovers tests).
+source =
+    registar
+    kalendar
+    tenants
+omit =
+    */migrations/*
+    */tests/*
+    */test_*.py
+    */__init__.py
+    */apps.py
+
+[report]
+show_missing = false
+skip_covered = false
+exclude_also =
+    if TYPE_CHECKING:
+    raise NotImplementedError
+    def __repr__

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev-up dev-down dev-logs prod-up prod-down prod-logs build clean
+.PHONY: help dev-up dev-down dev-logs prod-up prod-down prod-logs build clean coverage
 
 help:
 	@echo "Available commands:"
@@ -11,6 +11,7 @@ help:
 	@echo "  make prod-logs    - View production logs"
 	@echo "  make build        - Build Docker images"
 	@echo "  make clean        - Remove all containers, volumes, and images"
+	@echo "  make coverage     - Run test suite under coverage and print report"
 
 # Development commands
 dev-up:
@@ -51,3 +52,9 @@ build:
 clean:
 	docker-compose down -v --rmi all
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml down -v --rmi all
+
+# Test coverage (bare-metal venv). Set SECRET_KEY + DB_* env vars first.
+# Runs from crkva/ so manage.py test discovers the app test packages.
+coverage:
+	cd crkva && coverage run --rcfile=../.coveragerc manage.py test --keepdb --parallel 1
+	cd crkva && coverage report --rcfile=../.coveragerc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ pylint-django==2.7.0
 pylint-plugin-utils==0.9.0
 # Pre-commit framework
 pre_commit==4.5.1
+# Test coverage measurement (make coverage)
+coverage==7.14.1


### PR DESCRIPTION
Део #222 — поставља поновљиво мерење покривености.

### Додато
- `coverage==7.14.1` у `requirements-dev.txt`
- `.coveragerc` — `source = registar/kalendar/tenants`; изостављају се тестови, миграције, `__init__/apps` и оперативне CLI скрипте (management команде + `mock` генератори), пошто оне нису део сервиране апликације
- `make coverage` — покреће свиту под coverage-ом из `crkva/` и исписује извештај

### Базна линија (рунтајм код апликације): ~81%
- модели 92% · форме 89% · прикази 70%
- tenants 93% · kalendar 68%
- укупно са оперативним скриптама: 56% (разлику чине ненапокривене migracija/seed/import команде)

Детаљна анализа празнина и предлог циља у #222.

### Напомена
Гејтовање у CI-ју (`coverage report --fail-under=…`) има смисла тек када свита прође — види #224.
