### PR TITLE
fix(registar): paginate slava households print across pages (#18)

### DIFF
--- a/crkva/registar/static/registar/print/slava.css
+++ b/crkva/registar/static/registar/print/slava.css
@@ -37,6 +37,25 @@
     }
     body > main, .u-container { padding: 0 !important; margin: 0 !important; max-width: none !important; }
 
+    /* The app shell makes html/body a viewport-height flex scroll container
+       (height:100%, display:flex, overflow-x:hidden -> overflow-y:auto), which
+       clips the printout to a single page. Restore normal block flow so the
+       list paginates across pages. */
+    html, body {
+        height: auto !important;
+        min-height: 0 !important;
+        display: block !important;
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+    }
+    body > main {
+        flex: none !important;
+        display: block !important;
+        height: auto !important;
+        overflow: visible !important;
+    }
+
     /* ---- Header: title + date, centered, no chrome ---- */
     .u-page-header {
         position: static !important;
@@ -83,6 +102,7 @@
 
     /* ---- List of households ---- */
     .spisak {
+        display: block !important;
         list-style: none !important;
         padding: 0 !important;
         margin: 0 !important;
@@ -92,6 +112,7 @@
     }
 
     .stavka {
+        display: block !important;
         page-break-inside: avoid;
         break-inside: avoid;
         list-style: none !important;


### PR DESCRIPTION
## Проблем

Штампа извештаја домаћинстава по слави је секла ставке на прелому стране и понашала се као да је цела страница једна слика (једна страна).

## Узрок

App shell који print лист није поништавао:
- `html, body` су flex scroll контејнер висине екрана (`height:100%`, `display:flex`, `overflow-x:hidden` → `overflow-y:auto`) → штампа исечена на једну страну.
- `.spisak`/`.stavka` су `display:flex` на екрану; `break-inside: avoid` је непоуздан на flex ставкама → домаћинство се цепа на пола.

## Решење (само print CSS)

- `html/body/main` → нормалан block ток, `height:auto`, `overflow:visible`.
- `.spisak`/`.stavka` → `display:block` па се `page-break-inside: avoid` поштује и листа тече кроз стране.

Без промене модела/Python-а; чиста print-CSS исправка. Везано за #18.
