### PR TITLE
fix(registar): уклони мртви K_REGKADA селект из увоза крштења (#254)

### DIFF
--- a/crkva/registar/management/commands/migracija_krstenja.py
+++ b/crkva/registar/management/commands/migracija_krstenja.py
@@ -96,7 +96,9 @@ SOURCE_COLUMNS = (
     "K_KUMZANIM",
     "K_KUMMEST",
     "K_REGMESTO",
-    "K_REGKADA",
+    # K_REGKADA (датум регистрације) изостављен: DBF 'D' поље је празно
+    # у целом извору (0/3579), па је селект био мртав уз тврдо
+    # registracija_datum=None. Нема шта да се учита (#254).
     "K_REGBROJ",
     "K_REGSTR",
 )
@@ -162,7 +164,6 @@ class KrstenjeRecord:  # pylint: disable=too-many-instance-attributes
     kum_mesto: str
 
     registracija_mesto: str
-    registracija_datum: Optional[date]
     registracija_broj: Optional[str]
     registracija_strana: Optional[str]
 
@@ -226,9 +227,10 @@ def parse_row(row: tuple) -> KrstenjeRecord:
         kum_zanimanje=cyr(row[43]),
         kum_mesto=cyr(row[44]),
         registracija_mesto=cyr(row[45]),
-        registracija_datum=None,
-        registracija_broj=cyr(row[47]) or None,
-        registracija_strana=cyr(row[48]) or None,
+        # K_REGKADA уклоњен из SOURCE_COLUMNS (#254) → K_REGBROJ/K_REGSTR
+        # су се померили на индексе 46/47.
+        registracija_broj=cyr(row[46]) or None,
+        registracija_strana=cyr(row[47]) or None,
     )
 
 
@@ -429,7 +431,6 @@ class Command(MigrationCommand):
             "ime_blizanca": r.blizanac_ime,
             "telesna_mana": r.dete_sa_manom.strip() == "1",
             "mesto_registracije": r.registracija_mesto,
-            "datum_registracije": r.registracija_datum,
             "maticni_broj": r.registracija_broj,
             "strana_registracije": r.registracija_strana,
             "primedba": "",

--- a/crkva/registar/tests/test_migracija_krstenja_regkada.py
+++ b/crkva/registar/tests/test_migracija_krstenja_regkada.py
@@ -1,0 +1,36 @@
+"""#254: K_REGKADA (датум регистрације крштења) је празан у целом извору.
+
+DBF поље ``K_REGKADA`` ('D', 8) је NULL у свих 3579 редова, а ``parse_row`` је
+тврдо постављао ``registracija_datum=None`` поред мртвог селекта. Уклоњено из
+``SOURCE_COLUMNS`` уз померање ``K_REGBROJ``/``K_REGSTR`` на индексе 46/47.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.test import SimpleTestCase
+
+from registar.management.commands.migracija_krstenja import SOURCE_COLUMNS, parse_row
+
+
+class RegKadaRemovedTests(SimpleTestCase):
+    def test_regkada_not_in_source_columns(self):
+        self.assertNotIn("K_REGKADA", SOURCE_COLUMNS)
+
+    def test_registration_block_is_mesto_broj_strana(self):
+        self.assertEqual(
+            SOURCE_COLUMNS[-3:], ("K_REGMESTO", "K_REGBROJ", "K_REGSTR")
+        )
+
+    def test_parse_row_reads_reindexed_registration_columns(self):
+        row = [""] * len(SOURCE_COLUMNS)
+        row[45] = "100"  # K_REGMESTO
+        row[46] = "200"  # K_REGBROJ (раније 47)
+        row[47] = "300"  # K_REGSTR  (раније 48)
+        rec = parse_row(tuple(row))
+        self.assertEqual(rec.registracija_mesto, "100")
+        self.assertEqual(rec.registracija_broj, "200")
+        self.assertEqual(rec.registracija_strana, "300")
+
+    def test_record_has_no_registration_date_field(self):
+        rec = parse_row(tuple([""] * len(SOURCE_COLUMNS)))
+        self.assertFalse(hasattr(rec, "registracija_datum"))


### PR DESCRIPTION
## Проблем (#254)

`migracija_krstenja` је селектовао `K_REGKADA` (индекс 46) у `SOURCE_COLUMNS`, а `parse_row` је тврдо постављао `registracija_datum=None` — мртав селект уз заваравајуће тврдо `None`.

## Провера извора (HSPKRST.DBF)

| колона | тип | попуњено |
|---|---|---|
| `K_REGMESTO` → `mesto_registracije` | C | **3573 / 3579** |
| `K_REGKADA` → `datum_registracije` | **D** | **0 / 3579** |
| `K_REGBROJ` → `maticni_broj` | C | 0 / 3579 |
| `K_REGSTR` → `strana_registracije` | C | 0 / 3579 |

Премиса тикета („податак постоји у DBF-у“) **не важи**: `K_REGKADA` је DBF датумско поље празно у целом извору. Дакле датум регистрације не постоји — нема шта да се парсира ни да се накнадно допуни (`datum_registracije=NULL` у бази је исправан). `K_REGMESTO` јесте попуњен и остаје.

## Решење (фолбек из тикета за празан извор)

- `K_REGKADA` уклоњен из `SOURCE_COLUMNS` (више нема мртвог селекта), уз објашњење.
- Мртво поље `registracija_datum` уклоњено из `KrstenjeRecord` и из мапирања модела — `datum_registracije` остаје нулабилно поље, само се не пуни из увоза.
- `K_REGBROJ`/`K_REGSTR` померени на индексе 46/47 (`parse_row`), понашање непромењено (и они су празни).

## Тестови

`test_migracija_krstenja_regkada.py` (4): `K_REGKADA` није у `SOURCE_COLUMNS`; регистрациони блок је `(K_REGMESTO, K_REGBROJ, K_REGSTR)`; `parse_row` чита реиндексиране колоне; нема `registracija_datum` поља. Без миграција, без промене података (све три колоне су ионако празне) → деплој `reload`.

Closes #254
