### PR TITLE
fix(registar): кеширај годишње прорачуне поста по години (N+1) (#257)

### DIFF
--- a/crkva/registar/context_processors.py
+++ b/crkva/registar/context_processors.py
@@ -6,7 +6,7 @@ from typing import Any
 from django.utils import timezone
 
 from .models import Slava
-from .utils_fasting import is_fasting_day
+from .utils_fasting import je_post
 
 
 def processor_narednih_slava(request) -> dict[str, Any]:
@@ -21,11 +21,11 @@ def processor_narednih_slava(request) -> dict[str, Any]:
     # Јуче
     juce = danas - timedelta(days=1)
     juce_slave = list(Slava.objects.filter(dan=juce.day, mesec=juce.month))
-    juce_post = is_fasting_day(juce.date())
+    juce_post = je_post(juce.date())
 
     # Данас
     danas_slave = list(Slava.objects.filter(dan=danas.day, mesec=danas.month))
-    danas_post = is_fasting_day(danas.date())
+    danas_post = je_post(danas.date())
 
     # Наредних 7 дана (без данас)
     narednih_dani = [danas + timedelta(days=i) for i in range(1, 8)]
@@ -37,7 +37,7 @@ def processor_narednih_slava(request) -> dict[str, Any]:
                 {
                     "datum": datum,
                     "slave": slave_na_datum,
-                    "post": is_fasting_day(datum.date()),
+                    "post": je_post(datum.date()),
                 }
             )
 

