### PR TITLE
fix(tenants): постојећи корисник може у другу парохију (#228)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ notebooks/
 
 # Node tooling (biome)
 node_modules/
+
+# env backups (никад у git — садрже DB_PASS/SECRET_KEY)
+.env.*

--- a/crkva/tenants/forms.py
+++ b/crkva/tenants/forms.py
@@ -36,7 +36,11 @@ class AddUserForm(forms.Form):
     last_name = forms.CharField(max_length=150, required=False, label="Презиме")
     email = forms.EmailField(required=False, label="Е-маил")
     password = forms.CharField(
-        label="Лозинка", widget=forms.PasswordInput, min_length=8
+        label="Лозинка",
+        widget=forms.PasswordInput,
+        required=False,
+        min_length=8,
+        help_text="Обавезна само за новог корисника; за постојећег се игнорише.",
     )
     role = forms.ChoiceField(choices=Role.choices, label="Улога")
     is_default = forms.BooleanField(
@@ -44,17 +48,31 @@ class AddUserForm(forms.Form):
     )
 
     def clean_username(self):
+        # Постојеће корисничко име више није грешка: постојећи корисник се може
+        # везати за још једну парохију (ново чланство). Дупло чланство у ИСТОЈ
+        # парохији проверава view (има request.tenant). (#228)
         username = self.cleaned_data["username"].strip()
         if not username:
             raise ValidationError("Корисничко име је обавезно.")
-        if User.objects.filter(username=username).exists():
-            raise ValidationError("Корисник са овим именом већ постоји.")
         return username
 
     def clean_password(self):
-        password = self.cleaned_data["password"]
-        validate_password(password)
+        password = self.cleaned_data.get("password", "")
+        if password:
+            validate_password(password)
         return password
+
+    def clean(self):
+        cleaned = super().clean()
+        username = cleaned.get("username")
+        # Лозинка је обавезна само када се прави НОВИ корисник.
+        if (
+            username
+            and not cleaned.get("password")
+            and not User.objects.filter(username=username).exists()
+        ):
+            self.add_error("password", "Лозинка је обавезна за новог корисника.")
+        return cleaned
 
 
 class EditRoleForm(forms.Form):

--- a/crkva/tenants/tests/test_user_management.py
+++ b/crkva/tenants/tests/test_user_management.py
@@ -108,18 +108,83 @@ class UserManagementViewTests(TestCase):
         )
         self.assertEqual(r.status_code, 403)
 
