### PR TITLE
fix(registar): у филтеру славе само свештеници са парохијом (#27)

### DIFF
--- a/crkva/registar/tests/test_slava_view.py
+++ b/crkva/registar/tests/test_slava_view.py
@@ -191,3 +191,12 @@ class SlavaDomacinstvaPriestFilterTests(TestCase):
         r = self.client.get(self.url)
         self.assertContains(r, "slava-svestenik-form")
         self.assertContains(r, "Петар")
+
+    def test_dropdown_excludes_priests_without_parish(self):
+        # The filter narrows by parish, so a parish-less priest can filter
+        # nothing — he must not appear in the dropdown (#27 follow-up).
+        r = self.client.get(self.url)
+        ids = {s.pk for s in r.context["svestenici"]}
+        self.assertIn(self.sv3.pk, ids)
+        self.assertNotIn(self.sv_np.pk, ids)
+        self.assertNotContains(r, "Без Парохије")

--- a/crkva/registar/views/slava_view.py
+++ b/crkva/registar/views/slava_view.py
@@ -19,7 +19,13 @@ def slava_domacinstva(request: HttpRequest, uid: int) -> HttpResponse:
     """
     slava = get_object_or_404(Slava, uid=uid)
 
-    svestenici = list(Svestenik.objects.order_by("prezime", "ime"))
+    # Only priests with a parish can drive the territory filter (we filter
+    # households by the priest's parish), so omit parish-less priests (#27).
+    svestenici = list(
+        Svestenik.objects.filter(parohija__isnull=False)
+        .select_related("parohija")
+        .order_by("prezime", "ime")
+    )
     svestenik = resolve_svestenik(request)
     selected_id = (request.GET.get("svestenik") or "").strip()
     nema_parohije = svestenik is not None and not svestenik.parohija_id


### PR DESCRIPTION
Решава #27.

### Проблем
У филтеру „Свештеник“ на приказу славских домаћинстава (`/slava/<uid>/`) падајући мени је нудио **све** свештенике, укључујући и оне **без парохије**. Пошто се домаћинства филтрирају по **парохији** свештеника, избор свештеника без парохије не филтрира ништа (празан приказ) — бескорисна ставка у менију.

### Решење
- Падајући мени сада приказује **само свештенике који имају парохију** (`parohija__isnull=False`).
- Додат `select_related("parohija")` да се избегне N+1 упит при исписивању парохије уз име свештеника.

Логика самог филтрирања (`by_parish_filter`, #26) остаје непромењена — заштита за свештеника без парохије и даље постоји ако се `?svestenik=` зада ручно.

### Тестови
- Нови `test_dropdown_excludes_priests_without_parish` (свештеник без парохије није у `svestenici` нити у HTML-у).
- Сви постојећи тестови приказа славе пролазе (14/14).
