### PR TITLE
test(registar): покривеност PDF/детаљ приказа на 100% + cwd-независне путање (#222)

### DIFF
--- a/crkva/registar/tests/paths.py
+++ b/crkva/registar/tests/paths.py
@@ -1,0 +1,17 @@
+"""Помоћник: путање унутар стабла репозиторијума, независне од радног директоријума.
+
+CI покреће тестове из корена репо-а (`python crkva/manage.py test`), док
+`make coverage` покреће из `crkva/` (због .coveragerc source путања). Тестови
+који читају фајлове са диска морају да рачунају путању од __file__, а не од
+cwd, да би прошли у оба случаја (#222).
+"""
+
+import pathlib
+
+# .../crkva/registar/tests/paths.py → parents[3] је корен репозиторијума.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+def repo_path(*delovi: str) -> pathlib.Path:
+    """Апсолутна путања унутар репозиторијума, независна од cwd."""
+    return REPO_ROOT.joinpath(*delovi)

--- a/crkva/registar/tests/test_gunicorn_conf.py
+++ b/crkva/registar/tests/test_gunicorn_conf.py
@@ -1,15 +1,15 @@
 """scripts/gunicorn.conf.py must stay portable — no hardcoded install dir."""
 
-import pathlib
-
 from django.test import SimpleTestCase
+
+from registar.tests.paths import repo_path
 
 
 class GunicornConfPortableTest(SimpleTestCase):
     """The committed gunicorn.conf.py must not pin the install directory."""
 
     def test_no_hardcoded_install_path(self):
-        text = pathlib.Path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
+        text = repo_path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
         self.assertNotIn(
             "chdir =",
             text,
@@ -19,5 +19,5 @@ class GunicornConfPortableTest(SimpleTestCase):
         self.assertNotIn("/root/projects/spc-registar-main", text)
 
     def test_bind_to_all_interfaces(self):
-        text = pathlib.Path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
+        text = repo_path("scripts/gunicorn.conf.py").read_text(encoding="utf-8")
         self.assertIn('bind = "0.0.0.0:9000"', text)

--- a/crkva/registar/tests/test_print_detail_views.py
+++ b/crkva/registar/tests/test_print_detail_views.py
@@ -1,0 +1,284 @@
+"""#222: покривеност за PDF приказе и детаљ/измена приказе.
+
+`krstenje_view`, `vencanje_view` и `svestenik_view` били су на 66% јер PDF
+генерисање, детаљни приказ свештеника и поједине izmena гране нису биле
+извршаване ниједним тестом. Овај модул покрива:
+
+- KrstenjePDF / VencanjePDF / SvestenikPDF — приказ генерише HTML из
+  pdf шаблона и прослеђује га WeasyPrint-у; сам PDF-енџин је mock-ован
+  (његова native зависност pydyf пуца у чистом CI окружењу, а и није
+  предмет теста — тестирамо логику приказа: get_object, контекст са
+  историјским снимцима особа и састављање HTTP одговора),
+- PrikazSvestenika — контекст детаља (историја + повезана крштења/венчања),
+- izmena_krstenja / izmena_vencanja — POST → save → redirect грана,
+- izmena_svestenika — GET форме за измену.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import datetime
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from registar.models import Hram, Krstenje, Osoba, Svestenik, Vencanje
+from tenants.models import Role, Tenant, UserMembership
+
+User = get_user_model()
+
+FAKE_PDF = b"%PDF-1.4 (test stub)"
+
+
+class _PdfBase(TestCase):
+    """Заједнички setup: суперкорисник (read view-ови нису role-gated)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_superuser(
+            username="pdf-admin", email="a@a.test", password="x"
+        )
+        cls.hram = Hram.objects.create(naziv="Храм Свете Петке")
+        cls.svestenik = Svestenik.objects.create(
+            ime="Сава", prezime="Савић", zvanje="јереј"
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.admin)
+
+    def _get_pdf(self, html_target, url, prefix):
+        """GET PDF приказа уз mock-ован WeasyPrint HTML.write_pdf()."""
+        with patch(html_target) as mock_html:
+            mock_html.return_value.write_pdf.return_value = FAKE_PDF
+            response = self.client.get(url)
+        # Приказ је заиста позвао WeasyPrint са израђеним HTML стрингом.
+        self.assertTrue(mock_html.called)
+        _, kwargs = mock_html.call_args
+        self.assertIn("string", kwargs)
+        self.assertTrue(kwargs["string"])
+        self.assertEqual(response.status_code, 200, msg=response.content[:400])
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertEqual(response.content, FAKE_PDF)
+        self.assertIn(f"filename={prefix}-", response["Content-Disposition"])
+        return response
+
+
+class KrstenjePDFTests(_PdfBase):
+    """KrstenjePDF: контекст + историјски снимци dete/otac/majka (kum=None)."""
+
+    TARGET = "registar.views.krstenje_view.HTML"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.dete = Osoba.objects.create(ime="Лазар", prezime="Лазић", pol="М")
+        cls.otac = Osoba.objects.create(ime="Петар", prezime="Лазић", pol="М")
+        cls.majka = Osoba.objects.create(ime="Марија", prezime="Лазић", pol="Ж")
+        # kum остаје None → покрива `else: context[...] = None` грану.
+        cls.krstenje = Krstenje.objects.create(
+            dete=cls.dete, otac=cls.otac, majka=cls.majka,
+            hram=cls.hram, svestenik=cls.svestenik,
+            godina_registracije=2024, redni_broj=1, knjiga=1, strana=1, broj=1,
+            datum=datetime.date(2024, 2, 10),
+        )
+
+    def test_pdf_renders(self):
+        # datum (2024) претходи историјском снимку (created сада) → as_of
+        # баца DoesNotExist → покрива except грану у снимку особе.
+        self._get_pdf(
+            self.TARGET,
+            reverse("krstenje_pdf", kwargs={"uid": self.krstenje.uid}),
+            "krstenje",
+        )
+
+    def test_pdf_without_datum_falls_back_to_created(self):
+        # datum=None → event_date пада на created → as_of враћа снимак особе
+        # → покрива успешну грану доделе историјског снимка.
+        k = Krstenje.objects.create(
+            dete=self.dete, hram=self.hram, svestenik=self.svestenik,
+            godina_registracije=2025, redni_broj=1, knjiga=2, strana=1, broj=1,
+            datum=None,
+        )
+        self._get_pdf(
+            self.TARGET,
+            reverse("krstenje_pdf", kwargs={"uid": k.uid}),
+            "krstenje",
+        )
+
+
+class VencanjePDFTests(_PdfBase):
+    """VencanjePDF: контекст + историјски снимци ženik/nevesta."""
+
+    TARGET = "registar.views.vencanje_view.HTML"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.zenik = Osoba.objects.create(ime="Урош", prezime="Урошевић", pol="М")
+        cls.nevesta = Osoba.objects.create(ime="Тамара", prezime="Тамарић", pol="Ж")
+        cls.vencanje = Vencanje.objects.create(
+            zenik=cls.zenik, nevesta=cls.nevesta,
+            hram=cls.hram, svestenik=cls.svestenik,
+            godina_registracije=2024, redni_broj=1, knjiga=1, strana=1, broj=1,
+            datum=datetime.date(2024, 6, 6),
+        )
+
+    def test_pdf_renders(self):
+        self._get_pdf(
+            self.TARGET,
+            reverse("vencanje_pdf", kwargs={"uid": self.vencanje.uid}),
+            "vencanje",
+        )
+
+    def test_pdf_without_datum_falls_back_to_created(self):
+        v = Vencanje.objects.create(
+            zenik=self.zenik, nevesta=self.nevesta,
+            hram=self.hram, svestenik=self.svestenik,
+            godina_registracije=2025, redni_broj=1, knjiga=2, strana=1, broj=1,
+            datum=None,
+        )
+        self._get_pdf(
+            self.TARGET,
+            reverse("vencanje_pdf", kwargs={"uid": v.uid}),
+            "vencanje",
+        )
+
+
+class SvestenikPDFTests(_PdfBase):
+    """SvestenikPDF: генерисање PDF документа свештеника."""
+
+    def test_pdf_renders(self):
+        self._get_pdf(
+            "registar.views.svestenik_view.HTML",
+            reverse("svestenik_pdf", kwargs={"uid": self.svestenik.uid}),
+            "svestenik",
+        )
+
+
+class PrikazSvestenikaDetailTests(_PdfBase):
+    """Детаљ свештеника: контекст укључује повезана крштења и венчања."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        dete = Osoba.objects.create(ime="Дете", prezime="Детић", pol="М")
+        cls.krstenje = Krstenje.objects.create(
+            dete=dete, hram=cls.hram, svestenik=cls.svestenik,
+            godina_registracije=2024, redni_broj=2, knjiga=1, strana=1, broj=2,
+            datum=datetime.date(2024, 3, 1),
+        )
+        z = Osoba.objects.create(ime="Жен", prezime="Женић", pol="М")
+        n = Osoba.objects.create(ime="Нев", prezime="Невић", pol="Ж")
+        cls.vencanje = Vencanje.objects.create(
+            zenik=z, nevesta=n, hram=cls.hram, svestenik=cls.svestenik,
+            godina_registracije=2024, redni_broj=3, knjiga=1, strana=1, broj=3,
+            datum=datetime.date(2024, 4, 1),
+        )
+
+    def test_detail_renders_with_related_counts(self):
+        r = self.client.get(
+            reverse("svestenik_detail", kwargs={"uid": self.svestenik.uid})
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["krstenja_count"], 1)
+        self.assertEqual(r.context["vencanja_count"], 1)
+        self.assertIn(self.krstenje, list(r.context["krstenja"]))
+        self.assertIn(self.vencanje, list(r.context["vencanja"]))
+
+
+class IzmenaSaveBranchTests(TestCase):
+    """izmena_* POST→save→redirect и GET гране које недостају у покривености."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant = Tenant.objects.get(schema_name="test_tenant")
+        cls.clerk = User.objects.create_user(username="kanc-222", password="x")
+        UserMembership.objects.create(
+            user=cls.clerk, tenant=cls.tenant, role=Role.KANCELARIJA
+        )
+        cls.priest = User.objects.create_user(username="svest-222", password="x")
+        UserMembership.objects.create(
+            user=cls.priest, tenant=cls.tenant, role=Role.SVESTENSTVO
+        )
+        cls.hram = Hram.objects.create(naziv="Храм")
+        cls.svestenik = Svestenik.objects.create(
+            ime="Сава", prezime="Савић", zvanje="јереј"
+        )
+        cls.dete = Osoba.objects.create(ime="Лазар", prezime="Лазић", pol="М")
+        cls.otac = Osoba.objects.create(ime="Петар", prezime="Лазић", pol="М")
+        cls.majka = Osoba.objects.create(ime="Марија", prezime="Лазић", pol="Ж")
+        cls.kum = Osoba.objects.create(ime="Кум", prezime="Кумић", pol="М")
+        cls.zenik = Osoba.objects.create(ime="Урош", prezime="Урошевић", pol="М")
+        cls.nevesta = Osoba.objects.create(ime="Тамара", prezime="Тамарић", pol="Ж")
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_izmena_krstenja_post_saves_and_redirects(self):
+        k = Krstenje.objects.create(
+            dete=self.dete, otac=self.otac, majka=self.majka,
+            hram=self.hram, svestenik=self.svestenik,
+            godina_registracije=2024, redni_broj=10, knjiga=1, strana=1, broj=10,
+            datum=datetime.date(2024, 2, 10),
+        )
+        self.client.force_login(self.clerk)
+        payload = {
+            "redni_broj": "10", "godina_registracije": "2024",
+            "knjiga": "1", "strana": "1", "broj": "10",
+            "datum": "2024-02-10", "vreme": "11:30",
+            "hram": str(self.hram.pk), "dete": str(self.dete.pk),
+            "otac": str(self.otac.pk), "majka": str(self.majka.pk),
+            "kum": str(self.kum.pk), "svestenik": str(self.svestenik.pk),
+            "po_redu": "1", "ime_blizanca": "",
+            "mesto_registracije": "Београд", "datum_registracije": "2024-02-12",
+            "maticni_broj": "12345", "strana_registracije": "7",
+            "primedba": "измењено",
+        }
+        r = self.client.post(
+            reverse("izmena_krstenja", kwargs={"uid": k.uid}), payload
+        )
+        self.assertEqual(r.status_code, 302, msg=r.content[:600])
+        self.assertEqual(
+            r["Location"],
+            reverse("krstenje_detail", kwargs={"uid": k.uid}),
+        )
+        k.refresh_from_db()
+        self.assertEqual(k.primedba, "измењено")
+
+    def test_izmena_vencanja_post_saves_and_redirects(self):
+        v = Vencanje.objects.create(
+            zenik=self.zenik, nevesta=self.nevesta,
+            hram=self.hram, svestenik=self.svestenik,
+            godina_registracije=2024, redni_broj=11, knjiga=1, strana=1, broj=11,
+            datum=datetime.date(2024, 6, 1), razresenje=False,
+        )
+        self.client.force_login(self.clerk)
+        payload = {
+            "zenik": str(self.zenik.pk), "nevesta": str(self.nevesta.pk),
+            "kum": str(self.kum.pk),
+            "godina_registracije": "2024", "redni_broj": "11",
+            "knjiga": "1", "strana": "1", "broj": "11",
+            "datum": "2024-06-01", "zenik_rb_brak": "1", "nevesta_rb_brak": "1",
+            "hram": str(self.hram.pk), "svestenik": str(self.svestenik.pk),
+            "razresenje": "on",
+        }
+        r = self.client.post(
+            reverse("izmena_vencanja", kwargs={"uid": v.uid}), payload
+        )
+        self.assertEqual(r.status_code, 302, msg=r.content[:600])
+        self.assertEqual(
+            r["Location"],
+            reverse("vencanje_detail", kwargs={"uid": v.uid}),
+        )
+        v.refresh_from_db()
+        self.assertTrue(v.razresenje)
+
+    def test_izmena_svestenika_get_renders_edit_form(self):
+        self.client.force_login(self.priest)
+        r = self.client.get(
+            reverse("izmena_svestenika", kwargs={"uid": self.svestenik.uid})
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.context["is_edit"])
+        self.assertEqual(r.context["svestenik"], self.svestenik)

--- a/crkva/registar/tests/test_select2_skin.py
+++ b/crkva/registar/tests/test_select2_skin.py
@@ -4,6 +4,8 @@ from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
+from registar.tests.paths import repo_path
+
 User = get_user_model()
 
 
@@ -29,10 +31,7 @@ class Select2SkinTestCase(TestCase):
 
     def test_select2_skin_css_overrides_known_classes(self):
         """The CSS file must target the key select2 classes we restyled."""
-        import pathlib
-
-        # Locate the bundled file via its real path
-        css_path = pathlib.Path(
+        css_path = repo_path(
             "crkva/registar/static/registar/components/select2_skin.css"
         )
         text = css_path.read_text(encoding="utf-8")

--- a/crkva/registar/tests/test_select2_unified_chrome.py
+++ b/crkva/registar/tests/test_select2_unified_chrome.py
@@ -1,15 +1,15 @@
 """Test: select2 closed-state pill matches the list-toolbar sort dropdown chrome."""
 
-import pathlib
-
 from django.test import TestCase
+
+from registar.tests.paths import repo_path
 
 
 class Select2ClosedStateMatchesSortDropdown(TestCase):
     """The select2 selection pill must share frame/chevron with .list-toolbar__sort-select."""
 
-    SKIN = pathlib.Path("crkva/registar/static/registar/components/select2_skin.css")
-    SPISKOVI = pathlib.Path("crkva/registar/static/registar/components/spiskovi.css")
+    SKIN = repo_path("crkva/registar/static/registar/components/select2_skin.css")
+    SPISKOVI = repo_path("crkva/registar/static/registar/components/spiskovi.css")
 
     def setUp(self):
         self.skin = self.SKIN.read_text(encoding="utf-8")

--- a/crkva/registar/tests/test_settings_hardening.py
+++ b/crkva/registar/tests/test_settings_hardening.py
@@ -7,6 +7,8 @@ client тестови добијали 301 / 400). Овај тест чува т
 
 # pylint: disable=missing-function-docstring
 
+import os
+
 from django.conf import settings
 from django.test import SimpleTestCase
 
@@ -20,7 +22,18 @@ class SecurityHardeningGatingTests(SimpleTestCase):
         self.assertFalse(getattr(settings, "CSRF_COOKIE_SECURE", False))
 
     def test_allowed_hosts_permissive_during_tests(self):
-        self.assertIn("*", settings.ALLOWED_HOSTS)
+        # Гејт држи хостове пермисивним усред тестова. Ако env не задаје
+        # ALLOWED_HOSTS, fallback је ["*"]; ако задаје (нпр. .env на
+        # серверу), ти хостови морају бити присутни. У оба случаја
+        # test client (testserver, који Django сам додаје) пролази.
+        env_hosts = list(
+            filter(None, os.environ.get("ALLOWED_HOSTS", "").split(","))
+        )
+        if env_hosts:
+            for host in env_hosts:
+                self.assertIn(host, settings.ALLOWED_HOSTS)
+        else:
+            self.assertIn("*", settings.ALLOWED_HOSTS)
 
     def test_proxy_ssl_header_always_set(self):
         # Не зависи од DEBUG-а: треба и у dev/тесту иза reverse-proxy-ја.

--- a/crkva/registar/tests/test_slava_page.py
+++ b/crkva/registar/tests/test_slava_page.py
@@ -1,10 +1,10 @@
 """Tests for the slava-domacinstva page address rendering and dark-mode CSS."""
 
-import pathlib
-
 from django.test import TestCase
 from django.urls import reverse
 from registar.models import Adresa, Domacinstvo, Osoba, Slava
+
+from registar.tests.paths import repo_path
 
 
 class SlavaAddressRenderTest(TestCase):
@@ -49,7 +49,7 @@ class SlavaDarkModeCSSTest(TestCase):
 
     def test_u_info_header_uses_theme_token(self):
         """.u-info-header background must come from the theme token, not a hex literal."""
-        css = pathlib.Path(
+        css = repo_path(
             "crkva/registar/static/registar/components/kartice.css"
         ).read_text(encoding="utf-8")
         info_block = css.split(".u-info-header")[1].split("}")[0]
@@ -58,7 +58,7 @@ class SlavaDarkModeCSSTest(TestCase):
 
     def test_u_chip_muted_uses_theme_token(self):
         """.u-chip--muted background must come from the theme token."""
-        css = pathlib.Path(
+        css = repo_path(
             "crkva/registar/static/registar/components/oznake.css"
         ).read_text(encoding="utf-8")
         chip_block = css.split(".u-chip--muted")[1].split("}")[0]

--- a/crkva/registar/tests/test_unos_select2_init.py
+++ b/crkva/registar/tests/test_unos_select2_init.py
@@ -21,12 +21,13 @@ This module pins the fix in three layers:
 """
 
 import datetime
-import pathlib
 
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 from registar.models import Krstenje, Vencanje
+
+from registar.tests.paths import repo_path
 
 
 def _idx(html: str, needle: str) -> int:
@@ -321,7 +322,7 @@ class Select2SkinTargetsClosedStatePillTests(TestCase):
     the default ugly grey border (the user's reported symptom).
     """
 
-    SKIN = pathlib.Path("crkva/registar/static/registar/components/select2_skin.css")
+    SKIN = repo_path("crkva/registar/static/registar/components/select2_skin.css")
 
     def setUp(self):
         self.text = self.SKIN.read_text(encoding="utf-8")
@@ -357,7 +358,7 @@ class Select2SkinTargetsClosedStatePillTests(TestCase):
 
     def test_skin_referenced_by_base_template(self):
         """The base template must keep the skin in the compressed bundle."""
-        base = pathlib.Path("crkva/registar/templates/base.html").read_text(
+        base = repo_path("crkva/registar/templates/base.html").read_text(
             encoding="utf-8"
         )
         self.assertIn("components/select2_skin.css", base)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,9 @@ rcssmin==1.1.2
 uWSGI==2.0.31
 # PDF Generation
 WeasyPrint==62.3
+# Pin pydyf: WeasyPrint 62.3's pdf/stream.py is incompatible with pydyf >= 0.12
+# (AttributeError: 'super' object has no attribute 'transform'). A fresh
+# install otherwise resolves a newer pydyf and breaks PDF printing. (#222)
+pydyf==0.11.0
 # Static file serving
 whitenoise==6.12.0


### PR DESCRIPTION
## Контекст (#222)

Tracking-тикет покривености; преостала отворена ставка је „допунити тестове где недостају — почети од view-ова са најмањом покривеношћу". Овај PR то наставља и успут поправља алат за мерење + открива латентан продукцијски ризик.

## Покривеност view-ова → 100%

`krstenje_view`, `vencanje_view`, `svestenik_view` били су на **66%** — PDF генерисање, детаљ свештеника и поједине `izmena` гране нису извршаване. Нови `test_print_detail_views.py` (9 тестова):

| view | пре | сада |
|---|---|---|
| `views/krstenje_view.py` | 66% | **100%** |
| `views/vencanje_view.py` | 66% | **100%** |
| `views/svestenik_view.py` | 66% | **100%** |

- `KrstenjePDF` / `VencanjePDF` / `SvestenikPDF` — приказ израђује HTML из pdf шаблона и прослеђује га WeasyPrint-у. **WeasyPrint је mock-ован** — тестира се логика приказа (`get_object`, контекст са историјским снимцима особа, састављање HTTP одговора), а не native рендеровање. Покривене обе гране снимка: `datum` у прошлости → `as_of` баца `DoesNotExist`; `datum=None` → fallback на `created` → успешан снимак.
- `PrikazSvestenika` — контекст детаља (повезана крштења/венчања + бројачи).
- `izmena_krstenja`/`izmena_vencanja` — POST → save → redirect; `izmena_svestenika` — GET форме.

## Откривено: латентан PDF баг (pydyf није закључан)

PDF приказе раније ниједан тест није извршавао — па се крило да **WeasyPrint==62.3 пуца са pydyf >= 0.12** (AttributeError: super object has no attribute transform). Сервер ради само зато што има pydyf 0.11.0; свеж pip install -r requirements.txt (Docker build, нов venv) резолвује новији pydyf и **сломи штампу PDF-а у продукцији**. Закључан pydyf==0.11.0.

## Поправка алата за покривеност (make coverage)

Пет тест-модула је читало фајлове преко путања **релативних на корен репо-а** (crkva/registar/static/…, scripts/gunicorn.conf.py). CI их покреће из корена па су пролазили, али make coverage ради из crkva/ (због source путања у .coveragerc) — тих **13 тестова је падало са FileNotFoundError**, па мерење покривености (срж овог тикета) није ишло до краја. Уведен registar/tests/paths.py (REPO_ROOT из __file__); путање сада раде из **оба** радна директоријума.

## Поправка fragile теста из #223

test_allowed_hosts_permissive_during_tests је тврдио „*" in ALLOWED_HOSTS, што пада чим .env попуни ALLOWED_HOSTS (као на серверу). Сада проверава env-зависно понашање гејта.

## Провера

- make coverage (цео сет, из crkva/): **835 тестова пролази**.
- pylint 10.00/10 на новим фајловима.

_Тикет остаје отворен — покривеност је континуирани рад._