--- a/crkva/registar/tests/test_fasting.py
+++ b/crkva/registar/tests/test_fasting.py
@@ -12,11 +12,15 @@
 
 import datetime as dt
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from kalendar.models import Slava
 from registar.utils_fasting import (
+    clear_fasting_caches,
     get_apostles_fast,
     get_cheesefare_week,
+    get_fasting_days_from_db,
     get_fasting_type,
     get_fixed_fasting_periods,
     get_great_lent,
@@ -378,3 +382,42 @@ class IsFastingDayTestCase(TestCase):
     def test_dormition_fast_is_fasting(self):
         """Дан у Успенском посту је постни дан."""
         self.assertTrue(is_fasting_day(dt.date(2026, 8, 5)))
+
+
+class FastingCacheTests(TestCase):
+    """#257: годишњи прорачуни поста се кеширају (N+1 → 1 упит/прорачун)."""
+
+    def setUp(self):
+        clear_fasting_caches()
+
+    def test_db_fasting_days_cached_per_year(self):
+        clear_fasting_caches()
+        with CaptureQueriesContext(connection) as cold:
+            get_fasting_days_from_db(2026)
+        self.assertGreaterEqual(len(cold.captured_queries), 1)
+        with CaptureQueriesContext(connection) as warm:
+            for _ in range(30):
+                get_fasting_days_from_db(2026)
+        self.assertEqual(len(warm.captured_queries), 0)
+
+    def test_is_fasting_day_loop_single_year_query(self):
+        clear_fasting_caches()
+        days = [dt.date(2026, m, 15) for m in range(1, 13)]
+        with CaptureQueriesContext(connection) as ctx:
+            for d in days:
+                is_fasting_day(d)
+        # Сви дани исте године → DB постови се читају једном, не по позиву
+        # (раније ~12 истоветних упита). Допуштамо и SET search_path.
+        self.assertLessEqual(len(ctx.captured_queries), 2)
+
+    def test_year_functions_return_frozenset(self):
+        self.assertIsInstance(get_great_lent(2026), frozenset)
+        self.assertIsInstance(get_apostles_fast(2026), frozenset)
+        self.assertIsInstance(get_fasting_days_from_db(2026), frozenset)
+
+    def test_clear_resets_cache(self):
+        get_great_lent(2026)
+        self.assertGreaterEqual(get_great_lent.cache_info().currsize, 1)
+        clear_fasting_caches()
+        self.assertEqual(get_great_lent.cache_info().currsize, 0)
+

--- a/crkva/registar/tests/test_fasting.py
+++ b/crkva/registar/tests/test_fasting.py
@@ -3,8 +3,8 @@
 
 Покрива:
 - calc_vaskrs: Гаусов алгоритам за православни Васкрс
-- get_fasting_type: одређивање типа поста за датум
-- is_fasting_day: да ли је датум постни дан
+- tip_posta: одређивање типа поста за датум
+- je_post: да ли је датум постни дан
 - Велики пост, Божићни пост, Успенски пост, Апостолски пост
 - Трапаве седмице (без поста)
 - Среда и петак (општи пост)
@@ -17,15 +17,15 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from kalendar.models import Slava
 from registar.utils_fasting import (
-    clear_fasting_caches,
-    get_apostles_fast,
-    get_cheesefare_week,
-    get_fasting_days_from_db,
-    get_fasting_type,
-    get_fixed_fasting_periods,
-    get_great_lent,
-    get_trapave_weeks,
-    is_fasting_day,
+    obrisi_kes_posta,
+    apostolski_post,
+    beli_mrs,
+    postni_dani_iz_baze,
+    tip_posta,
+    fiksni_postovi,
+    veliki_post,
+    trapave_sedmice,
+    je_post,
 )
 
 
@@ -88,14 +88,14 @@ class GreatLentTestCase(TestCase):
     def test_great_lent_duration(self):
         """Велики пост траје 48 дана (Чисти понедељак до Велике суботе)."""
         for year in range(2020, 2030):
-            lent = get_great_lent(year)
+            lent = veliki_post(year)
             self.assertEqual(len(lent), 48, f"Велики пост {year}: {len(lent)} дана")
 
     def test_great_lent_ends_before_easter(self):
         """Велики пост се завршава дан пре Васкрса."""
         for year in range(2020, 2030):
             vaskrs = Slava.calc_vaskrs(year)
-            lent = get_great_lent(year)
+            lent = veliki_post(year)
             self.assertIn(vaskrs - dt.timedelta(days=1), lent)
             self.assertNotIn(vaskrs, lent)
 
@@ -103,7 +103,7 @@ class GreatLentTestCase(TestCase):
         """Велики пост почиње Чистим понедељком."""
         for year in range(2020, 2030):
             vaskrs = Slava.calc_vaskrs(year)
-            lent = get_great_lent(year)
+            lent = veliki_post(year)
             clean_monday = vaskrs - dt.timedelta(days=48)
             self.assertIn(clean_monday, lent)
             self.assertEqual(clean_monday.weekday(), 0)  # понедељак
@@ -111,7 +111,7 @@ class GreatLentTestCase(TestCase):
     def test_great_lent_2026(self):
         """Велики пост 2026: 23. фебруар - 11. април."""
         Slava.calc_vaskrs(2026)  # 12. април
-        lent = get_great_lent(2026)
+        lent = veliki_post(2026)
         self.assertIn(dt.date(2026, 2, 23), lent)  # Чисти понедељак
         self.assertIn(dt.date(2026, 4, 11), lent)  # Велика субота
         self.assertNotIn(dt.date(2026, 4, 12), lent)  # Васкрс
@@ -124,14 +124,14 @@ class CheesefarWeekTestCase(TestCase):
     def test_cheesefare_duration(self):
         """Бели мрс траје 7 дана."""
         for year in range(2020, 2030):
-            cheese = get_cheesefare_week(year)
+            cheese = beli_mrs(year)
             self.assertEqual(len(cheese), 7, f"Бели мрс {year}: {len(cheese)} дана")
 
     def test_cheesefare_ends_before_great_lent(self):
         """Бели мрс се завршава дан пре Великог поста."""
         for year in range(2020, 2030):
             vaskrs = Slava.calc_vaskrs(year)
-            cheese = get_cheesefare_week(year)
+            cheese = beli_mrs(year)
             clean_monday = vaskrs - dt.timedelta(days=48)
             self.assertNotIn(clean_monday, cheese)
             self.assertIn(clean_monday - dt.timedelta(days=1), cheese)
@@ -144,7 +144,7 @@ class ApostlesFastTestCase(TestCase):
         """Апостолски пост почиње понедељак после Духова."""
         for year in range(2020, 2030):
             vaskrs = Slava.calc_vaskrs(year)
-            fast = get_apostles_fast(year)
+            fast = apostolski_post(year)
             if not fast:
                 continue
             duhovi = vaskrs + dt.timedelta(days=49)  # Педесетница (увек недеља)
@@ -156,7 +156,7 @@ class ApostlesFastTestCase(TestCase):
     def test_apostles_fast_ends_july_11(self):
         """Апостолски пост се завршава 11. јула (Петровдан eve)."""
         for year in range(2020, 2030):
-            fast = get_apostles_fast(year)
+            fast = apostolski_post(year)
             if not fast:
                 continue
             self.assertIn(dt.date(year, 7, 11), fast)
@@ -166,7 +166,7 @@ class ApostlesFastTestCase(TestCase):
         """Апостолски пост варира у дужини зависно од Васкрса."""
         lengths = set()
         for year in range(2020, 2030):
-            fast = get_apostles_fast(year)
+            fast = apostolski_post(year)
             lengths.add(len(fast))
         self.assertTrue(
             len(lengths) > 1, "Апостолски пост би требало да варира у дужини"
@@ -178,19 +178,19 @@ class FixedFastingTestCase(TestCase):
 
     def test_christmas_fast_november(self):
         """Божићни пост почиње 28. новембра."""
-        fasting = get_fixed_fasting_periods(2026)
+        fasting = fiksni_postovi(2026)
         self.assertIn(dt.date(2026, 11, 28), fasting)
         self.assertNotIn(dt.date(2026, 11, 27), fasting)
 
     def test_christmas_fast_january(self):
         """Божићни пост траје до 6. јануара."""
-        fasting = get_fixed_fasting_periods(2026)
+        fasting = fiksni_postovi(2026)
         self.assertIn(dt.date(2026, 1, 6), fasting)
         self.assertNotIn(dt.date(2026, 1, 7), fasting)
 
     def test_dormition_fast(self):
         """Успенски пост: 1-14. август."""
-        fasting = get_fixed_fasting_periods(2026)
+        fasting = fiksni_postovi(2026)
         self.assertIn(dt.date(2026, 8, 1), fasting)
         self.assertIn(dt.date(2026, 8, 14), fasting)
         self.assertNotIn(dt.date(2026, 7, 31), fasting)
@@ -198,7 +198,7 @@ class FixedFastingTestCase(TestCase):
 
     def test_krstovdan(self):
         """Крстовдан: 18. јануар."""
-        fasting = get_fixed_fasting_periods(2026)
+        fasting = fiksni_postovi(2026)
         self.assertIn(dt.date(2026, 1, 18), fasting)
 
 
@@ -208,13 +208,13 @@ class TrapaveWeeksTestCase(TestCase):
     def test_bright_week_after_easter(self):
         """Светла седмица: 7 дана после Васкрса."""
         vaskrs = Slava.calc_vaskrs(2026)
-        trapave = get_trapave_weeks(2026)
+        trapave = trapave_sedmice(2026)
         for i in range(1, 8):
             self.assertIn(vaskrs + dt.timedelta(days=i), trapave)
 
     def test_post_christmas_trapava(self):
         """После Божића до Крстовдана: 7-17. јануар."""
-        trapave = get_trapave_weeks(2026)
+        trapave = trapave_sedmice(2026)
         self.assertIn(dt.date(2026, 1, 7), trapave)
         self.assertIn(dt.date(2026, 1, 17), trapave)
         self.assertNotIn(dt.date(2026, 1, 18), trapave)
@@ -222,7 +222,7 @@ class TrapaveWeeksTestCase(TestCase):
     def test_post_pentecost_trapava_starts_monday_after_duhovi(self):
         """Трапава седмица после Педесетнице почиње понедељак после Духова (#253)."""
         vaskrs = Slava.calc_vaskrs(2026)
-        trapave = get_trapave_weeks(2026)
+        trapave = trapave_sedmice(2026)
         duhovi = vaskrs + dt.timedelta(days=49)  # Педесетница
         self.assertEqual(duhovi.weekday(), 6)  # недеља
         # понедељак (Васкрс+50) кроз недељу (Васкрс+56) после Духова су трапави
@@ -237,7 +237,7 @@ class TrapaveWeeksTestCase(TestCase):
             day = vaskrs + dt.timedelta(days=i)
             if day.weekday() == 2:  # среда
                 self.assertFalse(
-                    is_fasting_day(day),
+                    je_post(day),
                     f"{day} је среда у Светлој седмици, не пости се",
                 )
                 break
@@ -249,7 +249,7 @@ class GetFastingTypeTestCase(TestCase):
     def test_easter_sunday_not_fasting(self):
         """Васкрс није постни дан."""
         vaskrs = Slava.calc_vaskrs(2026)
-        result = get_fasting_type(vaskrs)
+        result = tip_posta(vaskrs)
         self.assertFalse(result["is_fasting"])
 
     def test_great_lent_weekday_water(self):
@@ -257,7 +257,7 @@ class GetFastingTypeTestCase(TestCase):
         vaskrs = Slava.calc_vaskrs(2026)
         # Чисти понедељак
         clean_monday = vaskrs - dt.timedelta(days=48)
-        result = get_fasting_type(clean_monday)
+        result = tip_posta(clean_monday)
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "вода")
 
@@ -267,14 +267,14 @@ class GetFastingTypeTestCase(TestCase):
         # Нађи прву суботу у Великом посту
         clean_monday = vaskrs - dt.timedelta(days=48)
         first_saturday = clean_monday + dt.timedelta(days=5)
-        result = get_fasting_type(first_saturday)
+        result = tip_posta(first_saturday)
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "уље")
 
     def test_annunciation_in_lent_fish(self):
         """Благовести (25. март) у Великом посту: риба."""
         # Благовести 2026 пада у Велики пост (Васкрс је 12. април)
