### PR TITLE
feat(registar): филтер домаћинстава по слави и парохији свештеника (#27)

### DIFF
--- a/crkva/registar/templates/registar/slava_domacinstva.html
+++ b/crkva/registar/templates/registar/slava_domacinstva.html
@@ -23,6 +23,17 @@
   {% endif %}
 </div>
 
+<form method="get" class="vodica-toolbar" id="slava-svestenik-form">
+  <label for="svestenik-select" class="vodica-toolbar__label">Свештеник:</label>
+  <select name="svestenik" id="svestenik-select" class="list-toolbar__select" onchange="document.getElementById('slava-svestenik-form').submit()">
+    <option value="">— сва домаћинства —</option>
+    {% for s in svestenici %}
+      <option value="{{ s.pk }}" {% if selected_id == s.pk|stringformat:"s" %}selected{% endif %}>{{ s.ime }} {{ s.prezime }}{% if s.parohija %} ({{ s.parohija }}){% endif %}</option>
+    {% endfor %}
+  </select>
+  {% if svestenik and svestenik.parohija %}<span class="vodica-report__sub">територија парохије {{ svestenik.parohija }}</span>{% endif %}
+</form>
+
 {% if grupe %}
   <ul class="spisak spisak--grouped" id="spisak-list">
     {% for grupa in grupe %}
@@ -75,9 +86,21 @@
     {% endfor %}
   </ul>
 {% else %}
-  <div class="spisak__empty">
-    Нема домаћинстава која славе {{ slava.naziv }}.
-  </div>
+  {% if nema_parohije %}
+    <div class="spisak__empty">
+      Свештеник {{ svestenik.ime }} {{ svestenik.prezime }} нема додељену парохију, па нема територију за приказ.
+      <br><small>Парохија се поставља на картици свештеника.</small>
+    </div>
+  {% elif svestenik %}
+    <div class="spisak__empty">
+      Нема домаћинстава која славе {{ slava.naziv }} на територији парохије {{ svestenik.parohija }}.
+      <br><small>Улице се додељују парохији преко адресе (поље „свештеник (улица)“).</small>
+    </div>
+  {% else %}
+    <div class="spisak__empty">
+      Нема домаћинстава која славе {{ slava.naziv }}.
+    </div>
+  {% endif %}
 {% endif %}
 
 {% endblock %}

--- a/crkva/registar/tests/test_slava_view.py
+++ b/crkva/registar/tests/test_slava_view.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from kalendar.models import Slava
-from registar.models import Adresa, Domacinstvo, Osoba
+from registar.models import Adresa, Domacinstvo, Osoba, Parohija, Svestenik
 
 User = get_user_model()
 
@@ -68,15 +68,24 @@ class SlavaDomacinstvaGroupingTests(TestCase):
         sp = Adresa.objects.create(ulica="Споредна", broj="5")
         Domacinstvo.objects.create(
             domacin=Osoba.objects.create(ime="Марко", prezime="Петровић", pol="М"),
-            slava=cls.slava, adresa=gl1, slavska_vodica=True, vaskrsnja_vodica=False,
+            slava=cls.slava,
+            adresa=gl1,
+            slavska_vodica=True,
+            vaskrsnja_vodica=False,
         )
         Domacinstvo.objects.create(
             domacin=Osoba.objects.create(ime="Јована", prezime="Аврамовић", pol="Ж"),
-            slava=cls.slava, adresa=gl2, slavska_vodica=False, vaskrsnja_vodica=True,
+            slava=cls.slava,
+            adresa=gl2,
+            slavska_vodica=False,
+            vaskrsnja_vodica=True,
         )
         Domacinstvo.objects.create(
             domacin=Osoba.objects.create(ime="Лука", prezime="Јовановић", pol="М"),
-            slava=cls.slava, adresa=sp, slavska_vodica=True, vaskrsnja_vodica=True,
+            slava=cls.slava,
+            adresa=sp,
+            slavska_vodica=True,
+            vaskrsnja_vodica=True,
         )
         # No-address household lands in the trailing "Без улице" group.
         Domacinstvo.objects.create(
@@ -115,3 +124,70 @@ class SlavaDomacinstvaGroupingTests(TestCase):
     def test_count_includes_all_households(self):
         r = self.client.get(self.url)
         self.assertEqual(r.context["count"], 4)
+
+
+class SlavaDomacinstvaPriestFilterTests(TestCase):
+    """Issue #27: optional ?svestenik= narrows households to the priest's parish."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.slava = Slava.objects.create(
+            naziv="Аранђеловдан", mesec=11, dan=21, pokretni=False
+        )
+        cls.p3 = Parohija.objects.create(naziv="3")
+        cls.p9 = Parohija.objects.create(naziv="9")
+        cls.sv3 = Svestenik.objects.create(
+            ime="Петар", prezime="Тројка", zvanje="јереј", parohija=cls.p3
+        )
+        cls.sv_np = Svestenik.objects.create(
+            ime="Без", prezime="Парохије", zvanje="јереј", parohija=None
+        )
+        a3 = Adresa.objects.create(ulica="Главна", broj="1", svestenik=cls.sv3)
+        a9 = Adresa.objects.create(
+            ulica="Друга",
+            broj="2",
+            svestenik=Svestenik.objects.create(
+                ime="Павле", prezime="Деветка", zvanje="јереј", parohija=cls.p9
+            ),
+        )
+
+        def hh(ime, adresa):
+            o = Osoba.objects.create(ime=ime, prezime="Тест", pol="М")
+            return Domacinstvo.objects.create(domacin=o, adresa=adresa, slava=cls.slava)
+
+        cls.h3 = hh("Аца", a3)  # parish 3
+        cls.h9 = hh("Бора", a9)  # parish 9
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="p27", password="x")
+        self.client.force_login(self.user)
+        self.url = reverse("slava_detail", kwargs={"uid": self.slava.uid})
+
+    def test_no_filter_shows_all_parishes(self):
+        r = self.client.get(self.url)
+        self.assertEqual(r.context["count"], 2)
+        self.assertIsNone(r.context["svestenik"])
+
+    def test_filter_narrows_to_priest_parish(self):
+        r = self.client.get(self.url, {"svestenik": self.sv3.pk})
+        self.assertEqual(r.context["count"], 1)
+        self.assertEqual({d.uid for d in r.context["domacinstva"]}, {self.h3.uid})
+
+    def test_filter_resolves_by_parish_not_individual_priest(self):
+        # A different priest in the SAME parish sees the same households (#26).
+        sv3b = Svestenik.objects.create(
+            ime="Лука", prezime="Тројкић", zvanje="јереј", parohija=self.p3
+        )
+        r = self.client.get(self.url, {"svestenik": sv3b.pk})
+        self.assertEqual(r.context["count"], 1)
+        self.assertEqual({d.uid for d in r.context["domacinstva"]}, {self.h3.uid})
+
+    def test_priest_without_parish_shows_nothing(self):
+        r = self.client.get(self.url, {"svestenik": self.sv_np.pk})
+        self.assertEqual(r.context["count"], 0)
+        self.assertTrue(r.context["nema_parohije"])
+
+    def test_priest_dropdown_is_rendered(self):
+        r = self.client.get(self.url)
+        self.assertContains(r, "slava-svestenik-form")
+        self.assertContains(r, "Петар")

--- a/crkva/registar/views/domacinstvo_view.py
+++ b/crkva/registar/views/domacinstvo_view.py
@@ -14,32 +14,8 @@ from registar.forms import DomacinstvoForm
 from registar.forms.domacinstvo_form import UkucaninFormSet
 from registar.models import Domacinstvo, Svestenik
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from registar.views.territory import by_parish_filter, resolve_svestenik
 from tenants.permissions import tenant_role_required
-
-
-def _resolve_svestenik(request: HttpRequest):
-    """Свештеник из ?svestenik=<uid>, или None."""
-    val = (request.GET.get("svestenik") or "").strip()
-    if not val:
-        return None
-    try:
-        return Svestenik.objects.filter(pk=int(val)).first()
-    except (ValueError, TypeError):
-        return None
-
-
-def _by_parish_filter(qs, svestenik):
-    """Домаћинства чија адреса припада парохији изабраног свештеника (#26).
-
-    Улице су додељене свештеницима, али свештеници ротирају — стабилна
-    јединица је парохија, па филтрирамо по `adresa.svestenik.parohija`.
-    """
-    if svestenik is not None and svestenik.parohija_id:
-        return qs.filter(adresa__svestenik__parohija=svestenik.parohija_id)
-    if svestenik is not None:
-        # Свештеник без парохије — ништа да се прикаже.
-        return qs.none()
-    return qs
 
 
 @tenant_role_required("domacinstvo")
@@ -86,7 +62,7 @@ class SpisakDomacinsta(
             .prefetch_related("ukucani", "ukucani__osoba")
             .all()
         )
-        qs = _by_parish_filter(qs, _resolve_svestenik(self.request))
+        qs = by_parish_filter(qs, resolve_svestenik(self.request))
         return self.get_search_queryset(qs)
 
     def get_context_data(self, **kwargs):
@@ -96,7 +72,7 @@ class SpisakDomacinsta(
             d.zivi_clanovi = [u for u in members if not u.preminuo]
             d.preminuli_clanovi = [u for u in members if u.preminuo]
         # Priest filter controls (issue #26).
-        svestenik = _resolve_svestenik(self.request)
+        svestenik = resolve_svestenik(self.request)
         context["svestenik_filter_options"] = Svestenik.objects.order_by(
             "prezime", "ime"
         )
@@ -184,11 +160,11 @@ def domacinstva_print(request: HttpRequest) -> HttpResponse:
     домаћинства парохије изабраног свештеника (адреса + телефони), погодно за
     обилазак на терену.
     """
-    svestenik = _resolve_svestenik(request)
+    svestenik = resolve_svestenik(request)
     domacinstva = []
     if svestenik is not None and svestenik.parohija_id:
         domacinstva = list(
-            _by_parish_filter(
+            by_parish_filter(
                 Domacinstvo.objects.select_related(
                     "domacin", "adresa", "adresa__svestenik"
                 ),

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -5,20 +5,34 @@ from itertools import groupby
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
-from registar.models import Domacinstvo, Slava
+from registar.models import Domacinstvo, Slava, Svestenik
+from registar.views.territory import by_parish_filter, resolve_svestenik
 
 
 @login_required
 def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
-    """Приказује домаћинства која славе одређену славу."""
+    """Приказује домаћинства која славе одређену славу.
+
+    Опциони филтер `?svestenik=<uid>` сужава приказ на парохију изабраног
+    свештеника (славска водица по свештенику, #27) — корисно да свештеник
+    испланира обилазак свечара дате славе по улицама своје парохије.
+    """
     slava = get_object_or_404(Slava, uid=uid)
 
-    # Get all households celebrating this slava
+    svestenici = list(Svestenik.objects.order_by("prezime", "ime"))
+    svestenik = resolve_svestenik(request)
+    selected_id = (request.GET.get("svestenik") or "").strip()
+    nema_parohije = svestenik is not None and not svestenik.parohija_id
+
+    # Households celebrating this slava, optionally narrowed to the selected
+    # priest's parish (territory resolved by parish, not by priest — #26).
     domacinstva = list(
-        Domacinstvo.objects.filter(slava=slava)
-        .select_related("domacin", "adresa")
-        .prefetch_related("ukucani", "ukucani__osoba")
-        .order_by(
+        by_parish_filter(
+            Domacinstvo.objects.filter(slava=slava)
+            .select_related("domacin", "adresa")
+            .prefetch_related("ukucani", "ukucani__osoba"),
+            svestenik,
+        ).order_by(
             "adresa__ulica",
             "adresa__broj",
             "domacin__prezime",
@@ -51,6 +65,10 @@ def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
         "domacinstva": domacinstva,
         "grupe": grupe,
         "count": len(domacinstva),
+        "svestenici": svestenici,
+        "svestenik": svestenik,
+        "selected_id": selected_id,
+        "nema_parohije": nema_parohije,
     }
 
     return render(request, "registar/slava_domacinstva.html", context)

--- a/crkva/registar/views/territory.py
+++ b/crkva/registar/views/territory.py
@@ -1,0 +1,39 @@
+"""Свештеник → територија (парохија) филтер за приказе домаћинстава (#26).
+
+Улице су додељене свештеницима преко `Adresa.svestenik`, али свештеници
+ротирају — стабилна јединица територије је ПАРОХИЈА. Зато домаћинства
+филтрирамо по парохији изабраног свештеника, а не по самом свештенику.
+
+Дели се између приказа домаћинстава (`domacinstvo_view`), васкршње водице
+(#26) и славске водице по свештенику (#27).
+"""
+
+from __future__ import annotations
+
+from django.http import HttpRequest
+from registar.models import Svestenik
+
+
+def resolve_svestenik(request: HttpRequest):
+    """Свештеник из ?svestenik=<uid>, или None ако није изабран/невалидан."""
+    val = (request.GET.get("svestenik") or "").strip()
+    if not val:
+        return None
+    try:
+        return Svestenik.objects.filter(pk=int(val)).first()
+    except (ValueError, TypeError):
+        return None
+
+
+def by_parish_filter(qs, svestenik):
+    """Сужава `qs` домаћинстава на парохију изабраног свештеника (#26).
+
+    - без свештеника → `qs` непромењен (сва домаћинства),
+    - свештеник са парохијом → `adresa.svestenik.parohija` == његова парохија,
+    - свештеник без парохије → празан `qs` (нема територију за приказ).
+    """
+    if svestenik is not None and svestenik.parohija_id:
+        return qs.filter(adresa__svestenik__parohija=svestenik.parohija_id)
+    if svestenik is not None:
+        return qs.none()
+    return qs


### PR DESCRIPTION
Део #27.

## Шта
Страница домаћинстава за славу (`slava/<uid>/`) сада прихвата опциони `?svestenik=<uid>` који сужава списак на **парохију изабраног свештеника**, да свештеник може да испланира обилазак свечара дате славе **по улицама** своје територије. Без параметра — понашање је непромењено (сва домаћинства те славе).

## Како
- Територија се разрешава по **парохији**, не по појединачном свештенику (свештеници ротирају; стабилна јединица је парохија) — исти механизам као #26.
- Помоћници `resolve_svestenik` / `by_parish_filter` извучени у нови `registar/views/territory.py` и деле их `domacinstvo_view` и `slava_view` (уклоњене дупле локалне копије — чисти и налаз из ревизије кода).
- Шаблон добија падајући избор свештеника (GET, аутоматски submit) и поруке празног стања свесне филтера (нема парохије / нема свечара у парохији / нема уопште).

## Тестови
5 нових: без филтера приказује све, филтер сужава на парохију, разрешавање по парохији а не по свештенику, свештеник без парохије не приказује ништа, падајући мени се рендерује. Цео сет пролази (**756 тестова, 0 пада**).

## Напомена
При раду на овоме уочен је засебан баг — дупли празници Васкршњег циклуса (нпр. Васкрс `slava/101/` покретни и `slava/370/` фиксни). Пријављено као #259 (решавамо касније).
