### PR TITLE
ci: least-privilege GITHUB_TOKEN дозволе за Tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN (CodeQL: actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Решава безбедносни налаз (CodeQL `actions/missing-workflow-permissions`) на Tests workflow-у уведеном у #241.

Без експлицитног `permissions:` блока, `GITHUB_TOKEN` добија подразумеване широке дозволе. Job само ради `checkout`, па га ограничавамо на:

```yaml
permissions:
  contents: read
```

Без функционалне промене — суита и даље ради исто.
