### PR TITLE
perf(tenants): кеширај чланство на захтеву (#256)

### DIFF
--- a/crkva/tenants/middleware.py
+++ b/crkva/tenants/middleware.py
@@ -17,6 +17,8 @@ from django.db import connection
 from django.http import HttpRequest, HttpResponse
 from django_tenants.utils import schema_exists
 
+from tenants.permissions import prime_tenant_permissions
+
 SESSION_TENANT_KEY = "active_tenant_id"
 logger = logging.getLogger(__name__)
 
@@ -29,8 +31,12 @@ class SessionTenantMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         prior_tenant = getattr(connection, "tenant", None)
-        tenant = self._resolve_tenant(request)
+        tenant, membership = self._resolve_tenant(request)
         request.tenant = tenant
+        # The membership loaded to route the schema also determines the user's
+        # permissions; seed the per-request cache so the context processor and
+        # can_edit/is_tenant_admin reuse it instead of re-querying (#256).
+        prime_tenant_permissions(getattr(request, "user", None), tenant, membership)
         self._activate(tenant)
         try:
             return self.get_response(request)
@@ -39,24 +45,28 @@ class SessionTenantMiddleware:
 
     @staticmethod
     def _resolve_tenant(request: HttpRequest):
+        """Return ``(tenant, membership)``.
+
+        ``membership`` is the caller's active ``UserMembership`` in the resolved
+        tenant when known (so callers can prime the permission cache), or
+        ``None`` for superusers (no row needed), anonymous users, or when the
+        user has no active membership in the resolved tenant.
+        """
         from tenants.models import Tenant, UserMembership
 
         user = getattr(request, "user", None)
         is_authenticated = user is not None and user.is_authenticated
         is_superuser = is_authenticated and user.is_superuser
 
-        def _may_access(tenant) -> bool:
-            # Superusers may enter any parish; everyone else needs an *active*
-            # membership in that specific tenant. A deactivated membership
-            # locks the user out of this parish only — never others, and
-            # never the shared User.is_active flag.
-            if is_superuser:
-                return True
+        def _membership(tenant):
+            # The single active membership for (user, tenant), or None. A
+            # deactivated membership locks the user out of this parish only —
+            # never others, and never the shared User.is_active flag.
             if not is_authenticated:
-                return False
+                return None
             return UserMembership.objects.filter(
                 user=user, tenant=tenant, is_active=True
-            ).exists()
+            ).first()
 
         session_tid = (
             request.session.get(SESSION_TENANT_KEY)
@@ -69,8 +79,12 @@ class SessionTenantMiddleware:
             except Tenant.DoesNotExist:
                 request.session.pop(SESSION_TENANT_KEY, None)
             else:
-                if _may_access(tenant):
-                    return tenant
+                # Superusers may enter any parish without a membership row.
+                if is_superuser:
+                    return tenant, None
+                membership = _membership(tenant)
+                if membership is not None:
+                    return tenant, membership
                 request.session.pop(SESSION_TENANT_KEY, None)
 
         if is_authenticated:
@@ -84,12 +98,14 @@ class SessionTenantMiddleware:
             )
             if membership is not None:
                 request.session[SESSION_TENANT_KEY] = membership.tenant_id
-                return membership.tenant
+                return membership.tenant, membership
 
+        # Fallback: the default parish. An authenticated user reaching here has
+        # no active membership anywhere, so (correctly) no permissions in it.
         try:
-            return Tenant.objects.get(is_default=True, is_active=True)
+            return Tenant.objects.get(is_default=True, is_active=True), None
         except Tenant.DoesNotExist:
-            return None
+            return None, None
 
     @staticmethod
     def _activate(tenant) -> None:

--- a/crkva/tenants/permissions.py
+++ b/crkva/tenants/permissions.py
@@ -48,10 +48,53 @@ WRITE_BY_ROLE: dict[str, frozenset[str]] = {
 }
 
 
