### PR TITLE
perf(tenants): резолуција улоге једним упитом у контекст-процесору (#256)

### DIFF
--- a/crkva/tenants/context_processors.py
+++ b/crkva/tenants/context_processors.py
@@ -8,8 +8,7 @@ from tenants.permissions import (
     OSOBA,
     SVESTENIK,
     VENCANJE,
-    can_edit,
-    is_tenant_admin,
+    tenant_permissions,
 )
 
 
@@ -19,20 +18,23 @@ def current_tenant(request):
     Templates may use either `tenant`/`is_tenant_admin` (django-tenants
     schema-level naming) or the user-facing aliases `parohija`/
     `is_parohija_admin` interchangeably.
+
+    The role is resolved once (a single membership query) and every flag is
+    derived from it in memory, so a render costs one query rather than six.
     """
     tenant = getattr(request, "tenant", None)
     user = getattr(request, "user", None)
-    admin_flag = is_tenant_admin(user, tenant)
+    is_admin, writable = tenant_permissions(user, tenant)
     return {
         # django-tenants infrastructure naming (kept for backwards compat)
         "tenant": tenant,
-        "is_tenant_admin": admin_flag,
+        "is_tenant_admin": is_admin,
         # User-facing aliases — preferred in new templates.
         "parohija": tenant,
-        "is_parohija_admin": admin_flag,
-        "can_edit_osoba": can_edit(user, tenant, OSOBA),
-        "can_edit_domacinstvo": can_edit(user, tenant, DOMACINSTVO),
-        "can_edit_krstenje": can_edit(user, tenant, KRSTENJE),
-        "can_edit_vencanje": can_edit(user, tenant, VENCANJE),
-        "can_edit_svestenik": can_edit(user, tenant, SVESTENIK),
+        "is_parohija_admin": is_admin,
+        "can_edit_osoba": OSOBA in writable,
+        "can_edit_domacinstvo": DOMACINSTVO in writable,
+        "can_edit_krstenje": KRSTENJE in writable,
+        "can_edit_vencanje": VENCANJE in writable,
+        "can_edit_svestenik": SVESTENIK in writable,
     }

--- a/crkva/tenants/permissions.py
+++ b/crkva/tenants/permissions.py
@@ -15,6 +15,10 @@ Use the `tenant_role_required(resource)` decorator on write views and
 the `can_edit_*` flags exposed by the context processor in templates.
 For tenant-admin-only pages (e.g. user management), use
 `tenant_admin_required` instead.
+
+`can_edit`, `is_tenant_admin` and the context processor all resolve the
+caller's role through a single helper, `tenant_permissions`, so a page
+render costs one membership query instead of one per flag.
 """
 
 from __future__ import annotations
@@ -44,33 +48,42 @@ WRITE_BY_ROLE: dict[str, frozenset[str]] = {
 }
 
 
-def can_edit(user, tenant, resource: str) -> bool:
-    """True if `user` may write `resource` inside `tenant`."""
+def tenant_permissions(user, tenant) -> tuple[bool, frozenset[str]]:
+    """Resolve ``(is_admin, writable_resources)`` for ``user`` in ``tenant``.
+
+    Issues at most **one** query. `UserMembership` is unique per
+    ``(user, tenant)``, so a single active row fully determines the role.
+
+    - Anonymous users / missing tenant → ``(False, frozenset())`` (no query).
+    - Superusers → ``(True, ALL_RESOURCES)`` (no query; they need no row).
+    - Otherwise the active membership's role decides both flags.
+    """
     if user is None or not user.is_authenticated:
-        return False
+        return False, frozenset()
     if user.is_superuser:
-        return True
+        return True, ALL_RESOURCES
     if tenant is None:
-        return False
+        return False, frozenset()
     membership = UserMembership.objects.filter(
         user=user, tenant=tenant, is_active=True
     ).first()
     if membership is None:
-        return False
-    return resource in WRITE_BY_ROLE.get(membership.role, frozenset())
+        return False, frozenset()
+    return membership.role == Role.ADMIN, WRITE_BY_ROLE.get(
+        membership.role, frozenset()
+    )
+
+
+def can_edit(user, tenant, resource: str) -> bool:
+    """True if `user` may write `resource` inside `tenant`."""
+    _is_admin, writable = tenant_permissions(user, tenant)
+    return resource in writable
 
 
 def is_tenant_admin(user, tenant) -> bool:
     """True if `user` has Админ role in `tenant`, or is a superuser."""
-    if user is None or not user.is_authenticated:
-        return False
-    if user.is_superuser:
-        return True
-    if tenant is None:
-        return False
-    return UserMembership.objects.filter(
-        user=user, tenant=tenant, role=Role.ADMIN, is_active=True
-    ).exists()
+    is_admin, _writable = tenant_permissions(user, tenant)
+    return is_admin
 
 
 def tenant_role_required(resource: str):

--- a/crkva/tenants/tests/test_permissions.py
+++ b/crkva/tenants/tests/test_permissions.py
@@ -163,3 +163,46 @@ class ContextProcessorTests(TestCase):
         self.assertTrue(ctx["can_edit_osoba"])
         self.assertTrue(ctx["can_edit_krstenje"])
         self.assertFalse(ctx["can_edit_svestenik"])
+
+    def test_context_processor_issues_single_membership_query(self):
+        # Regression for #256: every can_edit_* flag + is_admin derive from a
+        # single membership lookup, not one query per flag (was ~6 per render).
+        # We count only queries hitting the membership table, because
+        # django-tenants emits a "SET search_path" alongside each query in the
+        # test harness which would otherwise inflate a raw query count.
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from tenants.context_processors import current_tenant
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = self.clerk
+        request.tenant = self.tenant
+        with CaptureQueriesContext(connection) as captured:
+            current_tenant(request)
+        membership_queries = [
+            q
+            for q in captured.captured_queries
+            if "tenants_user_membership" in q["sql"]
+        ]
+        self.assertEqual(
+            len(membership_queries),
+            1,
+            "context processor must resolve the role in one membership query "
+            f"(got {len(membership_queries)})",
+        )
+
+    def test_context_processor_superuser_needs_no_query(self):
+        from tenants.context_processors import current_tenant
+
+        su = User.objects.create_superuser(
+            username="su256", password="x", email="su256@test"
+        )
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = su
+        request.tenant = self.tenant
+        with self.assertNumQueries(0):
+            ctx = current_tenant(request)
+        self.assertTrue(ctx["can_edit_osoba"])
+        self.assertTrue(ctx["is_tenant_admin"])


### PR DESCRIPTION
Затвара #256.

## Проблем
`current_tenant` контекст-процесор се извршава при сваком рендеру шаблона и за истог корисника/закупца је слао **до 6 истоветних** упита у базу: `is_tenant_admin` (1) + `can_edit` × 5 (5), сваки као засебан `UserMembership` упит — поврх упита који middleware већ ради.

## Решење
- Нови помоћник `tenant_permissions(user, tenant)` враћа `(is_admin, writable_resources)` у **једном** упиту.
- `can_edit` и `is_tenant_admin` сада делегирају на њега (уклоњено дуплирање логике провере чланства).
- Контекст-процесор разрешава улогу једном и све `can_edit_*` заставице рачуна у меморији.

`UserMembership` је јединствен по `(user, tenant)` (`unique_together`), па је сажимање `role`-филтрираног `exists()` у једно дохватање **очувано у понашању**.

## Резултат
6 упита по рендеру → **1**. За суперкориснике и анонимне → **0** упита.

## Тестови
- Нови регресиони тест: тачно један упит над табелом чланства по рендеру.
- Нови тест: суперкорисник не прави ниједан упит.
- Цео сет пролази (751 тест, `manage.py test registar.tests tenants.tests kalendar.tests`).