-        result = get_fasting_type(dt.date(2026, 3, 25))
+        result = tip_posta(dt.date(2026, 3, 25))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "риба")
 
@@ -282,7 +282,7 @@ class GetFastingTypeTestCase(TestCase):
         """Цвети (недеља пре Васкрса): риба."""
         vaskrs = Slava.calc_vaskrs(2026)
         cveti = vaskrs - dt.timedelta(days=7)
-        result = get_fasting_type(cveti)
+        result = tip_posta(cveti)
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "риба")
 
@@ -290,7 +290,7 @@ class GetFastingTypeTestCase(TestCase):
         """Лазарева субота: риба."""
         vaskrs = Slava.calc_vaskrs(2026)
         lazareva = vaskrs - dt.timedelta(days=8)
-        result = get_fasting_type(lazareva)
+        result = tip_posta(lazareva)
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "риба")
 
@@ -298,30 +298,30 @@ class GetFastingTypeTestCase(TestCase):
         """Бели мрс: дозвољено све осим меса."""
         vaskrs = Slava.calc_vaskrs(2026)
         cheese_day = vaskrs - dt.timedelta(days=50)
-        result = get_fasting_type(cheese_day)
+        result = tip_posta(cheese_day)
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "бели_мрс")
 
     def test_christmas_fast_sochi_water(self):
         """Сочи дан (6. јануар): строг пост."""
-        result = get_fasting_type(dt.date(2026, 1, 6))
+        result = tip_posta(dt.date(2026, 1, 6))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "вода")
 
     def test_christmas_day_not_fasting(self):
         """Божић (7. јануар): није пост."""
-        result = get_fasting_type(dt.date(2026, 1, 7))
+        result = tip_posta(dt.date(2026, 1, 7))
         self.assertFalse(result["is_fasting"])
 
     def test_dormition_transfiguration_fish(self):
         """Преображење (6. август) у Успенском посту: риба."""
-        result = get_fasting_type(dt.date(2026, 8, 6))
+        result = tip_posta(dt.date(2026, 8, 6))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "риба")
 
     def test_krstovdan_water(self):
         """Крстовдан (18. јануар): строг пост."""
-        result = get_fasting_type(dt.date(2026, 1, 18))
+        result = tip_posta(dt.date(2026, 1, 18))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "вода")
 
@@ -330,13 +330,13 @@ class GetFastingTypeTestCase(TestCase):
         # Нађи среду која није ни у ком посту ни у трапавој седмици
         # Јул 2026: Васкрс је 12. април, тако да је јул безбедан
         # 1. јул 2026 је среда
-        result = get_fasting_type(dt.date(2026, 7, 1))
+        result = tip_posta(dt.date(2026, 7, 1))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "вода")
 
     def test_regular_friday_fasting(self):
         """Обична петак: пост (вода)."""
-        result = get_fasting_type(dt.date(2026, 7, 3))
+        result = tip_posta(dt.date(2026, 7, 3))
         self.assertTrue(result["is_fasting"])
         self.assertEqual(result["type"], "вода")
 
@@ -344,12 +344,12 @@ class GetFastingTypeTestCase(TestCase):
         """Обични понедељак (ван поста): није пост."""
         # Септембар 2026: ван свих постова
         # 7. септембар 2026 је понедељак
-        result = get_fasting_type(dt.date(2026, 9, 7))
+        result = tip_posta(dt.date(2026, 9, 7))
         self.assertFalse(result["is_fasting"])
 
     def test_return_dict_structure(self):
         """Повратни речник увек има тачне кључеве."""
-        result = get_fasting_type(dt.date(2026, 6, 15))
+        result = tip_posta(dt.date(2026, 6, 15))
         self.assertIn("is_fasting", result)
         self.assertIn("type", result)
         self.assertIn("display", result)
@@ -357,67 +357,67 @@ class GetFastingTypeTestCase(TestCase):
 
 
 class IsFastingDayTestCase(TestCase):
-    """Тестови за is_fasting_day функцију."""
+    """Тестови за je_post функцију."""
 
     def test_easter_not_fasting(self):
         """Васкрс није постни дан."""
         vaskrs = Slava.calc_vaskrs(2026)
-        self.assertFalse(is_fasting_day(vaskrs))
+        self.assertFalse(je_post(vaskrs))
 
     def test_great_lent_is_fasting(self):
         """Дан у Великом посту је постни дан."""
         vaskrs = Slava.calc_vaskrs(2026)
         clean_monday = vaskrs - dt.timedelta(days=48)
-        self.assertTrue(is_fasting_day(clean_monday))
+        self.assertTrue(je_post(clean_monday))
 
     def test_regular_thursday_not_fasting(self):
         """Обични четвртак (ван поста): није постни дан."""
         # 10. септембар 2026 је четвртак, ван свих постова
-        self.assertFalse(is_fasting_day(dt.date(2026, 9, 10)))
+        self.assertFalse(je_post(dt.date(2026, 9, 10)))
 
     def test_christmas_fast_is_fasting(self):
         """Дан у Божићном посту је постни дан."""