+def _perms_from_membership(membership) -> tuple[bool, frozenset[str]]:
+    """Derive ``(is_admin, writable_resources)`` from a membership row."""
+    if membership is None:
+        return False, frozenset()
+    return membership.role == Role.ADMIN, WRITE_BY_ROLE.get(
+        membership.role, frozenset()
+    )
+
+
+def _perm_cache(user) -> dict:
+    """Per-request cache of resolved permissions, keyed by tenant pk.
+
+    Stored on the ``user`` instance — within a single request the same user
+    object flows through middleware, decorators and the context processor, so
+    one resolution is reused everywhere. A fresh request gets a fresh user
+    instance from the auth middleware, so the cache never goes stale.
+    """
+    cache = getattr(user, "_tenant_perms_cache", None)
+    if cache is None:
+        cache = {}
+        user._tenant_perms_cache = cache
+    return cache
+
+
+def prime_tenant_permissions(user, tenant, membership) -> None:
+    """Seed the per-request cache from a membership the caller already fetched.
+
+    Called by ``SessionTenantMiddleware`` after it resolves ``request.tenant``
+    (it loads the membership to route the schema anyway), so the context
+    processor and ``can_edit``/``is_tenant_admin`` reuse that single lookup
+    instead of re-querying. No-op for anonymous/superuser/missing tenant —
+    those need no query. ``membership`` may be ``None`` (user has no active
+    membership in ``tenant``), which correctly caches "no permissions".
+    """
+    if user is None or not user.is_authenticated or user.is_superuser:
+        return
+    if tenant is None:
+        return
+    _perm_cache(user)[tenant.pk] = _perms_from_membership(membership)
+
+
 def tenant_permissions(user, tenant) -> tuple[bool, frozenset[str]]:
     """Resolve ``(is_admin, writable_resources)`` for ``user`` in ``tenant``.
 
-    Issues at most **one** query. `UserMembership` is unique per
+    Issues at most **one** query per ``(user, tenant)`` per request, and zero
+    when the middleware has already primed the cache (see
+    ``prime_tenant_permissions``). `UserMembership` is unique per
     ``(user, tenant)``, so a single active row fully determines the role.
 
     - Anonymous users / missing tenant → ``(False, frozenset())`` (no query).
@@ -64,14 +107,15 @@ def tenant_permissions(user, tenant) -> tuple[bool, frozenset[str]]:
         return True, ALL_RESOURCES
     if tenant is None:
         return False, frozenset()
+    cache = _perm_cache(user)
+    if tenant.pk in cache:
+        return cache[tenant.pk]
     membership = UserMembership.objects.filter(
         user=user, tenant=tenant, is_active=True
     ).first()
-    if membership is None:
-        return False, frozenset()
-    return membership.role == Role.ADMIN, WRITE_BY_ROLE.get(
-        membership.role, frozenset()
-    )
+    result = _perms_from_membership(membership)
+    cache[tenant.pk] = result
+    return result
 
 
 def can_edit(user, tenant, resource: str) -> bool:

--- a/crkva/tenants/tests/test_permissions.py
+++ b/crkva/tenants/tests/test_permissions.py
@@ -176,7 +176,7 @@ class ContextProcessorTests(TestCase):
 
         factory = RequestFactory()
         request = factory.get("/")
-        request.user = self.clerk
+        request.user = User.objects.get(pk=self.clerk.pk)  # cold per-request cache
         request.tenant = self.tenant
         with CaptureQueriesContext(connection) as captured:
             current_tenant(request)
@@ -206,3 +206,66 @@ class ContextProcessorTests(TestCase):
             ctx = current_tenant(request)
         self.assertTrue(ctx["can_edit_osoba"])
         self.assertTrue(ctx["is_tenant_admin"])
+
+
+class MembershipPrimingTests(TestCase):
+    """#256: the middleware's resolution membership primes the per-request
+    permission cache, so the context processor/decorators re-query zero times.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="prime_kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+
+    def _membership_queries(self, fn):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as cap:
+            fn()
+        return [q for q in cap.captured_queries
+                if "tenants_user_membership" in q["sql"]]
+
+    def test_prime_makes_permission_checks_query_free(self):
+        from tenants.permissions import (
+            can_edit, is_tenant_admin, prime_tenant_permissions,
+        )
+        user = User.objects.get(pk=self.clerk.pk)  # fresh instance
+        membership = UserMembership.objects.get(user=user, tenant=self.tenant)
+        prime_tenant_permissions(user, self.tenant, membership)
+
+        q = self._membership_queries(lambda: (
+            can_edit(user, self.tenant, OSOBA),
+            can_edit(user, self.tenant, SVESTENIK),
+            is_tenant_admin(user, self.tenant),
+        ))
+        self.assertEqual(len(q), 0, "primed cache must avoid membership queries")
+        self.assertTrue(can_edit(user, self.tenant, OSOBA))
+        self.assertFalse(can_edit(user, self.tenant, SVESTENIK))
+        self.assertFalse(is_tenant_admin(user, self.tenant))
+
+    def test_middleware_resolution_primes_context_processor(self):
+        from tenants.context_processors import current_tenant
+        from tenants.middleware import SessionTenantMiddleware
+        from tenants.permissions import prime_tenant_permissions
+
+        request = RequestFactory().get("/")
+        request.user = User.objects.get(pk=self.clerk.pk)
+        request.session = {}
+
+        def resolve_and_prime():
+            tenant, membership = SessionTenantMiddleware._resolve_tenant(request)
+            request.tenant = tenant
+            prime_tenant_permissions(request.user, tenant, membership)
+
+        mw_q = self._membership_queries(resolve_and_prime)
+        cp_q = self._membership_queries(lambda: current_tenant(request))
+
+        self.assertLessEqual(len(mw_q), 1,
+                             "resolution should cost at most one membership query")
+        self.assertEqual(len(cp_q), 0,
+                         "context processor must reuse the primed cache")

