### PR TITLE
feat(registar): брзо додавање свештеника и парохије из dropdown-а (#233)

### DIFF
--- a/crkva/registar/forms/select2.py
+++ b/crkva/registar/forms/select2.py
@@ -101,7 +101,7 @@ class PublicSchemaModelSelect2Widget(ScriptAwareModelSelect2Widget):
 
 from django.db.models import Q  # noqa: E402
 
-from registar.models import Adresa, Hram, Svestenik  # noqa: E402
+from registar.models import Adresa, Hram, Parohija, Svestenik  # noqa: E402
 from registar.models.parohijan import Osoba  # noqa: E402
 
 
@@ -154,11 +154,17 @@ class FemaleOsobaSelect2Widget(OsobaSelect2Widget):
 
 
 class SvestenikSelect2Widget(ScriptAwareModelSelect2Widget):
-    """Autocomplete widget for Svestenik."""
+    """Autocomplete widget for Svestenik with inline quick-create."""
 
     model = Svestenik
     search_fields = ["ime__icontains", "prezime__icontains"]
     attrs = {"data-minimum-input-length": 0}
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-create-modal"] = "svestenik-create-modal"
+        attrs["data-create-label"] = "Додај свештеника"
+        return attrs
 
 
 class HramSelect2Widget(ScriptAwareModelSelect2Widget):
@@ -196,4 +202,17 @@ class AdresaSelect2Widget(ScriptAwareModelSelect2Widget):
         attrs["data-adresa-edit"] = "1"
         attrs["data-create-modal"] = "adresa-create-modal"
         attrs["data-create-label"] = "Додај нову адресу"
+        return attrs
+
+
+class ParohijaSelect2Widget(ScriptAwareModelSelect2Widget):
+    """Autocomplete widget for Parohija with inline quick-create."""
+
+    model = Parohija
+    search_fields = ["naziv__icontains"]
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["data-create-modal"] = "parohija-create-modal"
+        attrs["data-create-label"] = "Додај парохију"
         return attrs

--- a/crkva/registar/forms/svestenik_form.py
+++ b/crkva/registar/forms/svestenik_form.py
@@ -2,8 +2,8 @@
 
 from django import forms
 from registar.forms.distinct_lookup import DistinctValuesCharField
-from registar.forms.select2 import AdresaSelect2Widget, ScriptAwareModelSelect2Widget
-from registar.models import Adresa, Parohija, Svestenik
+from registar.forms.select2 import AdresaSelect2Widget, ParohijaSelect2Widget
+from registar.models import Svestenik
 
 
 class SvestenikForm(forms.ModelForm):
@@ -28,11 +28,7 @@ class SvestenikForm(forms.ModelForm):
             "adresa",
         ]
         widgets = {
-            "parohija": ScriptAwareModelSelect2Widget(
-                model=Parohija,
-                search_fields=["naziv__icontains"],
-                attrs={"data-minimum-input-length": 0},
-            ),
+            "parohija": ParohijaSelect2Widget(),
             "adresa": AdresaSelect2Widget(),
             "datum_rodjenja": forms.DateInput(
                 attrs={"type": "date"}, format="%Y-%m-%d"

--- a/crkva/registar/templates/registar/_modal_parohija.html
+++ b/crkva/registar/templates/registar/_modal_parohija.html
@@ -1,0 +1,48 @@
+{% comment %}
+Quick-add Parohija modal (#233). Uses the generic Modal.bindForm helper
+(modal.js) + quick_create.js footer. Registered in window.quickModals so the
+"+ Додај парохију" footer on Parohija select2 dropdowns can open it.
+{% endcomment %}
+<div id="parohija-create-modal" class="modal-overlay" hidden>
+  <div class="modal">
+    <div class="modal__header">
+      <h3><i class="fa-solid fa-place-of-worship"></i> Нова парохија</h3>
+      <button type="button" class="modal__close" onclick="Modal.close('parohija-create-modal')">&times;</button>
+    </div>
+    <div class="modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-naziv">Назив *</label>
+          <input type="text" id="modal-naziv" autocomplete="off" required>
+        </div>
+      </div>
+      <div class="error-text" hidden></div>
+    </div>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('parohija-create-modal')">Откажи</button>
+      <button type="button" class="button button--primary" onclick="window.quickModals && window.quickModals['parohija-create-modal'] && window.quickModals['parohija-create-modal'].save()">
+        <i class="fa-solid fa-check"></i> Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    function init() {
+      var inst = Modal.bindForm("parohija-create-modal", {
+        url: "{% url 'brzi_unos_parohije' %}",
+        fields: ["naziv"],
+        requiredFields: ["naziv"],
+        requiredMessage: "Назив парохије је обавезан.",
+      });
+      window.quickModals = window.quickModals || {};
+      window.quickModals["parohija-create-modal"] = inst;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/crkva/registar/templates/registar/_modal_svestenik.html
+++ b/crkva/registar/templates/registar/_modal_svestenik.html
@@ -1,0 +1,65 @@
+{% load svestenik_extras %}
+{% comment %}
+Quick-add Svestenik modal (#233). Uses the generic Modal.bindForm helper
+(modal.js) + quick_create.js footer. Registered in window.quickModals so the
+"+ Додај свештеника" footer on Svestenik select2 dropdowns can open it.
+Minimal fields (име/презиме/звање); остало се допуњује кроз пуну форму.
+{% endcomment %}
+<div id="svestenik-create-modal" class="modal-overlay" hidden>
+  <div class="modal">
+    <div class="modal__header">
+      <h3><i class="fa-solid fa-user-tie"></i> Нови свештеник</h3>
+      <button type="button" class="modal__close" onclick="Modal.close('svestenik-create-modal')">&times;</button>
+    </div>
+    <div class="modal__body">
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-ime">Име *</label>
+          <input type="text" id="modal-ime" autocomplete="off" required>
+        </div>
+        <div class="form-field">
+          <label for="modal-prezime">Презиме *</label>
+          <input type="text" id="modal-prezime" autocomplete="off" required>
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-field">
+          <label for="modal-zvanje">Звање *</label>
+          <select id="modal-zvanje" required>
+            {% svestenik_zvanja as zvanja %}
+            {% for value, label in zvanja %}
+              <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="error-text" hidden></div>
+    </div>
+    <div class="modal__footer">
+      <button type="button" class="button button--neutral" onclick="Modal.close('svestenik-create-modal')">Откажи</button>
+      <button type="button" class="button button--primary" onclick="window.quickModals && window.quickModals['svestenik-create-modal'] && window.quickModals['svestenik-create-modal'].save()">
+        <i class="fa-solid fa-check"></i> Сачувај
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    function init() {
+      var inst = Modal.bindForm("svestenik-create-modal", {
+        url: "{% url 'brzi_unos_svestenika' %}",
+        fields: ["ime", "prezime", "zvanje"],
+        requiredFields: ["ime", "prezime", "zvanje"],
+        requiredMessage: "Име, презиме и звање су обавезни.",
+      });
+      window.quickModals = window.quickModals || {};
+      window.quickModals["svestenik-create-modal"] = inst;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -203,6 +203,7 @@
 
   {% include 'registar/_modal_osoba.html' %}
   {% include 'registar/_modal_hram.html' %}
+  {% include 'registar/_modal_svestenik.html' %}
 </form>
 {% if krstenje %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/svestenik.html
+++ b/crkva/registar/templates/registar/svestenik.html
@@ -59,6 +59,7 @@
 
   {% if form %}{% include "registar/_modal_adresa.html" %}{% endif %}
   {% if form %}{% include "registar/_modal_adresa_create.html" %}{% endif %}
+  {% if form %}{% include "registar/_modal_parohija.html" %}{% endif %}
 </form>
 {% if svestenik %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -169,6 +169,7 @@
 
   {% include 'registar/_modal_osoba.html' %}
   {% include 'registar/_modal_hram.html' %}
+  {% include 'registar/_modal_svestenik.html' %}
 </form>
 {% if vencanje %}{% include "registar/_istorija_izmena.html" %}{% endif %}
 {% endblock %}

--- a/crkva/registar/templatetags/svestenik_extras.py
+++ b/crkva/registar/templatetags/svestenik_extras.py
@@ -1,0 +1,17 @@
+"""Template tags за свештеничке податке у модалима."""
+
+from django import template
+
+from registar.models.svestenik import zvanja as ZVANJA
+
+register = template.Library()
+
+
+@register.simple_tag
+def svestenik_zvanja():
+    """Враћа листу (value, label) звања свештеника за dropdown у модалу.
+
+    Извор је сам модел (`Svestenik.zvanje.choices`), да се листа не дуплира
+    у шаблону и не одступа од модела.
+    """
+    return ZVANJA

--- a/crkva/registar/tests/test_brzi_svestenik_parohija.py
+++ b/crkva/registar/tests/test_brzi_svestenik_parohija.py
@@ -1,0 +1,120 @@
+"""Брзи AJAX unos за Свештеник и Парохија из dropdown модала (#233).
+
+Покрива: метод (405), валидација (400), креирање (200), дедупликација
+(filter-first), валидација звања, дозвола (свештенички ресурс), и
+data-create-modal атрибуте на виџетима.
+"""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from registar.forms.select2 import ParohijaSelect2Widget, SvestenikSelect2Widget
+from registar.models import Parohija, Svestenik
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+
+class BrziSvestenikParohijaTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        # Свештенички ресурс има ADMIN (и SVESTENSTVO); KANCELARIJA нема.
+        cls.admin = User.objects.create_user(username="adm", password="x")
+        UserMembership.objects.create(
+            user=cls.admin, tenant=cls.tenant, role=Role.ADMIN
+        )
+        cls.clerk = User.objects.create_user(username="kanc", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin)
+
+    # ------------------------------------------------------------- свештеник
+    def test_svestenik_get_rejected_405(self):
+        r = self.client.get(reverse("brzi_unos_svestenika"))
+        self.assertEqual(r.status_code, 405)
+
+    def test_svestenik_missing_name_400(self):
+        r = self.client.post(
+            reverse("brzi_unos_svestenika"), {"ime": "", "prezime": "", "zvanje": "јереј"}
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_svestenik_invalid_zvanje_400(self):
+        r = self.client.post(
+            reverse("brzi_unos_svestenika"),
+            {"ime": "Петар", "prezime": "Петровић", "zvanje": "измишљено"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_svestenik_missing_zvanje_400(self):
+        r = self.client.post(
+            reverse("brzi_unos_svestenika"),
+            {"ime": "Петар", "prezime": "Петровић", "zvanje": ""},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_svestenik_create_and_dedup(self):
+        payload = {"ime": "Петар", "prezime": "Петровић", "zvanje": "јереј"}
+        r1 = self.client.post(reverse("brzi_unos_svestenika"), payload)
+        self.assertEqual(r1.status_code, 200)
+        self.assertIn("id", r1.json())
+        r2 = self.client.post(reverse("brzi_unos_svestenika"), payload)
+        self.assertEqual(r1.json()["id"], r2.json()["id"])
+        self.assertEqual(
+            Svestenik.objects.filter(ime="Петар", prezime="Петровић").count(), 1
+        )
+
+    def test_svestenik_text_includes_zvanje(self):
+        r = self.client.post(
+            reverse("brzi_unos_svestenika"),
+            {"ime": "Лазар", "prezime": "Лазић", "zvanje": "протојереј"},
+        )
+        self.assertIn("протојереј", r.json()["text"])
+
+    def test_svestenik_forbidden_for_kancelarija(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(
+            reverse("brzi_unos_svestenika"),
+            {"ime": "Нико", "prezime": "Никић", "zvanje": "јереј"},
+        )
+        self.assertIn(r.status_code, (302, 403))
+        self.assertFalse(Svestenik.objects.filter(prezime="Никић").exists())
+
+    # -------------------------------------------------------------- парохија
+    def test_parohija_get_rejected_405(self):
+        r = self.client.get(reverse("brzi_unos_parohije"))
+        self.assertEqual(r.status_code, 405)
+
+    def test_parohija_missing_naziv_400(self):
+        r = self.client.post(reverse("brzi_unos_parohije"), {"naziv": ""})
+        self.assertEqual(r.status_code, 400)
+
+    def test_parohija_create_and_dedup(self):
+        r1 = self.client.post(reverse("brzi_unos_parohije"), {"naziv": "Прва парохија"})
+        self.assertEqual(r1.status_code, 200)
+        r2 = self.client.post(reverse("brzi_unos_parohije"), {"naziv": "прва парохија"})
+        self.assertEqual(r1.json()["id"], r2.json()["id"])
+        self.assertEqual(Parohija.objects.filter(naziv="Прва парохија").count(), 1)
+
+    def test_parohija_forbidden_for_kancelarija(self):
+        self.client.force_login(self.clerk)
+        r = self.client.post(reverse("brzi_unos_parohije"), {"naziv": "Забрањена"})
+        self.assertIn(r.status_code, (302, 403))
+        self.assertFalse(Parohija.objects.filter(naziv="Забрањена").exists())
+
+    # --------------------------------------------------------------- виџети
+    def test_svestenik_widget_carries_create_attr(self):
+        attrs = SvestenikSelect2Widget().build_attrs({})
+        self.assertEqual(attrs.get("data-create-modal"), "svestenik-create-modal")
+
+    def test_parohija_widget_carries_create_attr(self):
+        attrs = ParohijaSelect2Widget().build_attrs({})
+        self.assertEqual(attrs.get("data-create-modal"), "parohija-create-modal")

--- a/crkva/registar/urls.py
+++ b/crkva/registar/urls.py
@@ -82,6 +82,16 @@ urlpatterns = [
     path("api/brzi-unos-adrese/", views.brzi_unos_adrese, name="brzi_unos_adrese"),
     path("api/brzi-unos-hrama/", views.brzi_unos_hrama, name="brzi_unos_hrama"),
     path(
+        "api/brzi-unos-svestenika/",
+        views.brzi_unos_svestenika,
+        name="brzi_unos_svestenika",
+    ),
+    path(
+        "api/brzi-unos-parohije/",
+        views.brzi_unos_parohije,
+        name="brzi_unos_parohije",
+    ),
+    path(
         "api/brzi-izmena-adrese/<uuid:uid>/",
         views.brzi_izmena_adrese,
         name="brzi_izmena_adrese",

--- a/crkva/registar/views/__init__.py
+++ b/crkva/registar/views/__init__.py
@@ -11,6 +11,8 @@ from .brzi_view import (
     brzi_unos_adrese,
     brzi_unos_hrama,
     brzi_unos_osobe,
+    brzi_unos_parohije,
+    brzi_unos_svestenika,
 )
 from .domacinstvo_view import (
     PrikazDomacinstva,

--- a/crkva/registar/views/brzi_view.py
+++ b/crkva/registar/views/brzi_view.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import DatabaseError, IntegrityError
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-from registar.models import Adresa, Hram, Osoba
+from registar.models import Adresa, Hram, Osoba, Parohija, Svestenik
 from tenants.permissions import tenant_role_required
 
 logger = logging.getLogger(__name__)
@@ -155,3 +155,49 @@ def brzi_unos_adrese(request):
             {"error": "Адреса се не може сачувати због конфликта."}, status=400
         )
     return JsonResponse({"id": str(adresa.uid), "text": str(adresa)})
+
+
+@tenant_role_required("svestenik")
+def brzi_unos_svestenika(request):
+    """AJAX endpoint за брзо креирање свештеника из модалног дијалога."""
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    ime = request.POST.get("ime", "").strip()
+    prezime = request.POST.get("prezime", "").strip()
+    zvanje = request.POST.get("zvanje", "").strip()
+
+    if not ime or not prezime:
+        return JsonResponse({"error": "Име и презиме су обавезни"}, status=400)
+
+    # Validate zvanje against the field's declared choices so a hand-crafted
+    # POST cannot store an arbitrary rank.
+    valid_zvanja = {c[0] for c in Svestenik._meta.get_field("zvanje").choices}
+    if not zvanje or zvanje not in valid_zvanja:
+        return JsonResponse({"error": "Изаберите важеће звање"}, status=400)
+
+    # Свештеник нема ограничење јединствености; filter-first да поновљени
+    # унос не направи дупликат, без ризика од MultipleObjectsReturned.
+    svestenik = Svestenik.objects.filter(
+        ime=ime, prezime=prezime, zvanje=zvanje
+    ).first()
+    if svestenik is None:
+        svestenik = Svestenik.objects.create(ime=ime, prezime=prezime, zvanje=zvanje)
+    return JsonResponse({"id": svestenik.uid, "text": str(svestenik)})
+
+
+@tenant_role_required("svestenik")
+def brzi_unos_parohije(request):
+    """AJAX endpoint за брзо креирање парохије из модалног дијалога."""
+    if request.method != "POST":
+        return JsonResponse({"error": "POST only"}, status=405)
+
+    naziv = request.POST.get("naziv", "").strip()
+    if not naziv:
+        return JsonResponse({"error": "Назив парохије је обавезан"}, status=400)
+
+    # Реупотреби постојећу парохију истог назива уместо дуплирања.
+    parohija = Parohija.objects.filter(naziv__iexact=naziv).first()
+    if parohija is None:
+        parohija = Parohija.objects.create(naziv=naziv)
+    return JsonResponse({"id": str(parohija.uid), "text": str(parohija)})


### PR DESCRIPTION
## #233 — доследно „+ Додај“ за dropdown-ове

Завршава последње отворене ставке umbrella issue-а: **Свештеник** и **Парохија**. (Домаћин/Укућанин #235, Храм #236, Адреса #237 већ мерџовани.)

## Шта

Свештеник и Парохија select2 поља добијају „+ Додај“ подножје, исто као Особа/Храм/Адреса. Минималан inline модал:

- **Свештеник** — име + презиме + звање (dropdown choices модела)
- **Парохија** — назив

Остала опциона поља (место/датум рођења, парохија, адреса) се допуњују кроз пуну форму касније — исти приступ као quick-add Особе.

## Како

Прати већ постојећи генерички образац — нема нове инфраструктуре:

1. Виџет (`SvestenikSelect2Widget`, нови `ParohijaSelect2Widget`) поставља `data-create-modal` + `data-create-label`.
2. `quick_create.js` исцртава подножје и отвара именовани модал.
3. `Modal.bindForm` шаље POST на нови `brzi_unos_svestenika` / `brzi_unos_parohije` endpoint.
4. Endpoint ради **filter-first** уместо `get_or_create` (свештеник/парохија немају ограничење јединствености → избегава `MultipleObjectsReturned` на постојећим дупликатима) и реупотребљава постојећи ред.

`svestenik_form` сада користи `ParohijaSelect2Widget()` уместо inline виџета.

## Дозволе

Оба endpoint-а траже ресурс **`svestenik`** (свештенство/админ). Канцеларија и даље бира постојеће свештенике/парохије из крштења/венчања (не може да их креира) — то прати модел овлашћења (клер управља свештенством). Тренутни prod корисници су admin, па за њих ради.

## Tags (последња ставка чеклисте)

Потврђено да Занимање/Вероисповест/Народност креирају нови ред: `TaggableLookupField.to_python` ради `get_or_create(naziv=...)` када унос није pk; покрива `test_taggable_lookup.py`.

## Тестови

`registar/tests/test_brzi_svestenik_parohija.py` (13): 405/400 гране, креирање+дедуп, валидација звања, забрана за канцеларију, и `data-create-modal` атрибути на виџетима. Пролазе уз постојеће `test_brzi_view` / `test_unos_svestenika`.

Без миграција (нема промена модела) — деплој = `reload`.

Closes #233