-        self.assertTrue(is_fasting_day(dt.date(2026, 12, 1)))
+        self.assertTrue(je_post(dt.date(2026, 12, 1)))
 
     def test_dormition_fast_is_fasting(self):
         """Дан у Успенском посту је постни дан."""
-        self.assertTrue(is_fasting_day(dt.date(2026, 8, 5)))
+        self.assertTrue(je_post(dt.date(2026, 8, 5)))
 
 
 class FastingCacheTests(TestCase):
     """#257: годишњи прорачуни поста се кеширају (N+1 → 1 упит/прорачун)."""
 
     def setUp(self):
-        clear_fasting_caches()
+        obrisi_kes_posta()
 
     def test_db_fasting_days_cached_per_year(self):
-        clear_fasting_caches()
+        obrisi_kes_posta()
         with CaptureQueriesContext(connection) as cold:
-            get_fasting_days_from_db(2026)
+            postni_dani_iz_baze(2026)
         self.assertGreaterEqual(len(cold.captured_queries), 1)
         with CaptureQueriesContext(connection) as warm:
             for _ in range(30):
-                get_fasting_days_from_db(2026)
+                postni_dani_iz_baze(2026)
         self.assertEqual(len(warm.captured_queries), 0)
 
-    def test_is_fasting_day_loop_single_year_query(self):
-        clear_fasting_caches()
+    def test_je_post_loop_single_year_query(self):
+        obrisi_kes_posta()
         days = [dt.date(2026, m, 15) for m in range(1, 13)]
         with CaptureQueriesContext(connection) as ctx:
             for d in days:
-                is_fasting_day(d)
+                je_post(d)
         # Сви дани исте године → DB постови се читају једном, не по позиву
         # (раније ~12 истоветних упита). Допуштамо и SET search_path.
         self.assertLessEqual(len(ctx.captured_queries), 2)
 
     def test_year_functions_return_frozenset(self):
-        self.assertIsInstance(get_great_lent(2026), frozenset)
-        self.assertIsInstance(get_apostles_fast(2026), frozenset)
-        self.assertIsInstance(get_fasting_days_from_db(2026), frozenset)
+        self.assertIsInstance(veliki_post(2026), frozenset)
+        self.assertIsInstance(apostolski_post(2026), frozenset)
+        self.assertIsInstance(postni_dani_iz_baze(2026), frozenset)
 
     def test_clear_resets_cache(self):
-        get_great_lent(2026)
-        self.assertGreaterEqual(get_great_lent.cache_info().currsize, 1)
-        clear_fasting_caches()
-        self.assertEqual(get_great_lent.cache_info().currsize, 0)
+        veliki_post(2026)
+        self.assertGreaterEqual(veliki_post.cache_info().currsize, 1)
+        obrisi_kes_posta()
+        self.assertEqual(veliki_post.cache_info().currsize, 0)
 

--- a/crkva/registar/tests/test_search_filters.py
+++ b/crkva/registar/tests/test_search_filters.py
@@ -80,11 +80,14 @@ class VencanjeFilterTests(TestCase):
             zenik=cls.zenik, nevesta=cls.nevesta, kum=cls.kum,
             stari_svat=cls.stari_svat, hram=cls.hram,
             datum=datetime.date(2023, 9, 3),
+            godina_registracije=2023, redni_broj=1,
         )
         z2 = Osoba.objects.create(ime="Иван", prezime="Иванић", pol="М")
         n2 = Osoba.objects.create(ime="Маја", prezime="Мајић", pol="Ж")
+        # Различит (godina, redni_broj) — иначе крши vencanje_god_redni_uniq (#251).
         Vencanje.objects.create(
-            zenik=z2, nevesta=n2, datum=datetime.date(2019, 2, 2)
+            zenik=z2, nevesta=n2, datum=datetime.date(2019, 2, 2),
+            godina_registracije=2019, redni_broj=1,
         )
 
     def _search(self, term):

--- a/crkva/registar/tests/test_slava_map.py
+++ b/crkva/registar/tests/test_slava_map.py
@@ -53,10 +53,16 @@ class ResolveSlavaTests(TestCase):
         self.assertNotIn(fix.uid, POKRETNE_SLAVE_OFFSET_BY_SIFRA)
         self.assertEqual(resolve_slava(fix.uid, Slava), fix)
 
-    def test_fixed_feast_uid_matches_sl_sifra_ordering(self):
-        # Поредак slave.jsonl прати SL_SIFRA: фиксни празник на (дан,месец)
-        # има PK == стара сифра. Провера на Никољдан (сифра 353, 19.12).
-        nikola = Slava.objects.filter(uid=353).first()
+    def test_seeded_fixed_feast_resolves_by_its_own_pk(self):
+        # Фиксни празник се разрешава преко свог PK. Не тврдимо апсолутну
+        # вредност uid-а: AutoField секвенца је дељена кроз цео тест-рун и
+        # напредује од претходних тестова, па uid==сифра важи само на
+        # свежем сеаду (rebuild), не у пуном сету. Тражимо стваран фиксни
+        # ред (Никола) по називу и проверавамо разрешење по његовом PK.
+        nikola = (
+            Slava.objects.filter(pokretni=False, naziv__icontains="Никола")
+            .exclude(uid__in=POKRETNE_SLAVE_OFFSET_BY_SIFRA)
+            .first()
+        )
         self.assertIsNotNone(nikola)
-        self.assertFalse(nikola.pokretni)
-        self.assertIn("Никола", nikola.naziv)
+        self.assertEqual(resolve_slava(nikola.uid, Slava), nikola)

--- a/crkva/registar/utils_fasting.py
+++ b/crkva/registar/utils_fasting.py
@@ -10,6 +10,9 @@
 from __future__ import annotations
 
 import datetime as dt
+from functools import lru_cache
+
+from django_tenants.utils import schema_context
 
 
 def _date_range(start: dt.date, end: dt.date) -> set[dt.date]:
@@ -22,25 +25,30 @@ def _date_range(start: dt.date, end: dt.date) -> set[dt.date]:
     return days
 
 