--- a/crkva/tenants/tests/test_tenant_resolution.py
+++ b/crkva/tenants/tests/test_tenant_resolution.py
@@ -37,7 +37,10 @@ class ResolveTenantTests(TestCase):
         return request
 
     def resolve(self, request):
-        return SessionTenantMiddleware._resolve_tenant(request)
+        # _resolve_tenant now returns (tenant, membership); tests assert on the
+        # resolved tenant (membership is the perm-cache seed, see #256).
+        tenant, _membership = SessionTenantMiddleware._resolve_tenant(request)
+        return tenant
 
     def test_active_membership_resolves_and_sets_session(self):
         UserMembership.objects.create(


### PR DESCRIPTION
## Допуна #256 (после #258)
#258 је контекст-процесор свео са ~6 на 1 упит за чланство. Али је `SessionTenantMiddleware` и даље радио **засебан** упит за чланство при разрешавању тенанта — дакле два упита за исти `(корисник, тенант)` на свакој страници. Овај PR уклања и тај дупликат.

## Шта мења
- **`tenant_permissions`** меморише резултат **по захтеву** (на инстанци `user`, кључ `tenant.pk`); сви провери дозвола у истом захтеву (context-processor + декоратори + view-ови) деле један упит. Свеж HTTP захтев добија свежу инстанцу корисника од auth middleware-а → кеш никад није устарео.
- **`SessionTenantMiddleware._resolve_tenant`** сада враћа `(tenant, membership)`, а `__call__` сеје кеш преко новог `prime_tenant_permissions(...)`. Чланство које се ионако учитава да би се изабрала шема се поново употреби, па context-processor и `can_edit`/`is_tenant_admin` **не питају базу поново**.
- Логика приступа је непромењена: сесиони пут само мења `.exists()` → `.first()` (`membership is not None` је еквивалент); суперкорисници и даље улазе без чланства; пад на подразумевани тенант значи да корисник нема чланство → тачно нема дозвола.

## Ефекат
Аутентификована страница: **1 упит за чланство** за тај пар (било ~6 пре #258, па 2 после #258, сада 1). Суперкорисник: 0.

## Тестови
- `MembershipPrimingTests`: (1) после `prime_tenant_permissions` сви провери су без упита; (2) разрешавање middleware-а сеје кеш тако да context-processor ради **0** упита.
- Постојећи #258 тест ажуриран да користи свежу инстанцу корисника (хладан кеш).
- Цео `tenants` пакет пролази (53), укључујући `GatedViewTests` (пун пролаз кроз middleware + декораторе).

Closes #256
