### PR TITLE
feat(registar): group slava households by street + holy-water flags in report (#18)

### DIFF
--- a/crkva/registar/static/registar/components/spiskovi.css
+++ b/crkva/registar/static/registar/components/spiskovi.css
@@ -915,6 +915,34 @@ body.history-open {
 .stavka--slava { flex-direction: column; align-items: stretch; }
 .stavka--slava .stavka-veza { display: block; }
 
+/* Street group header for the slava households report (#18) */
+.spisak__group-head {
+  list-style: none;
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: color-mix(in oklab, var(--color-accent) 7%, var(--color-surface));
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+.spisak__group-head i { margin-right: var(--space-2); opacity: 0.6; }
+
+/* Holy-water yes/no row (#18): slavska + vaskrsnja vodica */
+.stavka__vodica {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-4);
+  margin-top: var(--space-2);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+.stavka__vodica-val { font-weight: 600; }
+.stavka__vodica-val--yes { color: var(--color-primary); }
+
 .stavka__roster {
   display: flex;
   flex-direction: column;

--- a/crkva/registar/static/registar/print/slava.css
+++ b/crkva/registar/static/registar/print/slava.css
@@ -207,4 +207,34 @@
     }
     .stavka__roster-role::before { content: " ("; }
     .stavka__roster-role::after  { content: ")"; }
+
+    /* Street group header (#18) */
+    .spisak__group-head {
+        list-style: none !important;
+        font-family: "PT Serif", "Source Serif Pro", Georgia, serif !important;
+        font-size: 11pt !important;
+        font-weight: 700 !important;
+        font-variant: small-caps;
+        letter-spacing: 0.04em;
+        margin: 3mm 0 0.5mm 0 !important;
+        padding: 0 0 0.5mm 0 !important;
+        border: 0 !important;
+        border-bottom: 0.6pt solid #000 !important;
+        page-break-after: avoid;
+        break-after: avoid;
+        page-break-inside: avoid;
+    }
+    .spisak__group-head i { display: none !important; }
+
+    /* Holy-water yes/no (#18) */
+    .stavka__vodica {
+        display: block !important;
+        font-size: 9pt !important;
+        margin: 0.5mm 0 0 0 !important;
+    }
+    .stavka__vodica-item + .stavka__vodica-item::before {
+        content: "   \00B7   ";
+        font-weight: 400;
+    }
+    .stavka__vodica-val { font-weight: 700 !important; }
 }

--- a/crkva/registar/templates/registar/slava_domacinstva.html
+++ b/crkva/registar/templates/registar/slava_domacinstva.html
@@ -23,9 +23,11 @@
   {% endif %}
 </div>
 
-{% if domacinstva %}
-  <ul class="spisak" id="spisak-list">
-    {% for domacinstvo in domacinstva %}
+{% if grupe %}
+  <ul class="spisak spisak--grouped" id="spisak-list">
+    {% for grupa in grupe %}
+      <li class="spisak__group-head"><i class="fa-solid fa-road"></i> {{ grupa.ulica }}</li>
+      {% for domacinstvo in grupa.domacinstva %}
       <li class="stavka stavka--slava">
         <a href="{% url 'domacinstvo_detail' uid=domacinstvo.uid %}" class="stavka-veza">
           <span class="stavka__primary">
@@ -36,6 +38,10 @@
             {% if domacinstvo.adresa %}<i class="fa-solid fa-location-dot"></i> {{ domacinstvo.adresa }}{% endif %}
             {% if domacinstvo.tel_fiksni %}{% if domacinstvo.adresa %} &middot; {% endif %}<i class="fa-solid {{ domacinstvo.tel_fiksni|phone_icon }}"></i> {{ domacinstvo.tel_fiksni|format_phone }}{% endif %}
             {% if domacinstvo.tel_mobilni %}{% if domacinstvo.adresa or domacinstvo.tel_fiksni %} &middot; {% endif %}<i class="fa-solid {{ domacinstvo.tel_mobilni|phone_icon }}"></i> {{ domacinstvo.tel_mobilni|format_phone }}{% endif %}
+          </span>
+          <span class="stavka__vodica">
+            <span class="stavka__vodica-item">Славска водица: <strong class="stavka__vodica-val{% if domacinstvo.slavska_vodica %} stavka__vodica-val--yes{% endif %}">{% if domacinstvo.slavska_vodica %}да{% else %}не{% endif %}</strong></span>
+            <span class="stavka__vodica-item">Васкршња водица: <strong class="stavka__vodica-val{% if domacinstvo.vaskrsnja_vodica %} stavka__vodica-val--yes{% endif %}">{% if domacinstvo.vaskrsnja_vodica %}да{% else %}не{% endif %}</strong></span>
           </span>
 
           {% if domacinstvo.ukucani.all %}
@@ -65,6 +71,7 @@
           {% endif %}
         </a>
       </li>
+      {% endfor %}
     {% endfor %}
   </ul>
 {% else %}

--- a/crkva/registar/tests/test_slava_view.py
+++ b/crkva/registar/tests/test_slava_view.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from kalendar.models import Slava
+from registar.models import Adresa, Domacinstvo, Osoba
 
 User = get_user_model()
 
@@ -52,3 +53,65 @@ class SlavaDomacinstvaViewTests(TestCase):
         for d in r.context["domacinstva"]:
             self.assertTrue(hasattr(d, "zivi_clanovi"))
             self.assertTrue(hasattr(d, "preminuli_clanovi"))
+
+
+class SlavaDomacinstvaGroupingTests(TestCase):
+    """Issue #18: report groups households by street and shows holy water."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.slava = Slava.objects.create(
+            naziv="Тест слава 2", mesec=6, dan=10, pokretni=False
+        )
+        gl1 = Adresa.objects.create(ulica="Главна", broj="1")
+        gl2 = Adresa.objects.create(ulica="Главна", broj="2")
+        sp = Adresa.objects.create(ulica="Споредна", broj="5")
+        Domacinstvo.objects.create(
+            domacin=Osoba.objects.create(ime="Марко", prezime="Петровић", pol="М"),
+            slava=cls.slava, adresa=gl1, slavska_vodica=True, vaskrsnja_vodica=False,
+        )
+        Domacinstvo.objects.create(
+            domacin=Osoba.objects.create(ime="Јована", prezime="Аврамовић", pol="Ж"),
+            slava=cls.slava, adresa=gl2, slavska_vodica=False, vaskrsnja_vodica=True,
+        )
+        Domacinstvo.objects.create(
+            domacin=Osoba.objects.create(ime="Лука", prezime="Јовановић", pol="М"),
+            slava=cls.slava, adresa=sp, slavska_vodica=True, vaskrsnja_vodica=True,
+        )
+        # No-address household lands in the trailing "Без улице" group.
+        Domacinstvo.objects.create(
+            domacin=Osoba.objects.create(ime="Ана", prezime="Николић", pol="Ж"),
+            slava=cls.slava,
+        )
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="grouptester", password="x")
+        self.client.force_login(self.user)
+        self.url = reverse("slava_detail", kwargs={"uid": self.slava.uid})
+
+    def test_context_groups_by_street(self):
+        r = self.client.get(self.url)
+        self.assertIn("grupe", r.context)
+        ulice = [g["ulica"] for g in r.context["grupe"]]
+        self.assertEqual(ulice, ["Главна", "Споредна", "Без улице"])
+        sizes = {g["ulica"]: len(g["domacinstva"]) for g in r.context["grupe"]}
+        self.assertEqual(sizes, {"Главна": 2, "Споредна": 1, "Без улице": 1})
+
+    def test_street_header_rendered(self):
+        r = self.client.get(self.url)
+        self.assertContains(r, "spisak__group-head")
+        self.assertContains(r, "Главна")
+        self.assertContains(r, "Споредна")
+
+    def test_holy_water_rendered_with_yes_no(self):
+        r = self.client.get(self.url)
+        self.assertContains(r, "stavka__vodica")
+        self.assertContains(r, "Славска водица")
+        self.assertContains(r, "Васкршња водица")
+        body = r.content.decode("utf-8")
+        self.assertIn("да", body)
+        self.assertIn("не", body)
+
+    def test_count_includes_all_households(self):
+        r = self.client.get(self.url)
+        self.assertEqual(r.context["count"], 4)

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -1,5 +1,7 @@
 """Views for displaying households celebrating a specific slava."""
 
+from itertools import groupby
+
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
@@ -31,9 +33,23 @@ def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
         d.zivi_clanovi = [u for u in members if not u.preminuo]
         d.preminuli_clanovi = [u for u in members if u.preminuo]
 
+    # Group households by street for the printed report (issue #18). The
+    # queryset is already ordered by adresa__ulica, so consecutive items share
+    # a street; households without an address fall into a trailing group.
+    def _street(d):
+        if d.adresa and (d.adresa.ulica or "").strip():
+            return d.adresa.ulica.strip()
+        return ""
+
+    grupe = [
+        {"ulica": ulica or "Без улице", "domacinstva": list(items)}
+        for ulica, items in groupby(domacinstva, key=_street)
+    ]
+
     context = {
         "slava": slava,
         "domacinstva": domacinstva,
+        "grupe": grupe,
         "count": len(domacinstva),
     }
 


### PR DESCRIPTION
## Захтев (#18)

Штампа домаћинстава по слави треба да садржи: груписање по улицама, презиме домаћинства, адресу, контакт, и славску + васкршњу водицу (да-не).

## Стање пре

Извештај `slava_domacinstva` (`slava/<uid>/`) је већ приказивао **презиме**, **адресу** и **контакт**, и био је **сортиран** по улици — али без видљивог груписања, и без водице.

## Промене

- [x] **Груписање по улицама** — `view` гради `grupe` по `adresa.ulica`; шаблон рендерује заглавље улице пре сваке групе. Домаћинства без адресе иду у завршну групу „Без улице".
- [x] **Презиме домаћинства** — већ постојало.
- [x] **Адреса** — већ постојала.
- [x] **Контакт** — већ постојао (фиксни/мобилни).
- [x] **Славска и васкршња водица (да-не)** — нови ред по домаћинству; поља `slavska_vodica`/`vaskrsnja_vodica` већ постоје на моделу.

Додат screen + print CSS за заглавље улице и ред водице.

## Тестови

`registar/tests/test_slava_view.py` (+4): груписање по улици и редослед (укључујући „Без улице"), приказ заглавља улице, приказ водице да/не, тачан укупан број.

Покренути циљани тестови: **8 пролаза**. Без миграција (нема промене модела).

Closes #18