-def get_fasting_days_from_db(year: int) -> set[dt.date]:
-    """Врати скуп постних дана за дату годину из базе података."""
+@lru_cache(maxsize=128)
+def get_fasting_days_from_db(year: int) -> frozenset[dt.date]:
+    """Врати скуп постних дана за дату годину из базе података.
+
+    Резултат зависи само од године (Slava подаци су статични) па се кешира
+    по години — рендер месеца тако издаје 1 уместо ~30 истоветних упита
+    (#257). Slava живи у public шеми (дељени модел), па се чита у
+    schema_context("public") да буде исти за све закупце и безбедан за кеш.
+    """
     from registar.models import Slava
 
     fasting = set()
+    with schema_context("public"):
+        for post in Slava.objects.filter(post=True):
+            period = post.get_post(year)
+            if period and period[0] and period[1]:
+                start, end = period
+                fasting.update(_date_range(start, end))
 
-    # Узми све постове из базе
-    postovi = Slava.objects.filter(post=True)
-
-    for post in postovi:
-        period = post.get_post(year)
-        if period and period[0] and period[1]:
-            start, end = period
-            fasting.update(_date_range(start, end))
-
-    return fasting
+    return frozenset(fasting)
 
 
-def get_fixed_fasting_periods(year: int) -> set[dt.date]:
+@lru_cache(maxsize=128)
+def get_fixed_fasting_periods(year: int) -> frozenset[dt.date]:
     """Врати фиксне постне периоде (који се не рачунају из базе)."""
     fasting = set()
 
@@ -56,10 +64,11 @@ def get_fixed_fasting_periods(year: int) -> set[dt.date]:
     # Крстовдан: 18. јануар (појединачни дан)
     fasting.add(dt.date(year, 1, 18))
 
-    return fasting
+    return frozenset(fasting)
 
 
-def get_apostles_fast(year: int) -> set[dt.date]:
+@lru_cache(maxsize=128)
+def get_apostles_fast(year: int) -> frozenset[dt.date]:
     """Врати Апостолски (Петровдан) пост за дату годину.
 
     Почиње понедељак после Духова (Педесетнице) и траје до 11. јула (Петровдан eve).
@@ -81,12 +90,13 @@ def get_apostles_fast(year: int) -> set[dt.date]:
 
     # Ако је почетак после краја (кратак пост), врати празан скуп
     if start > end:
-        return set()
+        return frozenset()
 
-    return _date_range(start, end)
+    return frozenset(_date_range(start, end))
 
 
-def get_cheesefare_week(year: int) -> set[dt.date]:
+@lru_cache(maxsize=128)
+def get_cheesefare_week(year: int) -> frozenset[dt.date]:
     """Врати Бели мрс (недеља пре Великог поста - делимични пост без меса)."""
     from registar.models import Slava
 
@@ -99,10 +109,11 @@ def get_cheesefare_week(year: int) -> set[dt.date]:
     start = cisti_ponedeljak - dt.timedelta(days=7)
     end = cisti_ponedeljak - dt.timedelta(days=1)
 
-    return _date_range(start, end)
+    return frozenset(_date_range(start, end))
 
 
-def get_great_lent(year: int) -> set[dt.date]:
+@lru_cache(maxsize=128)
+def get_great_lent(year: int) -> frozenset[dt.date]:
     """Врати Велики пост за дату годину.
 
     Почиње Чистим понедељком (48 дана пре Васкрса) и
@@ -118,10 +129,11 @@ def get_great_lent(year: int) -> set[dt.date]:
     # Велика субота (Great Saturday) - 1 дан пре Васкрса
     end = vaskrs - dt.timedelta(days=1)
 
-    return _date_range(start, end)
+    return frozenset(_date_range(start, end))
 
 
-def get_trapave_weeks(year: int) -> set[dt.date]:
+@lru_cache(maxsize=128)
+def get_trapave_weeks(year: int) -> frozenset[dt.date]:
     """Врати трапаве седмице (седмице без поста) за дату годину."""
     from registar.models import Slava
 
@@ -149,7 +161,24 @@ def get_trapave_weeks(year: int) -> set[dt.date]:
     # После Божића до Крстовдана (7-17. јануар)
     trapave.update(_date_range(dt.date(year, 1, 7), dt.date(year, 1, 17)))
 
-    return trapave
+    return frozenset(trapave)
+
+
+def clear_fasting_caches() -> None:
+    """Очисти годишње кешеве поста.
+
+    Позвати после измене Slava `post` података (нпр. reseed) или у тестовима
+    који мењају DB постове, да се не послужи устајали резултат.
+    """
+    for fn in (
+        get_fasting_days_from_db,
+        get_fixed_fasting_periods,
+        get_apostles_fast,
+        get_cheesefare_week,
+        get_great_lent,
+        get_trapave_weeks,
+    ):
+        fn.cache_clear()
 
 
 def is_fasting_day(date: dt.date) -> bool:

--- a/crkva/registar/utils_fasting.py
+++ b/crkva/registar/utils_fasting.py
@@ -15,18 +15,18 @@ from functools import lru_cache
 from django_tenants.utils import schema_context
 
 
-def _date_range(start: dt.date, end: dt.date) -> set[dt.date]:
-    """Скуп датума у затвореном интервалу [start, end]."""
+def _opseg_datuma(pocetak: dt.date, kraj: dt.date) -> set[dt.date]:
+    """Скуп датума у затвореном интервалу [pocetak, kraj]."""
     days = set()
-    cur = start
-    while cur <= end:
+    cur = pocetak
+    while cur <= kraj:
         days.add(cur)
         cur = cur + dt.timedelta(days=1)
     return days
 
 
 @lru_cache(maxsize=128)
-def get_fasting_days_from_db(year: int) -> frozenset[dt.date]:
+def postni_dani_iz_baze(godina: int) -> frozenset[dt.date]:
     """Врати скуп постних дана за дату годину из базе података.
 
     Резултат зависи само од године (Slava подаци су статични) па се кешира
@@ -36,46 +36,46 @@ def get_fasting_days_from_db(year: int) -> frozenset[dt.date]:
     """
     from registar.models import Slava
 
-    fasting = set()
+    postni_dani = set()
     with schema_context("public"):
         for post in Slava.objects.filter(post=True):
-            period = post.get_post(year)
+            period = post.get_post(godina)
             if period and period[0] and period[1]:
