### PR TITLE
test: покривеност најслабијих модула + исправка FilterSet претраге (#222)

### DIFF
--- a/crkva/kalendar/tests/test_slava_calc.py
+++ b/crkva/kalendar/tests/test_slava_calc.py
@@ -1,0 +1,63 @@
+"""Тестови за прорачуне у моделу Slava (Васкрс, датум, пост, назив месеца).
+
+Покрива calc_vaskrs (Гаусов алгоритам), get_datum (фиксни/покретни/празан),
+get_post (без поста и са границама) и get_mesec_naziv. Чисти прорачуни
+без базе. Issue #222 — kalendar/models/slava.py био на 64%.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import datetime
+
+from django.test import SimpleTestCase
+from kalendar.models.slava import Slava
+
+
+class CalcVaskrsTests(SimpleTestCase):
+    def test_known_year_2024(self):
+        # Православни Васкрс 2024 (грегоријански) = 5. мај.
+        self.assertEqual(Slava.calc_vaskrs(2024), datetime.date(2024, 5, 5))
+
+    def test_known_year_2023(self):
+        self.assertEqual(Slava.calc_vaskrs(2023), datetime.date(2023, 4, 16))
+
+
+class GetDatumTests(SimpleTestCase):
+    def test_fixed_feast(self):
+        s = Slava(naziv="Усековање", opsti_naziv="Усековање", dan=28, mesec=8)
+        self.assertEqual(s.get_datum(2024), datetime.date(2024, 8, 28))
+
+    def test_movable_feast_uses_offset(self):
+        # Покретни празник 49 дана после Васкрса 2024 (5. мај).
+        s = Slava(naziv="X", opsti_naziv="X", pokretni=True, offset_dani=49)
+        self.assertEqual(s.get_datum(2024), datetime.date(2024, 6, 23))
+
+    def test_movable_feast_weeks_offset(self):
+        s = Slava(naziv="X", opsti_naziv="X", pokretni=True, offset_nedelje=1)
+        self.assertEqual(s.get_datum(2024), datetime.date(2024, 5, 12))
+
+    def test_no_date_returns_none(self):
+        s = Slava(naziv="X", opsti_naziv="X")
+        self.assertIsNone(s.get_datum(2024))
+
+
+class GetPostTests(SimpleTestCase):
+    def test_no_fast_returns_none(self):
+        s = Slava(naziv="X", opsti_naziv="X", post=False)
+        self.assertIsNone(s.get_post(2024))
+
+    def test_fast_returns_start_end_tuple(self):
+        s = Slava(naziv="X", opsti_naziv="X", post=True, post_od=-48, post_do=0)
+        start, end = s.get_post(2024)
+        self.assertEqual(start, datetime.date(2024, 3, 18))
+        self.assertEqual(end, datetime.date(2024, 5, 5))
+
+
+class GetMesecNazivTests(SimpleTestCase):
+    def test_known_month(self):
+        s = Slava(naziv="X", opsti_naziv="X", dan=28, mesec=8)
+        self.assertEqual(s.get_mesec_naziv(), "август")
+
+    def test_no_month_empty(self):
+        s = Slava(naziv="X", opsti_naziv="X")
+        self.assertEqual(s.get_mesec_naziv(), "")

--- a/crkva/registar/filters/krstenja_filter.py
+++ b/crkva/registar/filters/krstenja_filter.py
@@ -19,7 +19,12 @@ class KrstenjeFilter(django_filters.FilterSet):
         fields = []
 
     def filter_search(self, queryset, _name, value):
-        """Претражује уносе на основу више текстуалних поља, укључујући датум."""
+        """Претражује уносе на основу више текстуалних поља, укључујући датум.
+
+        Поља детета/оца/мајке/кума живе на везаним Osoba редовима, па се
+        претражују преко релација (dete__ime…), не преко @property имена
+        (ime_deteta…) која ORM не уме да разреши.
+        """
         termini_pretrage = value.split()
         queryset = queryset.annotate(datum_str=Cast("datum", models.CharField()))
 
@@ -29,14 +34,15 @@ class KrstenjeFilter(django_filters.FilterSet):
             inner = models.Q()
             for v in get_query_variants(rec):
                 inner |= (
-                    models.Q(ime_deteta__icontains=v)
-                    | models.Q(gradjansko_ime_deteta__icontains=v)
-                    | models.Q(ime_oca__icontains=v)
-                    | models.Q(prezime_oca__icontains=v)
-                    | models.Q(ime_majke__icontains=v)
-                    | models.Q(prezime_majke__icontains=v)
-                    | models.Q(ime_kuma__icontains=v)
-                    | models.Q(prezime_kuma__icontains=v)
+                    models.Q(dete__ime__icontains=v)
+                    | models.Q(dete__gradjansko_ime__icontains=v)
+                    | models.Q(dete__prezime__icontains=v)
+                    | models.Q(otac__ime__icontains=v)
+                    | models.Q(otac__prezime__icontains=v)
+                    | models.Q(majka__ime__icontains=v)
+                    | models.Q(majka__prezime__icontains=v)
+                    | models.Q(kum__ime__icontains=v)
+                    | models.Q(kum__prezime__icontains=v)
                     | models.Q(datum_str__icontains=v)
                 )
             # Сви термини морају да се пронађу (AND)

--- a/crkva/registar/filters/vencanja_filter.py
+++ b/crkva/registar/filters/vencanja_filter.py
@@ -19,7 +19,12 @@ class VencanjeFilter(django_filters.FilterSet):
         fields = []
 
     def filter_search(self, queryset, _name, value):
-        """Претражује уносе на основу више текстуалних поља, укључујући датум."""
+        """Претражује уносе на основу више текстуалних поља, укључујући датум.
+
+        Женик/невеста/кум/стари сват су FK на Osoba, а храм на Hram, па се
+        претражују преко релација (zenik__ime, hram__naziv…), не преко самих
+        FK поља која не подржавају icontains.
+        """
         termini_pretrage = value.split()
         queryset = queryset.annotate(datum_str=Cast("datum", models.CharField()))
 
@@ -28,12 +33,14 @@ class VencanjeFilter(django_filters.FilterSet):
             inner = models.Q()
             for v in get_query_variants(rec):
                 inner |= (
-                    models.Q(ime_zenika__icontains=v)
-                    | models.Q(prezime_zenika__icontains=v)
-                    | models.Q(ime_neveste__icontains=v)
-                    | models.Q(prezime_neveste__icontains=v)
-                    | models.Q(kum__icontains=v)
-                    | models.Q(stari_svat__icontains=v)
+                    models.Q(zenik__ime__icontains=v)
+                    | models.Q(zenik__prezime__icontains=v)
+                    | models.Q(nevesta__ime__icontains=v)
+                    | models.Q(nevesta__prezime__icontains=v)
+                    | models.Q(kum__ime__icontains=v)
+                    | models.Q(kum__prezime__icontains=v)
+                    | models.Q(stari_svat__ime__icontains=v)
+                    | models.Q(stari_svat__prezime__icontains=v)
                     | models.Q(hram__naziv__icontains=v)
                     | models.Q(datum_str__icontains=v)
                 )

--- a/crkva/registar/tests/test_adresa_merge_view.py
+++ b/crkva/registar/tests/test_adresa_merge_view.py
@@ -1,0 +1,105 @@
+"""Тестови за приказе спајања адреса (duplikati_adresa + spoji_adresu).
+
+Покрива: листу кандидата-дупликата (админ), извршење спајања (POST →
+пресмеравање + редирект), self-merge гард (ValueError → flash), захтев
+дозволе (не-админ → 403) и require_POST (GET → 405).
+Issue #222 — views/adresa_view.py био на 34%.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Adresa, Osoba
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class AdresaMergeViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.admin = User.objects.create_user(username="adm", password="x")
+        UserMembership.objects.create(
+            user=cls.admin, tenant=cls.tenant, role=Role.ADMIN
+        )
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin)
+
+    def _make_dup_pair(self):
+        # Исти нормализовани кључ (strip+lower), али различити под Lower()
+        # захваљујући размацима — пролази unique_adresa_normalized.
+        a = Adresa.objects.create(ulica="Главна", broj="1", mesto="Београд")
+        b = Adresa.objects.create(ulica=" Главна ", broj="1", mesto="Београд")
+        return a, b
+
+    def test_duplikati_lists_group_for_admin(self):
+        self._make_dup_pair()
+        r = self.client.get(reverse("duplikati_adresa"))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["total_groups"], 1)
+        self.assertContains(r, "Главна")
+
+    def test_duplikati_forbidden_for_non_admin(self):
+        self.client.force_login(self.clerk)
+        r = self.client.get(reverse("duplikati_adresa"))
+        self.assertEqual(r.status_code, 403)
+
+    def test_spoji_merges_and_redirects(self):
+        loser, winner = self._make_dup_pair()
+        osoba = Osoba.objects.create(ime="Веза", prezime="Веза", adresa=loser)
+        r = self.client.post(
+            reverse(
+                "spoji_adresu",
+                kwargs={"loser_uid": loser.uid, "winner_uid": winner.uid},
+            )
+        )
+        self.assertRedirects(r, reverse("duplikati_adresa"))
+        self.assertFalse(Adresa.objects.filter(uid=loser.uid).exists())
+        osoba.refresh_from_db()
+        self.assertEqual(osoba.adresa_id, winner.uid)
+
+    def test_spoji_self_merge_flashes_error(self):
+        a, _ = self._make_dup_pair()
+        r = self.client.post(
+            reverse(
+                "spoji_adresu",
+                kwargs={"loser_uid": a.uid, "winner_uid": a.uid},
+            ),
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        # Ред није обрисан; приказана је порука о грешци.
+        self.assertTrue(Adresa.objects.filter(uid=a.uid).exists())
+        msgs = [m.message for m in r.context["messages"]]
+        self.assertTrue(any("into itself" in m for m in msgs))
+
+    def test_spoji_get_rejected_405(self):
+        a, b = self._make_dup_pair()
+        r = self.client.get(
+            reverse(
+                "spoji_adresu",
+                kwargs={"loser_uid": a.uid, "winner_uid": b.uid},
+            )
+        )
+        self.assertEqual(r.status_code, 405)
+
+    def test_spoji_forbidden_for_non_admin(self):
+        loser, winner = self._make_dup_pair()
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            reverse(
+                "spoji_adresu",
+                kwargs={"loser_uid": loser.uid, "winner_uid": winner.uid},
+            )
+        )
+        self.assertEqual(r.status_code, 403)
+        self.assertTrue(Adresa.objects.filter(uid=loser.uid).exists())

