### PR TITLE
fix(fasting): Духови су Васкрс+49, не +50 (#253)

### DIFF
--- a/crkva/registar/tests/test_fasting.py
+++ b/crkva/registar/tests/test_fasting.py
@@ -143,10 +143,11 @@ class ApostlesFastTestCase(TestCase):
             fast = get_apostles_fast(year)
             if not fast:
                 continue
-            duhovi = vaskrs + dt.timedelta(days=50)
-            expected_start = duhovi + dt.timedelta(days=1)
+            duhovi = vaskrs + dt.timedelta(days=49)  # Педесетница (увек недеља)
+            self.assertEqual(duhovi.weekday(), 6)  # недеља
+            expected_start = duhovi + dt.timedelta(days=1)  # понедељак после Духова
             self.assertIn(expected_start, fast)
-            self.assertEqual(expected_start.weekday(), 1)  # уторак
+            self.assertEqual(expected_start.weekday(), 0)  # понедељак
 
     def test_apostles_fast_ends_july_11(self):
         """Апостолски пост се завршава 11. јула (Петровдан eve)."""
@@ -213,6 +214,16 @@ class TrapaveWeeksTestCase(TestCase):
         self.assertIn(dt.date(2026, 1, 7), trapave)
         self.assertIn(dt.date(2026, 1, 17), trapave)
         self.assertNotIn(dt.date(2026, 1, 18), trapave)
+
+    def test_post_pentecost_trapava_starts_monday_after_duhovi(self):
+        """Трапава седмица после Педесетнице почиње понедељак после Духова (#253)."""
+        vaskrs = Slava.calc_vaskrs(2026)
+        trapave = get_trapave_weeks(2026)
+        duhovi = vaskrs + dt.timedelta(days=49)  # Педесетница
+        self.assertEqual(duhovi.weekday(), 6)  # недеља
+        # понедељак (Васкрс+50) кроз недељу (Васкрс+56) после Духова су трапави
+        for i in range(50, 57):
+            self.assertIn(vaskrs + dt.timedelta(days=i), trapave)
 
     def test_wednesday_in_trapava_not_fasting(self):
         """Среда у трапавој седмици није постни дан."""

--- a/crkva/registar/utils_fasting.py
+++ b/crkva/registar/utils_fasting.py
@@ -68,8 +68,9 @@ def get_apostles_fast(year: int) -> set[dt.date]:
 
     vaskrs = Slava.calc_vaskrs(year)
 
-    # Духови (Педесетница) су 50 дана после Васкрса
-    duhovi = vaskrs + dt.timedelta(days=50)
+    # Духови (Педесетница) су 49 дана после Васкрса (50. дан рачунајући Васкрс
+    # као први дан), и увек падају у недељу.
+    duhovi = vaskrs + dt.timedelta(days=49)
 
     # Пост почиње следећег понедељка после Духова
     # Духови су увек недеља, тако да је следећи дан понедељак
@@ -132,8 +133,8 @@ def get_trapave_weeks(year: int) -> set[dt.date]:
         _date_range(vaskrs + dt.timedelta(days=1), vaskrs + dt.timedelta(days=7))
     )
 
-    # Седмица после Духова (50 дана после Васкрса + 7 дана)
-    duhovi = vaskrs + dt.timedelta(days=50)
+    # Седмица после Духова (49 дана после Васкрса; недеља после је трапава)
+    duhovi = vaskrs + dt.timedelta(days=49)
     trapave.update(
         _date_range(duhovi + dt.timedelta(days=1), duhovi + dt.timedelta(days=7))
     )


### PR DESCRIPTION
## Проблем
Педесетница (Духови) је **50. дан** рачунајући Васкрс као први → **Васкрс + 49 дана**, и увек пада у недељу. Код је користио `vaskrs + timedelta(days=50)` — што је заправо Духовски **понедељак** (коментар је чак тврдио „Духови су увек недеља“ док је рачунао понедељак).

Последице:
1. `get_apostles_fast` — Петровски пост почињао у **уторак** (`duhovi+1`) уместо канонског понедељка после Педесетнице.
2. `get_trapave_weeks` — трапава (безпосна) седмица после Педесетнице померена за дан.

Сејана слава за Педесетницу већ користи тачан офсет 49, па су се два подсистема разилазила.

## Исправка
`crkva/registar/utils_fasting.py` — у оба места `duhovi = vaskrs + dt.timedelta(days=49)`.

## Провера (2025)
Васкрс 20.04 → +49 = недеља **08.06** (Педесетница) → пост почиње понедељак **09.06**. Раније је код стављао почетак на 10.06 (уторак).

## Тестови
- Исправљен `test_apostles_fast_starts_after_pentecost` који је **кодирао грешку** (очекивао уторак, `weekday()==1`); сада тврди да је Педесетница недеља (`weekday()==6`) и да пост почиње понедељак (`weekday()==0`), за 2020–2030.
- Нови `test_post_pentecost_trapava_starts_monday_after_duhovi` — трапава седмица после Духова обухвата Васкрс+50..+56.
- Цео `registar.tests.test_fasting` пролази (41).

Closes #253