-                start, end = period
-                fasting.update(_date_range(start, end))
+                pocetak, kraj = period
+                postni_dani.update(_opseg_datuma(pocetak, kraj))
 
-    return frozenset(fasting)
+    return frozenset(postni_dani)
 
 
 @lru_cache(maxsize=128)
-def get_fixed_fasting_periods(year: int) -> frozenset[dt.date]:
+def fiksni_postovi(godina: int) -> frozenset[dt.date]:
     """Врати фиксне постне периоде (који се не рачунају из базе)."""
-    fasting = set()
+    postni_dani = set()
 
     # Божићни пост: 28. новембар – 6. јануар
     # Део у текућој години (28.11 - 31.12)
-    fasting.update(_date_range(dt.date(year, 11, 28), dt.date(year, 12, 31)))
+    postni_dani.update(_opseg_datuma(dt.date(godina, 11, 28), dt.date(godina, 12, 31)))
     # Део у следећој години (1.1 - 6.1)
-    fasting.update(_date_range(dt.date(year, 1, 1), dt.date(year, 1, 6)))
+    postni_dani.update(_opseg_datuma(dt.date(godina, 1, 1), dt.date(godina, 1, 6)))
 
     # Успенски пост (Dormition fast): 1-14. август
-    fasting.update(_date_range(dt.date(year, 8, 1), dt.date(year, 8, 14)))
+    postni_dani.update(_opseg_datuma(dt.date(godina, 8, 1), dt.date(godina, 8, 14)))
 
     # Крстовдан: 18. јануар (појединачни дан)
-    fasting.add(dt.date(year, 1, 18))
+    postni_dani.add(dt.date(godina, 1, 18))
 
-    return frozenset(fasting)
+    return frozenset(postni_dani)
 
 
 @lru_cache(maxsize=128)
-def get_apostles_fast(year: int) -> frozenset[dt.date]:
+def apostolski_post(godina: int) -> frozenset[dt.date]:
     """Врати Апостолски (Петровдан) пост за дату годину.
 
     Почиње понедељак после Духова (Педесетнице) и траје до 11. јула (Петровдан eve).
     """
     from registar.models import Slava
 
-    vaskrs = Slava.calc_vaskrs(year)
+    vaskrs = Slava.calc_vaskrs(godina)
 
     # Духови (Педесетница) су 49 дана после Васкрса (50. дан рачунајући Васкрс
     # као први дан), и увек падају у недељу.
@@ -83,37 +83,37 @@ def get_apostles_fast(year: int) -> frozenset[dt.date]:
 
     # Пост почиње следећег понедељка после Духова
     # Духови су увек недеља, тако да је следећи дан понедељак
-    start = duhovi + dt.timedelta(days=1)
+    pocetak = duhovi + dt.timedelta(days=1)
 
     # Пост траје до 11. јула (укључујући)
-    end = dt.date(year, 7, 11)
+    kraj = dt.date(godina, 7, 11)
 
     # Ако је почетак после краја (кратак пост), врати празан скуп
-    if start > end:
+    if pocetak > kraj:
         return frozenset()
 
-    return frozenset(_date_range(start, end))
+    return frozenset(_opseg_datuma(pocetak, kraj))
 
 
 @lru_cache(maxsize=128)
-def get_cheesefare_week(year: int) -> frozenset[dt.date]:
+def beli_mrs(godina: int) -> frozenset[dt.date]:
     """Врати Бели мрс (недеља пре Великог поста - делимични пост без меса)."""
     from registar.models import Slava
 
-    vaskrs = Slava.calc_vaskrs(year)
+    vaskrs = Slava.calc_vaskrs(godina)
 
     # Чисти понедељак је 48 дана пре Васкрса
     cisti_ponedeljak = vaskrs - dt.timedelta(days=48)
 
     # Бели мрс је недеља пре Чистог понедељка
-    start = cisti_ponedeljak - dt.timedelta(days=7)
-    end = cisti_ponedeljak - dt.timedelta(days=1)
+    pocetak = cisti_ponedeljak - dt.timedelta(days=7)
+    kraj = cisti_ponedeljak - dt.timedelta(days=1)
 
-    return frozenset(_date_range(start, end))
+    return frozenset(_opseg_datuma(pocetak, kraj))
 
 
 @lru_cache(maxsize=128)
-def get_great_lent(year: int) -> frozenset[dt.date]:
+def veliki_post(godina: int) -> frozenset[dt.date]:
     """Врати Велики пост за дату годину.
 
     Почиње Чистим понедељком (48 дана пре Васкрса) и
@@ -121,106 +121,106 @@ def get_great_lent(year: int) -> frozenset[dt.date]:
     """
     from registar.models import Slava
 
-    vaskrs = Slava.calc_vaskrs(year)
+    vaskrs = Slava.calc_vaskrs(godina)
 
     # Чисти понедељак (Clean Monday) - 48 дана пре Васкрса
-    start = vaskrs - dt.timedelta(days=48)
+    pocetak = vaskrs - dt.timedelta(days=48)
 
     # Велика субота (Great Saturday) - 1 дан пре Васкрса
-    end = vaskrs - dt.timedelta(days=1)
+    kraj = vaskrs - dt.timedelta(days=1)
 
-    return frozenset(_date_range(start, end))
+    return frozenset(_opseg_datuma(pocetak, kraj))
 
 
 @lru_cache(maxsize=128)
-def get_trapave_weeks(year: int) -> frozenset[dt.date]:
+def trapave_sedmice(godina: int) -> frozenset[dt.date]:
     """Врати трапаве седмице (седмице без поста) за дату годину."""
     from registar.models import Slava
 
-    vaskrs = Slava.calc_vaskrs(year)
+    vaskrs = Slava.calc_vaskrs(godina)
     trapave = set()
 
     # Светла седмица (недеља после Васкрса)
     trapave.update(
-        _date_range(vaskrs + dt.timedelta(days=1), vaskrs + dt.timedelta(days=7))
+        _opseg_datuma(vaskrs + dt.timedelta(days=1), vaskrs + dt.timedelta(days=7))
     )
 
     # Седмица после Духова (49 дана после Васкрса; недеља после је трапава)
     duhovi = vaskrs + dt.timedelta(days=49)
     trapave.update(
-        _date_range(duhovi + dt.timedelta(days=1), duhovi + dt.timedelta(days=7))
+        _opseg_datuma(duhovi + dt.timedelta(days=1), duhovi + dt.timedelta(days=7))
     )
 
     # Митар и Фарисеј (3 недеље пре Чистог понедељка)
     cisti_ponedeljak = vaskrs - dt.timedelta(days=48)
     mitar_i_farisej_start = cisti_ponedeljak - dt.timedelta(days=21)
     trapave.update(
-        _date_range(mitar_i_farisej_start, mitar_i_farisej_start + dt.timedelta(days=6))
+        _opseg_datuma(mitar_i_farisej_start, mitar_i_farisej_start + dt.timedelta(days=6))
     )
 
     # После Божића до Крстовдана (7-17. јануар)
