### PR TITLE
fix(settings): продукцијско безбедносно учвршћивање (#223)

### DIFF
--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -36,8 +36,17 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 
-ALLOWED_HOSTS: List[str] = ["*"]
-ALLOWED_HOSTS.extend(filter(None, os.environ.get("ALLOWED_HOSTS", "").split(",")))
+# Тест-рунери (manage.py test / pytest) форсирају DEBUG=False, па би
+# продукцијско учвршћивање испод иначе укључило SSL redirect и празан
+# ALLOWED_HOSTS усред тестова. Откривамо тест-рун да то избегнемо (#223).
+_RUNNING_TESTS = "test" in sys.argv or sys.argv[0].endswith(("pytest", "py.test"))
+
+# Продукција прихвата само хостове из ALLOWED_HOSTS env; dev/тест дозвољавају све.
+ALLOWED_HOSTS: List[str] = list(
+    filter(None, os.environ.get("ALLOWED_HOSTS", "").split(","))
+)
+if DEBUG or _RUNNING_TESTS:
+    ALLOWED_HOSTS = ALLOWED_HOSTS or ["*"]
 
 # Behind Caddy, which terminates TLS and reverse-proxies plain HTTP to
 # gunicorn. Trust its X-Forwarded-Proto header so request.is_secure(),
@@ -46,6 +55,18 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 CSRF_TRUSTED_ORIGINS = list(
     filter(None, os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(","))
 )
+
+# Продукцијско безбедносно учвршћивање (#223) — активно када је DEBUG искључен
+# (и ван тестова). TLS терминира Caddy, па се ово ослања на горњи
+# SECURE_PROXY_SSL_HEADER (Caddy шаље X-Forwarded-Proto=https).
+if not DEBUG and not _RUNNING_TESTS:
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000  # 1 година
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
 
 # Application definition
 

--- a/crkva/registar/tests/test_settings_hardening.py
+++ b/crkva/registar/tests/test_settings_hardening.py
@@ -1,0 +1,29 @@
+"""#223: продукцијско безбедносно учвршћивање не сме да се укључи усред тестова.
+
+Гејт `_RUNNING_TESTS` у settings.py држи SSL-redirect, secure-cookies и
+рестриктиван ALLOWED_HOSTS искљученим док траје тест-рун (иначе би сви
+client тестови добијали 301 / 400). Овај тест чува тај гејт.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+class SecurityHardeningGatingTests(SimpleTestCase):
+    def test_ssl_redirect_off_during_tests(self):
+        self.assertFalse(getattr(settings, "SECURE_SSL_REDIRECT", False))
+
+    def test_secure_cookies_off_during_tests(self):
+        self.assertFalse(getattr(settings, "SESSION_COOKIE_SECURE", False))
+        self.assertFalse(getattr(settings, "CSRF_COOKIE_SECURE", False))
+
+    def test_allowed_hosts_permissive_during_tests(self):
+        self.assertIn("*", settings.ALLOWED_HOSTS)
+
+    def test_proxy_ssl_header_always_set(self):
+        # Не зависи од DEBUG-а: треба и у dev/тесту иза reverse-proxy-ја.
+        self.assertEqual(
+            settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https")
+        )


### PR DESCRIPTION
## Проблем (#223)

`manage.py check --deploy` је пријављивао **6 упозорења** (W004 HSTS, W008 SSL-redirect, W009 SECRET_KEY, W012/W016 secure cookies, W018 DEBUG).

## Решење (код — овај PR)

`settings.py`: безбедносно учвршћивање активно **када је DEBUG искључен и ван тест-рунова**:

```python
if not DEBUG and not _RUNNING_TESTS:
    SECURE_SSL_REDIRECT = True
    SESSION_COOKIE_SECURE = True
    CSRF_COOKIE_SECURE = True
    SECURE_HSTS_SECONDS = 31536000
    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
    SECURE_HSTS_PRELOAD = True
    SECURE_CONTENT_TYPE_NOSNIFF = True
```

- **ALLOWED_HOSTS**: продукција прихвата само хостове из env (више није `["*"]`); dev/тест дозвољавају све.
- TLS терминира **Caddy** (auto `X-Forwarded-Proto=https`) → ослањамо се на постојећи `SECURE_PROXY_SSL_HEADER`, нема redirect петље.
- Статику служи **WhiteNoise** → `DEBUG=False` не квари CSS/JS.

### Зашто `_RUNNING_TESTS` гејт
Django тест-рунер форсира `DEBUG=False`. Без гејта би `SECURE_SSL_REDIRECT` дао 301 на сваки client тест, а празан `ALLOWED_HOSTS` 400. Гејт (`"test" in argv` / pytest) држи учвршћивање искљученим током тестова.

## Решење (продукцијски `.env` — није у git-у, примењује се при деплоју)

- `DEBUG=0`
- `SECRET_KEY=<јак насумичан 50+>` — тренутно је `dev-secret-key-change-in-production` (познат placeholder!) → **ротација** (поништава постојеће сесије; 2 корисника се поново пријављују)
- `ALLOWED_HOSTS=crkva.46-224-30-151.sslip.io,46.224.30.151,127.0.0.1,localhost`
- `CSRF_TRUSTED_ORIGINS` већ постављен

Уз ове вредности `manage.py check --deploy` пријављује **0 проблема** (проверено на грани).

## Деплој (после мерџа)
`.env` измене → `collectstatic` → `reload`. Без миграција.

## Тестови
`test_settings_hardening.py` (4) — гејт држи SSL-redirect/secure-cookies искљученим и ALLOWED_HOSTS пермисивним у тестовима; `SECURE_PROXY_SSL_HEADER` увек постављен. CI већ има `check --deploy` (informational) корак.

Closes #223