--- a/crkva/registar/tests/test_brzi_view.py
+++ b/crkva/registar/tests/test_brzi_view.py
@@ -1,0 +1,114 @@
+"""Тестови за брзе AJAX endpoint-е (особа/храм/адреса) из модала.
+
+Покрива гране ван „срећног пута“: погрешан метод (405), валидација (400),
+дедупликација (get_or_create / постојећи ред), и prefill GET за измену
+адресе. Issue #222 — views/brzi_view.py био на 48%.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Adresa, Hram
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class BrziViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        # Канцеларија има права за osoba/domacinstvo/krstenje/vencanje.
+        cls.user = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.user, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    # --- особа ---
+    def test_osoba_get_rejected_405(self):
+        r = self.client.get(reverse("brzi_unos_osobe"))
+        self.assertEqual(r.status_code, 405)
+
+    def test_osoba_missing_name_400(self):
+        r = self.client.post(reverse("brzi_unos_osobe"), {"ime": "", "prezime": "X"})
+        self.assertEqual(r.status_code, 400)
+
+    def test_osoba_invalid_pol_400(self):
+        r = self.client.post(
+            reverse("brzi_unos_osobe"),
+            {"ime": "А", "prezime": "Б", "pol": "Q"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_osoba_valid_returns_id(self):
+        r = self.client.post(
+            reverse("brzi_unos_osobe"),
+            {"ime": "Ново", "prezime": "Лице", "pol": "М"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("id", r.json())
+
+    # --- храм ---
+    def test_hram_get_rejected_405(self):
+        r = self.client.get(reverse("brzi_unos_hrama"))
+        self.assertEqual(r.status_code, 405)
+
+    def test_hram_missing_naziv_400(self):
+        r = self.client.post(reverse("brzi_unos_hrama"), {"naziv": ""})
+        self.assertEqual(r.status_code, 400)
+
+    def test_hram_create_and_dedup(self):
+        r1 = self.client.post(
+            reverse("brzi_unos_hrama"), {"naziv": "Свети Сава", "mesto": "Београд"}
+        )
+        self.assertEqual(r1.status_code, 200)
+        r2 = self.client.post(
+            reverse("brzi_unos_hrama"), {"naziv": "Свети Сава", "mesto": "Београд"}
+        )
+        # Исти (naziv, mesto) → исти ред, без дупликата.
+        self.assertEqual(r1.json()["id"], r2.json()["id"])
+        self.assertEqual(Hram.objects.filter(naziv="Свети Сава").count(), 1)
+
+    # --- нова адреса ---
+    def test_adresa_get_rejected_405(self):
+        r = self.client.get(reverse("brzi_unos_adrese"))
+        self.assertEqual(r.status_code, 405)
+
+    def test_adresa_empty_400(self):
+        r = self.client.post(reverse("brzi_unos_adrese"), {"ulica": "", "mesto": ""})
+        self.assertEqual(r.status_code, 400)
+
+    def test_adresa_create_and_dedup(self):
+        payload = {"ulica": "Кнеза Милоша", "broj": "5", "mesto": "Београд"}
+        r1 = self.client.post(reverse("brzi_unos_adrese"), payload)
+        self.assertEqual(r1.status_code, 200)
+        r2 = self.client.post(reverse("brzi_unos_adrese"), payload)
+        # Постојећа адреса се поново користи (case-insensitive).
+        self.assertEqual(r1.json()["id"], r2.json()["id"])
+        self.assertEqual(Adresa.objects.filter(ulica="Кнеза Милоша").count(), 1)
+
+    # --- измена адресе ---
+    def test_izmena_get_returns_prefill(self):
+        a = Adresa.objects.create(ulica="Стара", broj="1", mesto="Ниш")
+        r = self.client.get(reverse("brzi_izmena_adrese", kwargs={"uid": a.uid}))
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(data["ulica"], "Стара")
+        self.assertEqual(data["mesto"], "Ниш")
+
+    def test_izmena_post_updates(self):
+        a = Adresa.objects.create(ulica="Стара", broj="1", mesto="Ниш")
+        r = self.client.post(
+            reverse("brzi_izmena_adrese", kwargs={"uid": a.uid}),
+            {"ulica": "Нова", "broj": "9", "broj_stana": "", "mesto": "Ниш"},
+        )
+        self.assertEqual(r.status_code, 200)
+        a.refresh_from_db()
+        self.assertEqual(a.ulica, "Нова")
+        self.assertEqual(a.broj, "9")

--- a/crkva/registar/tests/test_merge_service.py
+++ b/crkva/registar/tests/test_merge_service.py
@@ -1,0 +1,93 @@
+"""Тестови за services.merge (спајање дупликата адреса).
+
+Покрива merge_adrese (пресмеравање FK + брисање губитника + self-merge
+гард), adresa_fanout и batch_adresa_fanout (празан улаз + груписање +
+константан број упита). Issue #222 — services/merge.py био на 34%.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from registar.models import Adresa, Domacinstvo, Osoba, Svestenik
+from registar.services.merge import (
+    adresa_fanout,
+    batch_adresa_fanout,
+    merge_adrese,
+)
+
+
+class MergeAdreseTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.loser = Adresa.objects.create(ulica="Стара", broj="1", mesto="Београд")
+        cls.winner = Adresa.objects.create(ulica="Нова", broj="2", mesto="Београд")
+        # Два парохијана, једно домаћинство и један свештеник на губитнику.
+        cls.o1 = Osoba.objects.create(ime="А", prezime="А", adresa=cls.loser)
+        cls.o2 = Osoba.objects.create(ime="Б", prezime="Б", adresa=cls.loser)
+        domacin = Osoba.objects.create(ime="Дом", prezime="Дом", adresa=cls.loser)
+        cls.dom = Domacinstvo.objects.create(domacin=domacin, adresa=cls.loser)
+        cls.sv = Svestenik.objects.create(
+            ime="Поп", prezime="Попић", zvanje="јереј", adresa=cls.loser
+        )
+
+    def test_merge_repoints_all_fks_and_deletes_loser(self):
+        moved = merge_adrese(self.loser, self.winner)
+        self.assertEqual(moved, {"osoba": 3, "domacinstvo": 1, "svestenik": 1})
+        # Губитник обрисан.
+        self.assertFalse(Adresa.objects.filter(uid=self.loser.uid).exists())
+        # Све везе сада показују на победника.
+        self.assertEqual(Osoba.objects.filter(adresa=self.winner).count(), 3)
+        self.assertEqual(Domacinstvo.objects.filter(adresa=self.winner).count(), 1)
+        self.assertEqual(Svestenik.objects.filter(adresa=self.winner).count(), 1)
+
+    def test_merge_into_self_raises(self):
+        with self.assertRaises(ValueError):
+            merge_adrese(self.loser, self.loser)
+        # Ништа није обрисано.
+        self.assertTrue(Adresa.objects.filter(uid=self.loser.uid).exists())
+
+
+class FanoutTests(TestCase):
+    def test_adresa_fanout_counts(self):
+        a = Adresa.objects.create(ulica="Главна", broj="10", mesto="Ниш")
+        Osoba.objects.create(ime="Х", prezime="Х", adresa=a)
+        Osoba.objects.create(ime="Y", prezime="Y", adresa=a)
+        self.assertEqual(
+            adresa_fanout(a), {"osoba": 2, "domacinstvo": 0, "svestenik": 0}
+        )
+
+    def test_batch_fanout_empty_input(self):
+        self.assertEqual(batch_adresa_fanout([]), {})
+
+    def test_batch_fanout_groups_per_address(self):
+        a1 = Adresa.objects.create(ulica="Прва", broj="1", mesto="Нови Сад")
+        a2 = Adresa.objects.create(ulica="Друга", broj="2", mesto="Нови Сад")
+        Osoba.objects.create(ime="П1", prezime="П", adresa=a1)
+        Osoba.objects.create(ime="П2", prezime="П", adresa=a1)
+        Svestenik.objects.create(ime="С", prezime="С", zvanje="јереј", adresa=a2)
+        result = batch_adresa_fanout([a1, a2])
+        self.assertEqual(result[a1.uid], {"osoba": 2, "domacinstvo": 0, "svestenik": 0})
+        self.assertEqual(result[a2.uid], {"osoba": 0, "domacinstvo": 0, "svestenik": 1})
+
+    def test_batch_fanout_query_count_does_not_grow_with_n(self):
+        # Кључна особина: број упита је константан без обзира на број адреса
+        # (3 GROUP BY-а; режијски SET search_path под django-tenants је исти).
+        few = [
+            Adresa.objects.create(ulica=f"А{i}", broj=str(i), mesto="Бг")
+            for i in range(3)
+        ]
+        with CaptureQueriesContext(connection) as ctx_few:
+            batch_adresa_fanout(few)
+
+        many = few + [
+            Adresa.objects.create(ulica=f"Б{i}", broj=str(i), mesto="Бг")
+            for i in range(20)
+        ]
+        with CaptureQueriesContext(connection) as ctx_many:
+            batch_adresa_fanout(many)
+
+        self.assertEqual(
+            len(ctx_many.captured_queries), len(ctx_few.captured_queries)
+        )