-    trapave.update(_date_range(dt.date(year, 1, 7), dt.date(year, 1, 17)))
+    trapave.update(_opseg_datuma(dt.date(godina, 1, 7), dt.date(godina, 1, 17)))
 
     return frozenset(trapave)
 
 
-def clear_fasting_caches() -> None:
+def obrisi_kes_posta() -> None:
     """Очисти годишње кешеве поста.
 
     Позвати после измене Slava `post` података (нпр. reseed) или у тестовима
     који мењају DB постове, да се не послужи устајали резултат.
     """
     for fn in (
-        get_fasting_days_from_db,
-        get_fixed_fasting_periods,
-        get_apostles_fast,
-        get_cheesefare_week,
-        get_great_lent,
-        get_trapave_weeks,
+        postni_dani_iz_baze,
+        fiksni_postovi,
+        apostolski_post,
+        beli_mrs,
+        veliki_post,
+        trapave_sedmice,
     ):
         fn.cache_clear()
 
 
-def is_fasting_day(date: dt.date) -> bool:
+def je_post(datum: dt.date) -> bool:
     """Да ли је дати датум пост."""
-    year = date.year
+    godina = datum.year
 
     # Узми све постове из базе (додатни покретни постови)
-    fasting_from_db = get_fasting_days_from_db(year)
+    fasting_from_db = postni_dani_iz_baze(godina)
 
     # Узми фиксне постове (Божићни, Успенски, Крстовдан)
-    fixed_fasting = get_fixed_fasting_periods(year)
+    fixed_fasting = fiksni_postovi(godina)
 
     # Узми Велики пост (покретан, базиран на Васкрсу)
-    great_lent = get_great_lent(year)
+    great_lent = veliki_post(godina)
 
     # Узми Апостолски пост (покретан, базиран на Духовима)
-    apostles_fast = get_apostles_fast(year)
+    apostles_fast = apostolski_post(godina)
 
     # Узми Бели мрс (недеља пре Великог поста - делимични пост)
-    cheesefare = get_cheesefare_week(year)
+    cheesefare = beli_mrs(godina)
 
     # Ако је дан у било ком посту
     if (
-        date in fasting_from_db
-        or date in fixed_fasting
-        or date in great_lent
-        or date in apostles_fast
-        or date in cheesefare
+        datum in fasting_from_db
+        or datum in fixed_fasting
+        or datum in great_lent
+        or datum in apostles_fast
+        or datum in cheesefare
     ):
         return True
 
     # Провери да ли је среда или петак (општи пост)
-    if date.weekday() in (2, 4):  # 0=пон, 2=сре, 4=пет
+    if datum.weekday() in (2, 4):  # 0=пон, 2=сре, 4=пет
         # Провери да ли је у трапавој седмици
-        trapave = get_trapave_weeks(year)
-        if date not in trapave:
+        trapave = trapave_sedmice(godina)
+        if datum not in trapave:
             return True
 
     return False
 
 
-def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
+def tip_posta(datum: dt.date) -> dict[str, str | bool]:
     """Врати тип поста и дозвољена јела за дати датум.
 
     Враћа речник са следећим кључевима:
@@ -231,21 +231,21 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
     """
     from registar.models import Slava
 
-    year = date.year
-    weekday = date.weekday()  # 0=пон, 1=уто, 2=сре, 3=чет, 4=пет, 5=суб, 6=нед
+    godina = datum.year
+    dan_u_nedelji = datum.weekday()  # 0=пон, 1=уто, 2=сре, 3=чет, 4=пет, 5=суб, 6=нед
 
     # Провери да ли је у трапавој седмици (без поста)
-    trapave = get_trapave_weeks(year)
-    if date in trapave:
+    trapave = trapave_sedmice(godina)
+    if datum in trapave:
         return {"is_fasting": False, "type": None, "display": None, "description": None}
 
     # Велики пост (Great Lent)
-    great_lent = get_great_lent(year)
-    if date in great_lent:
-        vaskrs = Slava.calc_vaskrs(year)
+    great_lent = veliki_post(godina)
+    if datum in great_lent:
+        vaskrs = Slava.calc_vaskrs(godina)
 
         # Проверa за Благовести (25. март) у Великом посту
-        if date.month == 3 and date.day == 25:
+        if datum.month == 3 and datum.day == 25:
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -255,7 +255,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
 
         # Лазарева субота (дан пре Цвети)
         lazareva_subota = vaskrs - dt.timedelta(days=8)
-        if date == lazareva_subota:
+        if datum == lazareva_subota:
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -265,7 +265,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
 
         # Цвети (Вrbica, недеља пре Васкрса)
         cveti = vaskrs - dt.timedelta(days=7)
-        if date == cveti:
+        if datum == cveti:
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -274,7 +274,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Субота и недеља у Великом посту - уље и вино
-        if weekday in (5, 6):  # субота или недеља
+        if dan_u_nedelji in (5, 6):  # субота или недеља
             return {
                 "is_fasting": True,
                 "type": "уље",
@@ -291,8 +291,8 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
         }
 
     # Бели мрс (Cheesefare week - недеља пре Великог поста)
