### PR TITLE
ci(versioning): робустан auto-tag по префиксу гране + заштитни механизми

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,14 +1,17 @@
 name: Auto-tag on merge
 
-# Bumps the version tag on every PR merge into main, following our convention:
-#   feature/<slug>  → minor bump (0.X.0 → 0.(X+1).0)
-#   fix/<slug>      → patch bump (0.X.Y → 0.X.(Y+1))
-# Any other branch shape: skipped (a notice is logged).
+# Bumps the version tag on every PR merge into main, from the head-branch prefix:
+#   feature/, feat/                                   → minor bump
+#   fix/, bugfix/, hotfix/, perf/, refactor/,
+#   chore/, docs/, build/, ci/, test/, style/         → patch bump
+#   anything else                                     → job FAILS (no tag)
 #
-# The baseline is whatever's the latest semver tag reachable from main. Legacy
-# tags that aren't reachable (e.g. 1.0.0 / 2.0.0 on the pre-divergence history)
-# are ignored. When the team wants to bump the major (e.g. 1.0.0), tag manually
-# once and this workflow picks it up from there.
+# Failing loudly on an unrecognized prefix (instead of silently skipping) makes a
+# mis-named branch impossible to miss — a silent skip previously let several
+# merges land untagged. See CONTRIBUTING.md.
+#
+# Baseline is the latest semver tag reachable from main; legacy/divergent tags
+# are ignored. To bump the major, tag manually once and this picks up from there.
 
 on:
   pull_request:
@@ -33,23 +36,22 @@ jobs:
         run: |
           BRANCH="${{ github.event.pull_request.head.ref }}"
           echo "head branch: $BRANCH"