--- a/crkva/registar/tests/test_ordinal_filters.py
+++ b/crkva/registar/tests/test_ordinal_filters.py
@@ -1,0 +1,43 @@
+"""Тестови за redni_rec филтер (број → редни број речима).
+
+Покрива све гране: празно/None → „није уписано“, вредност < 1 → „није
+уписано“, опсег 1–20 (реч), > 20 („N.“), и не-број (непромењено).
+Issue #222 — филтер уведен у #243 имао је само 53% покривености.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.test import SimpleTestCase
+from registar.templatetags.ordinal_filters import NIJE_UPISANO, redni_rec
+
+
+class RedniRecTests(SimpleTestCase):
+    def test_none_is_nije_upisano(self):
+        self.assertEqual(redni_rec(None), NIJE_UPISANO)
+
+    def test_empty_string_is_nije_upisano(self):
+        self.assertEqual(redni_rec(""), NIJE_UPISANO)
+
+    def test_zero_is_nije_upisano(self):
+        self.assertEqual(redni_rec(0), NIJE_UPISANO)
+
+    def test_negative_is_nije_upisano(self):
+        self.assertEqual(redni_rec(-3), NIJE_UPISANO)
+
+    def test_first(self):
+        self.assertEqual(redni_rec(1), "прво")
+
+    def test_seventh(self):
+        self.assertEqual(redni_rec(7), "седмо")
+
+    def test_twentieth_upper_bound(self):
+        self.assertEqual(redni_rec(20), "двадесето")
+
+    def test_above_twenty_numeric_form(self):
+        self.assertEqual(redni_rec(21), "21.")
+
+    def test_numeric_string_coerced(self):
+        self.assertEqual(redni_rec("5"), "пето")
+
+    def test_non_numeric_returned_unchanged(self):
+        self.assertEqual(redni_rec("abc"), "abc")

--- a/crkva/registar/tests/test_phone_filters.py
+++ b/crkva/registar/tests/test_phone_filters.py
@@ -1,0 +1,78 @@
+"""Тестови за phone_filters template филтере (format_phone, tel_link, phone_icon).
+
+Покрива и објекте PhoneNumber и сирове стрингове, укључујући fallback гране
+за неважеће улазе које phonenumbers.parse одбија (issue #222 — подизање
+покривености templatetags/, која је била најнижа у апликацији: 20%).
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.test import SimpleTestCase
+from phonenumber_field.phonenumber import PhoneNumber
+from registar.templatetags.phone_filters import (
+    format_phone,
+    phone_icon,
+    tel_link,
+)
+
+
+class FormatPhoneTests(SimpleTestCase):
+    def test_empty_returns_empty(self):
+        self.assertEqual(format_phone(""), "")
+        self.assertEqual(format_phone(None), "")
+
+    def test_phonenumber_object_uses_as_national(self):
+        pn = PhoneNumber.from_string("+381641234567")
+        self.assertEqual(format_phone(pn), pn.as_national)
+
+    def test_valid_rs_string_formats_national(self):
+        # Рашчлањиво → национални формат са груписаним цифрама.
+        self.assertEqual(format_phone("0641234567"), "064 1234567")
+
+    def test_unparseable_string_returned_unchanged(self):
+        self.assertEqual(format_phone("није-број"), "није-број")
+
+
+class TelLinkTests(SimpleTestCase):
+    def test_empty_returns_empty(self):
+        self.assertEqual(tel_link(""), "")
+        self.assertEqual(tel_link(None), "")
+
+    def test_phonenumber_object_uses_e164(self):
+        pn = PhoneNumber.from_string("+381641234567")
+        self.assertEqual(tel_link(pn), "+381641234567")
+
+    def test_valid_string_to_e164(self):
+        self.assertEqual(tel_link("0641234567"), "+381641234567")
+
+    def test_unparseable_no_digits_returns_empty(self):
+        # phonenumbers одбија → fallback; нема цифара → празно.
+        self.assertEqual(tel_link("abc"), "")
+
+    def test_unparseable_leading_zero_branch(self):
+        # Одбијено рашчлањивање, цифре „0“ → +381 без водеће нуле.
+        self.assertEqual(tel_link("0abc"), "+381")
+
+    def test_unparseable_other_digits_branch(self):
+        # Одбијено рашчлањивање, цифре не почињу 0/381 → +381 + цифре.
+        self.assertEqual(tel_link("abc1"), "+3811")
+
+
+class PhoneIconTests(SimpleTestCase):
+    def test_empty_default_icon(self):
+        self.assertEqual(phone_icon(""), "fa-phone")
+        self.assertEqual(phone_icon(None), "fa-phone")
+
+    def test_mobile_number_icon(self):
+        self.assertEqual(phone_icon("0641234567"), "fa-mobile-screen")
+
+    def test_fixed_line_icon(self):
+        # Београдски фиксни (011) → икона телефона.
+        self.assertEqual(phone_icon("0112345678"), "fa-phone")
+
+    def test_unparseable_mobile_heuristic(self):
+        # Нерашчлањив, али почиње са 06 → хеуристика каже мобилни.
+        self.assertEqual(phone_icon("06/нешто"), "fa-mobile-screen")
+
+    def test_unparseable_default(self):
+        self.assertEqual(phone_icon("xyz"), "fa-phone")