-    def test_duplicate_username_rejected(self):
+    def test_existing_member_of_this_parish_rejected(self):
+        # „kanc“ је већ члан ове парохије → грешка, без дупог чланства (#228).
         self.client.force_login(self.admin)
         r = self.client.post(
             reverse("parohija:user_add"),
-            {
-                "username": "kanc",  # already exists
-                "password": "veryStrong!Pass1",
-                "role": Role.PREGLED,
-            },
+            {"username": "kanc", "role": Role.PREGLED},
         )
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.context["form"].errors)
+        self.assertEqual(
+            UserMembership.objects.filter(user=self.clerk, tenant=self.tenant).count(),
+            1,
+        )
+
+    def test_existing_user_added_to_current_parish(self):
+        # Постојећи корисник из друге парохије се веже за ову — без новог налога.
+        self.client.force_login(self.admin)
+        before = User.objects.count()
+        r = self.client.post(
+            reverse("parohija:user_add"),
+            {"username": "other_kanc", "role": Role.PREGLED},
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(User.objects.count(), before)
+        self.assertTrue(
+            UserMembership.objects.filter(
+                user=self.foreign_clerk, tenant=self.tenant, role=Role.PREGLED
+            ).exists()
+        )
+        self.assertTrue(
+            UserMembership.objects.filter(
+                user=self.foreign_clerk, tenant=self.other_tenant
+            ).exists()
+        )
+
+    def test_existing_user_password_not_reset(self):
+        # Admin једне парохије не сме да ресетује глобалну лозинку (#228).
+        self.client.force_login(self.admin)
+        old_hash = User.objects.get(username="other_kanc").password
+        self.client.post(
+            reverse("parohija:user_add"),
+            {
+                "username": "other_kanc",
+                "password": "attackerNewPass!9",
+                "role": Role.PREGLED,
+            },
+        )
+        self.assertEqual(User.objects.get(username="other_kanc").password, old_hash)
+
+    def test_new_user_requires_password(self):
+        self.client.force_login(self.admin)
+        r = self.client.post(
+            reverse("parohija:user_add"),
+            {"username": "brandnew", "role": Role.PREGLED},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("password", r.context["form"].errors)
+        self.assertFalse(User.objects.filter(username="brandnew").exists())
+
+    def test_setting_default_clears_previous_default(self):
+        m_other = UserMembership.objects.get(
+            user=self.foreign_clerk, tenant=self.other_tenant
+        )
+        m_other.is_default = True
+        m_other.save()
+        self.client.force_login(self.admin)
+        self.client.post(
+            reverse("parohija:user_add"),
+            {"username": "other_kanc", "role": Role.PREGLED, "is_default": "on"},
+        )
+        m_other.refresh_from_db()
+        self.assertFalse(m_other.is_default)
+        self.assertTrue(
+            UserMembership.objects.get(
+                user=self.foreign_clerk, tenant=self.tenant
+            ).is_default
+        )
 
     # ----- edit role -----
 

--- a/crkva/tenants/views.py
+++ b/crkva/tenants/views.py
@@ -95,21 +95,43 @@ def user_add(request: HttpRequest) -> HttpResponse:
     form = AddUserForm(request.POST or None)
     if request.method == "POST" and form.is_valid():
         data = form.cleaned_data
-        user = User.objects.create_user(
-            username=data["username"],
-            password=data["password"],
-            first_name=data["first_name"],
-            last_name=data["last_name"],
-            email=data["email"],
-        )
-        UserMembership.objects.create(
-            user=user,
-            tenant=request.tenant,
-            role=data["role"],
-            is_default=data["is_default"],
-        )
-        messages.success(request, f"Корисник {user.username} креиран.")
-        return redirect("parohija:user_list")
+        # Постојеће корисничко име → вежи постојећег корисника за ову парохију;
+        # ново → направи налог. Постојећем НЕ дирамо лозинку/профил (admin једне
+        # парохије не сме да ресетује глобални налог). (#228)
+        user = User.objects.filter(username=data["username"]).first()
+        is_new = user is None
+        if is_new:
+            user = User.objects.create_user(
+                username=data["username"],
+                password=data["password"],
+                first_name=data["first_name"],
+                last_name=data["last_name"],
+                email=data["email"],
+            )
+        if UserMembership.objects.filter(user=user, tenant=request.tenant).exists():
+            form.add_error(
+                None, f"Корисник {user.username} је већ члан ове парохије."
+            )
+        else:
+            if data["is_default"]:
+                # Тачно једна подразумевана парохија по кориснику.
+                UserMembership.objects.filter(user=user, is_default=True).update(
+                    is_default=False
+                )
+            UserMembership.objects.create(
+                user=user,
+                tenant=request.tenant,
+                role=data["role"],
+                is_default=data["is_default"],
+            )
+            if is_new:
+                messages.success(request, f"Корисник {user.username} креиран.")
+            else:
+                messages.success(
+                    request,
+                    f"Постојећи корисник {user.username} додат у ову парохију.",
+                )
+            return redirect("parohija:user_list")
     return render(request, "registar/unos_korisnika.html", {"form": form})
 
 


### PR DESCRIPTION
## Проблем (#228)

`UserMembership` подржава да корисник припада више парохија, али је UI то блокирао:
- `AddUserForm.clean_username` одбијао свако постојеће корисничко име;
- `user_add` увек звао `create_user`.

Зато се **постојећи** корисник није могао везати за додатну парохију.

## Решење

- `clean_username`: постојеће име више није грешка (само празно).
- `password`: обавезан **само за новог** корисника (провера у `clean()`); за постојећег се игнорише (help-text то каже).
- `user_add`: ако корисник постоји → веже се само ново `UserMembership` за активну парохију; **не дира му се лозинка ни профил** (admin једне парохије не сме да ресетује глобални налог — безбедносно). Дупло чланство у истој парохији се одбија. Постављање „подразумеване“ парохије чисти претходну (тачно једна `is_default` по кориснику).

## Тестови

`test_user_management.py`:
- постојећи корисник из друге парохије се веже за ову (без новог налога; изворно чланство нетакнуто),
- лозинка постојећег се **не** ресетује,
- нови корисник и даље тражи лозинку,
- дупло чланство у истој парохији одбијено,
- `is_default` се пребацује на нову парохију.

57 `tenants` тестова пролази. Без миграција → деплој `reload`.

Closes #228
