### PR TITLE
fix(settings): поверење у Caddy proxy за HTTPS/CSRF

### DIFF
--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -39,6 +39,14 @@ DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 ALLOWED_HOSTS: List[str] = ["*"]
 ALLOWED_HOSTS.extend(filter(None, os.environ.get("ALLOWED_HOSTS", "").split(",")))
 
+# Behind Caddy, which terminates TLS and reverse-proxies plain HTTP to
+# gunicorn. Trust its X-Forwarded-Proto header so request.is_secure(),
+# CSRF origin checks, and secure cookies work over the HTTPS hostname.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+CSRF_TRUSTED_ORIGINS = list(
+    filter(None, os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(","))
+)
+
 # Application definition
 
 # django-tenants: SHARED_APPS live in the public schema (visible to every


### PR DESCRIPTION
## Проблем
Апликација иза Caddy-ја (TLS терминација → обичан HTTP ка gunicorn-у) одбијала је POST захтеве на јавном HTTPS хосту са „CSRF верификација није прошла. Захтев одбијен." Django није препознавао да је захтев HTTPS, па је CSRF провера порекла падала.

## Решење
Додат минималан proxy-aware блок у `settings.py` (без тврдо кодираног домена):
```python
SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
CSRF_TRUSTED_ORIGINS = list(
    filter(None, os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(","))
)
```
- `SECURE_PROXY_SSL_HEADER`: веруј `X-Forwarded-Proto` од Caddy-ја → `request.is_secure()`, безбедни колачићи и CSRF раде преко HTTPS хоста.
- `CSRF_TRUSTED_ORIGINS`: чита се из окружења; **домен се не комитује** — само код који чита env.

Вредност остаје у `.env` на серверу:
```
CSRF_TRUSTED_ORIGINS=https://crkva.46-224-30-151.sslip.io
```
(више домена → раздвојити зарезом)

## Зашто комит
Овај код је до сада био само неулоговани локални измена на серверу — сваки `git checkout`/reset/нов клон би га обрисао и CSRF би поново падао. Код не садржи тајне; вредност домена остаје у `.env`.

## Тест
`manage.py check` пролази. Пријава на https://crkva.46-224-30-151.sslip.io ради.

Напомена (ван опсега): на серверу је тренутно `DEBUG=True` — препоручује се `DEBUG=0` у `.env` за јавни HTTPS.
