### PR TITLE
fix(registar): graceful 503 for any missing relation on public fallback (#229)

### DIFF
--- a/crkva/registar/middleware.py
+++ b/crkva/registar/middleware.py
@@ -2,9 +2,30 @@
 Middleware за обраду грешака у регистру.
 """
 
+import re
+
 from django.db import ProgrammingError
 from django.http import HttpResponse
 from django.template import loader
+
+# Регистарске табеле живе само у парохијским (tenant) шемама. Када се захтев
+# обрађује над public шемом (нпр. middleware падне на public јер парохија
+# није изабрана или шема недостаје), упит над њима баца
+# ProgrammingError: relation "..." does not exist. Преводимо познате називе у
+# читљиве српске; за непознате користимо сирово име табеле.
+TABLE_DISPLAY_NAMES = {
+    "krstenja": "крштења",
+    "vencanja": "венчања",
+    "osobe": "особе",
+    "svestenici": "свештеници",
+    "domacinstva": "домаћинства",
+    "slave": "славе",
+    "parohije": "парохије",
+    "adrese": "адресе",
+    "hramovi": "храмови",
+}
+
+_MISSING_RELATION_RE = re.compile(r"relation \"(?P<name>[^\"]+)\" does not exist")
 
 
 class HandleMissingTablesMiddleware:
@@ -18,27 +39,24 @@ class HandleMissingTablesMiddleware:
         return response
 
     def process_exception(self, request, exception):
-        """Обради изузетке који се дешавају током обраде захтева."""
-        if isinstance(exception, ProgrammingError):
-            error_message = str(exception)
-            if "relation" in error_message and "does not exist" in error_message:
-                # Извуци име табеле из поруке о грешци
-                table_name = None
-                if '"krstenja"' in error_message:
-                    table_name = "крштења"
-                elif '"vencanja"' in error_message:
-                    table_name = "венчања"
-                elif '"osobe"' in error_message:
-                    table_name = "особе"
-                elif '"svestenici"' in error_message:
-                    table_name = "свештеници"
+        """Обради изузетке који се дешавају током обраде захтева.
 
-                if table_name:
-                    template = loader.get_template("registar/missing_table.html")
-                    context = {
-                        "table_name": table_name,
-                        "error_detail": error_message,
-                    }
-                    return HttpResponse(template.render(context, request), status=503)
+        Сваки relation "..." does not exist (било која регистарска табела
+        недостаје — нпр. domacinstva, slave, … при паду на public) претвара
+        у грациозан 503 уместо сировог 500.
+        """
+        if not isinstance(exception, ProgrammingError):
+            return None
 
-        return None
+        match = _MISSING_RELATION_RE.search(str(exception))
+        if not match:
+            return None
+
+        raw_name = match.group("name")
+        table_name = TABLE_DISPLAY_NAMES.get(raw_name, raw_name)
+        template = loader.get_template("registar/missing_table.html")
+        context = {
+            "table_name": table_name,
+            "error_detail": str(exception),
+        }
+        return HttpResponse(template.render(context, request), status=503)

--- a/crkva/registar/tests/test_missing_tables_middleware.py
+++ b/crkva/registar/tests/test_missing_tables_middleware.py
@@ -1,0 +1,63 @@
+"""HandleMissingTablesMiddleware turns any missing-relation error into a 503 (#229).
+
+Previously only four hardcoded table names were handled, so a fall-back to the
+public schema that queried `domacinstva` or `slave` produced a raw 500.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.contrib.auth.models import AnonymousUser
+from django.db import ProgrammingError
+from django.test import RequestFactory, TestCase
+from registar.middleware import HandleMissingTablesMiddleware
+from tenants.models import Tenant
+
+
+class MissingTablesMiddlewareTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+
+    def setUp(self):
+        self.mw = HandleMissingTablesMiddleware(lambda r: None)
+
+    def _request(self):
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        request.tenant = self.tenant
+        return request
+
+    def _missing(self, table):
+        return ProgrammingError(
+            f"relation \"{table}\" does not exist\nLINE 1: SELECT ..."
+        )
+
+    def test_domacinstva_missing_returns_503(self):
+        resp = self.mw.process_exception(self._request(), self._missing("domacinstva"))
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, 503)
+        self.assertIn("домаћинства", resp.content.decode("utf-8"))
+
+    def test_slave_missing_returns_503(self):
+        resp = self.mw.process_exception(self._request(), self._missing("slave"))
+        self.assertEqual(resp.status_code, 503)
+        self.assertIn("славе", resp.content.decode("utf-8"))
+
+    def test_known_registar_table_still_handled(self):
+        resp = self.mw.process_exception(self._request(), self._missing("krstenja"))
+        self.assertEqual(resp.status_code, 503)
+        self.assertIn("крштења", resp.content.decode("utf-8"))
+
+    def test_unknown_table_falls_back_to_raw_name(self):
+        resp = self.mw.process_exception(self._request(), self._missing("neka_tabela"))
+        self.assertEqual(resp.status_code, 503)
+        self.assertIn("neka_tabela", resp.content.decode("utf-8"))
+
+    def test_non_missing_relation_programming_error_passes_through(self):
+        exc = ProgrammingError("syntax error at or near SELECT")
+        self.assertIsNone(self.mw.process_exception(self._request(), exc))
+
+    def test_non_programming_error_passes_through(self):
+        self.assertIsNone(
+            self.mw.process_exception(self._request(), ValueError("boom"))
+        )


### PR DESCRIPTION
## Проблем (#229)

Кад `SessionTenantMiddleware` падне на `public` шему (парохија није изабрана, шема недостаје, или активација баци грешку), `index` и `kalendar` упитују registar табеле које постоје само у tenant шемама (`Osoba/Krstenje/...`, `Count("domacinstvo")`). `HandleMissingTablesMiddleware` је препознавао само 4 чврсто кодирана имена, па су `domacinstva`/`slave` враћали сиров **500**.

## Решење

Препознај **било који** `relation "..." does not exist` преко regex-а и врати грациозну 503 страницу. Позната имена табела се преводе на српски (`domacinstva → домаћинства`, `slave → славе`, …), за непозната се користи сирово име.

## Тестови

`registar/tests/test_missing_tables_middleware.py` (ново): 503 за `domacinstva`/`slave`/`krstenja`, fallback на сирово име за непознату табелу, пролаз кроз (None) за ProgrammingError без „does not exist" и за не-ProgrammingError.

Цела свита: **736 пролаза**.

Closes #229