-          if [[ "$BRANCH" == feature/* ]]; then
-            echo "type=minor" >> "$GITHUB_OUTPUT"
-          elif [[ "$BRANCH" == fix/* ]]; then
-            echo "type=patch" >> "$GITHUB_OUTPUT"
-          else
-            echo "type=none" >> "$GITHUB_OUTPUT"
-            echo "::notice::Branch '$BRANCH' is not feature/* or fix/* — no tag created"
-          fi
+          PREFIX="${BRANCH%%/*}"
+          case "$PREFIX" in
+            feature|feat)
+              echo "type=minor" >> "$GITHUB_OUTPUT" ;;
+            fix|bugfix|hotfix|perf|refactor|chore|docs|build|ci|test|style)
+              echo "type=patch" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Branch '$BRANCH' has an unrecognized prefix '$PREFIX/'. Allowed: feature/|feat/ (minor); fix/|bugfix/|hotfix/|perf/|refactor/|chore/|docs/|build/|ci/|test/|style/ (patch). See CONTRIBUTING.md. No tag created."
+              exit 1 ;;
+          esac
 
       - name: Compute next version
-        if: steps.bump.outputs.type != 'none'
         id: ver
         run: |
           git fetch --tags --quiet
           # Only consider semver tags that are ancestors of the current main HEAD.
-          # This intentionally ignores legacy tags (e.g. 1.0.0 / 2.0.0) sitting
-          # on a divergent history.
           LATEST=$(git tag --merged HEAD --sort=-v:refname \
                    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
                    | head -n 1)
@@ -67,7 +69,6 @@ jobs:
           echo "::notice::Tagging $LATEST → $NEW (${{ steps.bump.outputs.type }} bump)"
 
       - name: Create + push tag
-        if: steps.bump.outputs.type != 'none'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,16 @@ repos:
         - id: check-merge-conflict
         - id: requirements-txt-fixer
 
+  # Enforce branch naming so auto-tag can version every merge (CONTRIBUTING.md).
+  - repo: local
+    hooks:
+      - id: branch-name
+        name: branch name follows the versioning convention
+        entry: scripts/check_branch_name.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+
   # Python code formatting and linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Доприношење — начин рада (ways of working)
+
+Канонска правила развојног тока за **spc-registar**. README даје кратак преглед; овде су детаљи.
+
+## Гранање
+
+Гранај од `main`. Префикс гране одређује како се верзија подиже при мерџу (види [Верзионисање](#верзионисање)):
+
+| Префикс | Бамп | За шта |
+|---|---|---|
+| `feature/`, `feat/` | **minor** | нова функционалност |
+| `fix/`, `bugfix/`, `hotfix/` | **patch** | исправке грешака |
+| `perf/`, `refactor/`, `chore/`, `docs/`, `build/`, `ci/`, `test/`, `style/` | **patch** | одржавање, перформансе, документација, алат |
+
+- Препоручено именовање: `feature/<кратки-опис>` или `fix/<број-issue>-<опис>` (нпр. `fix/256-context-processor`).
+- Грана **`bug`**-означеног issue-а иде у `fix/`; функционалност/`enhancement` у `feature/`.
+- **Сваки други префикс ће оборити auto-tag** при мерџу (намерно — да се погрешно име не превиди). Не комитуј директно на `main`.
+
+## Верзионисање
+
+`.github/workflows/auto-tag.yml` подиже семвер таг при сваком мерџу PR-а у `main`, на основу префикса гране (табела горе). Непознат префикс **обара** job (нема тихог прескакања). Основа је најновији `X.Y.Z` таг достижан са `main`; за major бамп, поставите таг ручно једном.
+
+## Поруке комита
+
+Conventional Commits (проверава `conventional-pre-commit`):
+
+```
+<тип>(<опсег>): <опис>
+```
+
+Дозвољени типови: `feat fix refactor docs test chore ci perf style build revert`. Без `Co-authored-by:` трејлера (хук `no-coauthored-by` га одбија).
+
+## pre-commit
+
+Инсталирај једном, па ради аутоматски:
+
+```
+pre-commit install                       # активира git хукове (pre-commit + commit-msg)
+pre-commit run --files <измењени фајлови> # ручно пре пуша
+```
+
+Хук `branch-name` проверава конвенцију именовања гране (једнократно заобиђи са `ALLOW_BRANCH=1 git commit ...`). Остали хукови: ruff, isort, autoflake, pylint, biome (CSS/JS), djlint (темплејти), Django тестови.
+
+## Тестови
+
+```
+python crkva/manage.py test registar.tests tenants.tests kalendar.tests --parallel 1
+```
+
+Покрећи из корена репозиторијума (неки тестови читају статичке фајлове релативно на радни директоријум). Више: [docs/testing.md](docs/testing.md).
+
+## Pull Request
+
+1. Направи грану по конвенцији.
+2. `pre-commit run --files <измењени>` и тестови зелени.
+3. Отвори PR на `main`. При мерџу `auto-tag` подиже верзију.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@
 
 ## Доприношење
 
-1. Направите гранау по конвенцији: `feature/<кратки-опис>` или `fix/<кратки-опис>`
+1. Направите грану по конвенцији: `feature/<кратки-опис>` (minor) или `fix/<кратки-опис>` (patch). Остали префикси и детаљи: [CONTRIBUTING.md](CONTRIBUTING.md).
 2. Пре пуша покрените: `pre-commit run --files <измењени фајлови>`
 3. Отворите Pull Request на главној грани (`main`); auto-tag workflow ће подићи семвер при мерџу (feature → minor, fix → patch)
 
-Више о развојном току: [docs/testing.md](docs/testing.md).
+Више: [CONTRIBUTING.md](CONTRIBUTING.md) (начин рада), [docs/testing.md](docs/testing.md) (тестови).
 
 ## Лиценца
 

--- a/scripts/check_branch_name.sh
+++ b/scripts/check_branch_name.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Enforce the branch-naming convention so auto-tag can version every merge.
+# Prefixes mirror .github/workflows/auto-tag.yml. See CONTRIBUTING.md.
+#
+# Exempt: main/master and detached HEAD (rebase, bisect, CI checkout).
+# One-off escape hatch:  ALLOW_BRANCH=1 git commit ...
+set -euo pipefail
+
+branch="$(git symbolic-ref --short -q HEAD || true)"
+
+case "$branch" in
+  "" | main | master) exit 0 ;;
+esac
+
+[ -n "${ALLOW_BRANCH:-}" ] && exit 0
+
+prefix="${branch%%/*}"
+case "$prefix" in
+  feature | feat | fix | bugfix | hotfix | perf | refactor | chore | docs | build | ci | test | style)
+    exit 0 ;;
+esac
+
+cat >&2 <<MSG
+✗ Грана "$branch" не прати конвенцију именовања (auto-tag је не може верзионисати).
+  Дозвољени префикси:
+    feature/  feat/                                  → minor
+    fix/  bugfix/  hotfix/  perf/  refactor/
+    chore/  docs/  build/  ci/  test/  style/        → patch
+  Преименуј грану, нпр:  git branch -m feature/${branch#*/}
+  Једнократно заобиђи:   ALLOW_BRANCH=1 git commit ...
+  Детаљи:                CONTRIBUTING.md
+MSG
+exit 1


### PR DESCRIPTION
## Зашто
`auto-tag` је **тихо прескакао** сваку грану која није `feature/*` или `fix/*`, па су неки мерџеви (нпр. #258, #260) ушли у `main` **без таг-а** (отуда ручни catch-up таг `2.47.0`). Тихи прескок је сакрио проблем.

## Шта
- **Робуснији `auto-tag`**: мапира уобичајене префиксе — `feature|feat` → **minor**; `fix|bugfix|hotfix|perf|refactor|chore|docs|build|ci|test|style` → **patch** — а на **непознат** префикс **обара** job (без тихог прескакања).
- **pre-commit хук `branch-name`** (`scripts/check_branch_name.sh`) одбија комит на грани која не прати конвенцију (`ALLOW_BRANCH=1` за једнократни заобилазак; `main`/`master`/detached изузети). Тестирано: пролази на `fix/*`, обара `garbage/x`.
- **`CONTRIBUTING.md`** — начин рада (гранање, верзионисање, поруке комита, pre-commit, тестови); линкован из README-а.

## Напомена
Изабран је CI-без-провере приступ — рана повратна информација иде преко локалног pre-commit хука (захтева `pre-commit install`), а `auto-tag` је ауторитативна брана при мерџу (црвен job ако је префикс непознат).

Произашло из дискусије о промашеним таговима за #256/#27.