--- a/crkva/registar/tests/test_search_autocomplete.py
+++ b/crkva/registar/tests/test_search_autocomplete.py
@@ -1,0 +1,81 @@
+"""Тестови за search_autocomplete JSON endpoint (груписани предлози).
+
+Покрива кратак упит (< 2 знака → празно), и груписане резултате по типу
+ентитета (парохијани, свештеници, крштења, венчања) са рангирањем.
+Issue #222 — views/search_view.py био на 51% (autocomplete неизвршен).
+"""
+
+# pylint: disable=missing-function-docstring
+
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Hram, Krstenje, Osoba, Svestenik, Vencanje
+
+User = get_user_model()
+
+
+class SearchAutocompleteTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_superuser(
+            username="auto", email="a@a.test", password="x"
+        )
+        cls.parohijan = Osoba.objects.create(
+            ime="Стефан", prezime="Стефановић", pol="М",
+            datum_rodjenja=datetime.date(1990, 1, 1),
+        )
+        cls.svestenik = Svestenik.objects.create(
+            ime="Сава", prezime="Савић", zvanje="јереј"
+        )
+        cls.hram = Hram.objects.create(naziv="Храм")
+        dete = Osoba.objects.create(ime="Михаило", prezime="Михаиловић", pol="М")
+        cls.krstenje = Krstenje.objects.create(
+            dete=dete, knjiga=1, broj=1, strana=1, redni_broj=1,
+            godina_registracije=2024, datum=datetime.date(2024, 1, 2),
+            vanbracno=False, blizanac=False, telesna_mana=False, hram=cls.hram,
+        )
+        zenik = Osoba.objects.create(ime="Урош", prezime="Урошевић", pol="М")
+        nevesta = Osoba.objects.create(ime="Тамара", prezime="Тамарић", pol="Ж")
+        cls.vencanje = Vencanje.objects.create(
+            zenik=zenik, nevesta=nevesta, hram=cls.hram,
+            datum=datetime.date(2023, 6, 6),
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def _labels(self, term):
+        r = self.client.get(reverse("search_autocomplete"), {"q": term})
+        self.assertEqual(r.status_code, 200)
+        return r.json(), [g["label"] for g in r.json()["groups"]]
+
+    def test_short_query_returns_empty(self):
+        r = self.client.get(reverse("search_autocomplete"), {"q": "С"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"groups": []})
+
+    def test_parohijan_group(self):
+        data, labels = self._labels("Стефан")
+        self.assertIn("Парохијани", labels)
+        grupa = next(g for g in data["groups"] if g["label"] == "Парохијани")
+        self.assertEqual(grupa["items"][0]["text"], "Стефан Стефановић")
+
+    def test_svestenik_group(self):
+        _, labels = self._labels("Савић")
+        self.assertIn("Свештеници", labels)
+
+    def test_krstenje_group(self):
+        _, labels = self._labels("Михаило")
+        self.assertIn("Крштења", labels)
+
+    def test_vencanje_group(self):
+        _, labels = self._labels("Урош")
+        self.assertIn("Венчања", labels)
+
+    def test_latin_query_finds_cyrillic(self):
+        _, labels = self._labels("Stefan")
+        self.assertIn("Парохијани", labels)

--- a/crkva/registar/tests/test_search_filters.py
+++ b/crkva/registar/tests/test_search_filters.py
@@ -1,0 +1,119 @@
+"""Тестови за KrstenjeFilter и VencanjeFilter (FilterSet претрага).
+
+Ови FilterSet-ови су били неупотребљени и поломљени (референцирали су
+@property имена и сирова FK поља уместо релационих путања), па су падали
+са FieldError при сваком термину. Овде се потврђује исправљена претрага:
+по имену (ћир/лат), по датуму, и AND семантика више термина.
+Issue #222 — filters/*_filter.py били на 55% (filter_search неизвршен).
+"""
+
+# pylint: disable=missing-function-docstring
+
+import datetime
+
+from django.test import TestCase
+from registar.filters import KrstenjeFilter, VencanjeFilter
+from registar.models import Hram, Krstenje, Osoba, Vencanje
+
+
+class KrstenjeFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.dete = Osoba.objects.create(ime="Марко", prezime="Марковић", pol="М")
+        cls.otac = Osoba.objects.create(ime="Петар", prezime="Марковић", pol="М")
+        cls.majka = Osoba.objects.create(ime="Ана", prezime="Марковић", pol="Ж")
+        cls.kum = Osoba.objects.create(ime="Лазар", prezime="Кумовић", pol="М")
+        cls.hram = Hram.objects.create(naziv="Храм")
+        cls.krstenje = Krstenje.objects.create(
+            dete=cls.dete, otac=cls.otac, majka=cls.majka, kum=cls.kum,
+            knjiga=1, broj=1, strana=1, redni_broj=1, godina_registracije=2024,
+            datum=datetime.date(2024, 5, 17),
+            vanbracno=False, blizanac=False, telesna_mana=False, hram=cls.hram,
+        )
+        # Несродан запис да се потврди да филтер заиста сужава.
+        other = Osoba.objects.create(ime="Никола", prezime="Илић", pol="М")
+        Krstenje.objects.create(
+            dete=other, knjiga=1, broj=2, strana=1, redni_broj=2,
+            godina_registracije=2024, datum=datetime.date(2020, 1, 1),
+            vanbracno=False, blizanac=False, telesna_mana=False, hram=cls.hram,
+        )
+
+    def _search(self, term):
+        return list(
+            KrstenjeFilter(
+                data={"search": term}, queryset=Krstenje.objects.all()
+            ).qs
+        )
+
+    def test_search_by_child_name(self):
+        self.assertEqual(self._search("Марко"), [self.krstenje])
+
+    def test_search_by_father_surname(self):
+        # И отац и дете и мајка деле презиме Марковић → тачно овај запис.
+        self.assertEqual(self._search("Марковић"), [self.krstenje])
+
+    def test_search_by_kum(self):
+        self.assertEqual(self._search("Кумовић"), [self.krstenje])
+
+    def test_search_latin_finds_cyrillic(self):
+        self.assertEqual(self._search("Marko"), [self.krstenje])
+
+    def test_search_by_date_string(self):
+        self.assertEqual(self._search("2024-05-17"), [self.krstenje])
+
+    def test_multi_term_and_semantics(self):
+        self.assertEqual(self._search("Марко Лазар"), [self.krstenje])
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(self._search("Непостојеће"), [])
+
+
+class VencanjeFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.zenik = Osoba.objects.create(ime="Душан", prezime="Зекић", pol="М")
+        cls.nevesta = Osoba.objects.create(ime="Јелена", prezime="Нинић", pol="Ж")
+        cls.kum = Osoba.objects.create(ime="Огњен", prezime="Кумић", pol="М")
+        cls.stari_svat = Osoba.objects.create(ime="Вук", prezime="Сватић", pol="М")
+        cls.hram = Hram.objects.create(naziv="Саборна црква")
+        cls.vencanje = Vencanje.objects.create(
+            zenik=cls.zenik, nevesta=cls.nevesta, kum=cls.kum,
+            stari_svat=cls.stari_svat, hram=cls.hram,
+            datum=datetime.date(2023, 9, 3),
+        )
+        z2 = Osoba.objects.create(ime="Иван", prezime="Иванић", pol="М")
+        n2 = Osoba.objects.create(ime="Маја", prezime="Мајић", pol="Ж")
+        Vencanje.objects.create(
+            zenik=z2, nevesta=n2, datum=datetime.date(2019, 2, 2)
+        )
+
+    def _search(self, term):
+        return list(
+            VencanjeFilter(
+                data={"search": term}, queryset=Vencanje.objects.all()
+            ).qs
+        )
+
+    def test_search_by_groom(self):
+        self.assertEqual(self._search("Душан"), [self.vencanje])
+
+    def test_search_by_bride(self):
+        self.assertEqual(self._search("Јелена"), [self.vencanje])
+
+    def test_search_by_kum(self):
+        self.assertEqual(self._search("Кумић"), [self.vencanje])
+
+    def test_search_by_stari_svat(self):
+        self.assertEqual(self._search("Сватић"), [self.vencanje])
+
+    def test_search_by_hram(self):
+        self.assertEqual(self._search("Саборна"), [self.vencanje])
+
+    def test_search_latin_finds_cyrillic(self):
+        self.assertEqual(self._search("Dusan"), [self.vencanje])
+
+    def test_search_by_date_string(self):
+        self.assertEqual(self._search("2023-09-03"), [self.vencanje])
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(self._search("Непостојеће"), [])


### PR DESCRIPTION
Наставак рада на покривености из #222 (последња неозначена ставка чек-листе: „допунити тестове где недостају — почети од модула са најмањом покривеношћу“).

## Подигнута покривеност (мерено новим тестовима над циљним модулима)
| Модул | Пре | Сада |
|---|---|---|
| `templatetags/phone_filters.py` | 20% | 96% |
| `templatetags/ordinal_filters.py` | 53% | 100% |
| `services/merge.py` | 34% | 95% |
| `views/adresa_view.py` | 34% | 98% |
| `filters/krstenja_filter.py` | 55% | 100% |
| `filters/vencanja_filter.py` | 55% | 100% |
| `views/brzi_view.py` | 48% | 82% |
| `kalendar/models/slava.py` | 64% | 90% |
| `views/search_view.py` (autocomplete) | 51% | ↑ |

Додато **80 тестова** (8 нових фајлова). Цела свита: **718 пролази** локално (свежа база); CI на чистом runner-у (#224) ће потврдити.

## Узгредни налаз: поломљени FilterSet-ови (исправљено)
`KrstenjeFilter`/`VencanjeFilter.filter_search` су референцирали `@property` имена (`ime_deteta`, `ime_oca`…) и сирова FK поља (`kum`, `stari_svat`) уместо релационих путања (`dete__ime`, `kum__ime`…) → падали су са `FieldError` при сваком термину. Извезени су из `registar.filters`, али нигде нису повезани с приказом (листе користе `get_search_queryset` mixin), па се баг није испољио у продукцији. Сада су исправни и потпуно покривени тестовима (ћир/лат, датум, AND семантика).

## Чек-листа #222
- [x] Попис покривености (#240)
- [x] Критични токови без тестова
- [x] Мерење у CI (#240/#241)
- [x] Допуна тестова где недостају — овај PR (наставиће се континуирано)