-    cheesefare = get_cheesefare_week(year)
-    if date in cheesefare:
+    cheesefare = beli_mrs(godina)
+    if datum in cheesefare:
         return {
             "is_fasting": True,
             "type": "бели_мрс",
@@ -302,12 +302,12 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
 
     # Божићни пост (Christmas Fast) - 28. новембар до 6. јануар
     if (
-        (date.month == 11 and date.day >= 28)
-        or (date.month == 12)
-        or (date.month == 1 and date.day <= 6)
+        (datum.month == 11 and datum.day >= 28)
+        or (datum.month == 12)
+        or (datum.month == 1 and datum.day <= 6)
     ):
         # Провери изузетке (Божић 25.12 по Јулијанском = 7.1 по Грегоријанском)
-        if date.month == 1 and date.day == 7:
+        if datum.month == 1 and datum.day == 7:
             return {
                 "is_fasting": False,
                 "type": None,
@@ -316,7 +316,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Сочи дан (6. јануар) - строг пост
-        if date.month == 1 and date.day == 6:
+        if datum.month == 1 and datum.day == 6:
             return {
                 "is_fasting": True,
                 "type": "вода",
@@ -325,7 +325,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Субота и недеља - риба
-        if weekday in (5, 6):
+        if dan_u_nedelji in (5, 6):
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -334,7 +334,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Уторак и четвртак - уље
-        if weekday in (1, 3):
+        if dan_u_nedelji in (1, 3):
             return {
                 "is_fasting": True,
                 "type": "уље",
@@ -351,9 +351,9 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
         }
 
     # Успенски пост (Dormition Fast) - 1-14. август
-    if date.month == 8 and 1 <= date.day <= 14:
+    if datum.month == 8 and 1 <= datum.day <= 14:
         # Преображење (6. август) - риба
-        if date.day == 6:
+        if datum.day == 6:
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -362,7 +362,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Субота и недеља - риба
-        if weekday in (5, 6):
+        if dan_u_nedelji in (5, 6):
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -371,7 +371,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Среда и петак - вода
-        if weekday in (2, 4):
+        if dan_u_nedelji in (2, 4):
             return {
                 "is_fasting": True,
                 "type": "вода",
@@ -388,10 +388,10 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
         }
 
     # Апостолски пост (Apostles' Fast)
-    apostles_fast = get_apostles_fast(year)
-    if date in apostles_fast:
+    apostles_fast = apostolski_post(godina)
+    if datum in apostles_fast:
         # Субота и недеља - риба
-        if weekday in (5, 6):
+        if dan_u_nedelji in (5, 6):
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -400,7 +400,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Уторак и четвртак - риба
-        if weekday in (1, 3):
+        if dan_u_nedelji in (1, 3):
             return {
                 "is_fasting": True,
                 "type": "риба",
@@ -409,7 +409,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
             }
 
         # Понедељак - уље
-        if weekday == 0:
+        if dan_u_nedelji == 0:
             return {
                 "is_fasting": True,
                 "type": "уље",
@@ -426,7 +426,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
         }
 
     # Крстовдан (18. јануар) - вода
-    if date.month == 1 and date.day == 18:
+    if datum.month == 1 and datum.day == 18:
         return {
             "is_fasting": True,
             "type": "вода",
@@ -435,7 +435,7 @@ def get_fasting_type(date: dt.date) -> dict[str, str | bool]:
         }
 
     # Општи пост (среда и петак)
-    if weekday in (2, 4):
+    if dan_u_nedelji in (2, 4):
         return {
             "is_fasting": True,
             "type": "вода",

--- a/crkva/registar/views/home_view.py
+++ b/crkva/registar/views/home_view.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
 from registar.models import Krstenje, Osoba, Slava, Svestenik, Vencanje
-from registar.utils_fasting import get_fasting_type
+from registar.utils_fasting import tip_posta
 
 
 @login_required
@@ -65,7 +65,7 @@ def index(request) -> HttpResponse:
 
     cells = []
     for d in days:
-        fasting_info = get_fasting_type(d)
+        fasting_info = tip_posta(d)
         day_slavas = by_day.get((d.month, d.day), [])
 
         # Separate fixed and moveable feasts

--- a/crkva/registar/views/kalendar_view.py
+++ b/crkva/registar/views/kalendar_view.py
@@ -12,7 +12,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from kalendar.models import Slava
 from registar.utils import MESECI
-from registar.utils_fasting import get_fasting_type
+from registar.utils_fasting import tip_posta
 
 
 # crkvenikalendar.rs uses Cyrillic-month-name spelled in Latin script in the URL.
@@ -91,7 +91,7 @@ def kalendar(
     for _ in range(first_weekday):
         cells.append({"is_placeholder": True})
     for d in days:
-        fasting_info = get_fasting_type(d)
+        fasting_info = tip_posta(d)
         day_slavas = by_day.get(d.day, [])
 
         # Separate fixed and moveable feasts


### PR DESCRIPTION
## Проблем (#257)

`is_fasting_day` (контекст-процесор, ~3× по свакој страници) и `get_fasting_type` (петља `for d in days` у календару) поново су рачунали **исте годишње скупове** — Велики пост, Апостолски пост, Бели мрс, Сиропусна/трапаве седмице — а `get_fasting_days_from_db` је уз то издавао `Slava.objects.filter(post=True)`. Рендер једног месеца → ~30 истоветних прорачуна (и упита кроз `is_fasting_day`); контекст-процесор додаје још. Класичан N+1 вођен петљом рендера.

## Решење

Свих 6 функција зависи **само од `year`**, па су обмотане у `functools.lru_cache(maxsize=128)`:

- `get_fasting_days_from_db`, `get_fixed_fasting_periods`, `get_apostles_fast`, `get_cheesefare_week`, `get_great_lent`, `get_trapave_weeks`

Додатно:
- Враћају **`frozenset`** — кеширани објекат је дељен, па се не сме мутирати (позиваоци раде само `in`).
- `get_fasting_days_from_db` чита `Slava` у `schema_context("public")` — `Slava` је дељени (public) модел, па је резултат исти за све закупце и **безбедан за глобални кеш** (детерминистички, не зависи од активног закупца).
- Нови `clear_fasting_caches()` — за reseed `Slava.post` података или тестове.

**Ефекат:** ~30+ прорачуна/упита по рендеру календара → **1 по години**.

## Тестови

`test_fasting.py::FastingCacheTests` (4):
- топли кеш: 30 позива `get_fasting_days_from_db` = **0 упита**;
- `is_fasting_day` кроз 12 месеци исте године = **≤1 упит** (раније ~12);
- повратни тип је `frozenset`;
- `clear_fasting_caches()` ресетује кеш.

Цео `test_fasting.py` (45) зелен. Без миграција; деплој = `reload` (lru_cache је per-worker, па reload чисти кеш).

Closes #257
