### PR TITLE
fix(stampa): празне ћелије приказују „-" уместо „None"

### DIFF
--- a/crkva/registar/templates/registar/krstenje.html
+++ b/crkva/registar/templates/registar/krstenje.html
@@ -3,6 +3,7 @@
 {% load info_components %}
 {% load julian_dates %}
 {% load ordinal_filters %}
+{% load print_filters %}
 
 {% block extra_css %}
   <link rel="stylesheet" href="{% static 'registar/print/krstenica.css' %}">
@@ -169,32 +170,32 @@
     <section class="tab-group__panel" data-show-mode="view">
       <div class="krstenica">
         <div class="krstenica-frame">
-          <div class="krst-field-knjiga">{{ krstenje.knjiga }}</div>
-          <div class="krst-field-strana">{{ krstenje.strana }}</div>
-          <div class="krst-field-broj">{{ krstenje.broj }}</div>
+          <div class="krst-field-knjiga">{{ krstenje.knjiga|crtica }}</div>
+          <div class="krst-field-strana">{{ krstenje.strana|crtica }}</div>
+          <div class="krst-field-broj">{{ krstenje.broj|crtica }}</div>
           <div class="krst-field-eparhija">БЕОГРАДСКО - КАРЛОВАЧКЕ</div>
-          <div class="krst-field-hram">{{ krstenje.hram }}</div>
-          <div class="krst-field-mesto">{% if tenant.mesto %}{{ tenant.mesto }}{% endif %}</div>
-          <div class="krst-field-godina">{{ krstenje.datum|date:"y" }}</div>
-          <div class="krst-table-field krst-field-rodjenje_datum">{{ krstenje.datum_rodjenja|julian_date }}{% if krstenje.vreme_rodjenja %}, {{ krstenje.vreme_rodjenja|time:"H:i" }} часова{% endif %}</div>
-          <div class="krst-table-field krst-field-rodjenje_mesto">{{ krstenje.mesto_rodjenja }}</div>
-          <div class="krst-table-field krst-field-krstenje_datum">{{ krstenje.datum|julian_date }}</div>
-          <div class="krst-table-field krst-field-krstenje_mesto">{% if krstenje.hram.mesto %}{{ krstenje.hram.mesto }}, {% endif %}{{ krstenje.hram }}</div>
-          <div class="krst-table-field krst-field-ime_pol">{{ krstenje.ime_deteta }}{{ krstenje.gradjansko_ime_deteta }}, {{ krstenje.get_pol_deteta_display }}</div>
-          <div class="krst-table-field krst-field-roditelji">{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}, {{ krstenje.zanimanje_oca|lower }} и<br>{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}, {{ krstenje.zanimanje_majke|lower }}<br>{% if krstenje.hram.mesto %}{{ krstenje.hram.mesto }}, {% endif %}{{ krstenje.adresa_deteta }}<br>{{ krstenje.veroispovest_oca }}</div>
+          <div class="krst-field-hram">{{ krstenje.hram|crtica }}</div>
+          <div class="krst-field-mesto">{{ tenant.mesto|crtica }}</div>
+          <div class="krst-field-godina">{{ krstenje.datum|date:"y"|crtica }}</div>
+          <div class="krst-table-field krst-field-rodjenje_datum">{{ krstenje.datum_rodjenja|julian_date|crtica }}{% if krstenje.vreme_rodjenja %}, {{ krstenje.vreme_rodjenja|time:"H:i" }} часова{% endif %}</div>
+          <div class="krst-table-field krst-field-rodjenje_mesto">{{ krstenje.mesto_rodjenja|crtica }}</div>
+          <div class="krst-table-field krst-field-krstenje_datum">{{ krstenje.datum|julian_date|crtica }}</div>
+          <div class="krst-table-field krst-field-krstenje_mesto">{% if krstenje.hram.mesto %}{{ krstenje.hram.mesto }}, {% endif %}{{ krstenje.hram|crtica }}</div>
+          <div class="krst-table-field krst-field-ime_pol">{% if krstenje.ime_deteta or krstenje.gradjansko_ime_deteta or krstenje.get_pol_deteta_display %}{{ krstenje.ime_deteta }}{{ krstenje.gradjansko_ime_deteta }}, {{ krstenje.get_pol_deteta_display }}{% else %}-{% endif %}</div>
+          <div class="krst-table-field krst-field-roditelji">{% if krstenje.ime_oca or krstenje.prezime_oca or krstenje.ime_majke or krstenje.prezime_majke or krstenje.adresa_deteta or krstenje.veroispovest_oca %}{{ krstenje.ime_oca }} {{ krstenje.prezime_oca }}, {{ krstenje.zanimanje_oca|lower }} и<br>{{ krstenje.ime_majke }} {{ krstenje.prezime_majke }}, {{ krstenje.zanimanje_majke|lower }}<br>{% if krstenje.hram.mesto %}{{ krstenje.hram.mesto }}, {% endif %}{{ krstenje.adresa_deteta }}<br>{{ krstenje.veroispovest_oca }}{% else %}-{% endif %}</div>
           <div class="krst-table-field krst-field-dete_po_redu">{{ krstenje.po_redu|redni_rec }}</div>
           <div class="krst-table-field krst-field-bracno">{{ krstenje.vanbracno|yesno:"није,јесте" }}</div>
           <div class="krst-table-field krst-field-blizanac">{{ krstenje.blizanac|yesno:"јесте,није" }}</div>
           <div class="krst-table-field krst-field-telesna_mana">{{ krstenje.telesna_mana|yesno:"јесте,није,непознато" }}</div>
-          <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|default_if_none:"" }}</div>
-          <div class="krst-table-field krst-field-kum">{{ krstenje.ime_kuma }}, {{ krstenje.zanimanje_kuma }}<br>{{ krstenje.adresa_kuma_mesto }}</div>
+          <div class="krst-table-field krst-field-svestenik">{{ krstenje.svestenik|crtica }}</div>
+          <div class="krst-table-field krst-field-kum">{% if krstenje.ime_kuma or krstenje.zanimanje_kuma or krstenje.adresa_kuma_mesto %}{{ krstenje.ime_kuma }}, {{ krstenje.zanimanje_kuma }}<br>{{ krstenje.adresa_kuma_mesto }}{% else %}-{% endif %}</div>
           <div class="krst-table-field krst-field-domovnik"></div>
-          <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|default_if_none:"" }}</div>
+          <div class="krst-table-field krst-field-primedba">{{ krstenje.primedba|crtica }}</div>
           <div class="krst-field-footer_br">{% now "d.m" %}</div>
           <div class="krst-field-footer_godina">{% now "y" %}</div>
           <div class="krst-field-footer_u">Београду</div>
-          <div class="krst-field-footer_parohija">{% if krstenje.svestenik %}{{ krstenje.svestenik.parohija }}{% endif %}</div>
-          <div class="krst-field-footer_paroh">{% if krstenje.svestenik %}{{ krstenje.svestenik }}{% endif %}</div>
+          <div class="krst-field-footer_parohija">{{ krstenje.svestenik.parohija|crtica }}</div>
+          <div class="krst-field-footer_paroh">{{ krstenje.svestenik|crtica }}</div>
         </div>
       </div>
     </section>

--- a/crkva/registar/templates/registar/vencanje.html
+++ b/crkva/registar/templates/registar/vencanje.html
@@ -3,6 +3,7 @@
 {% load info_components %}
 {% load julian_dates %}
 {% load ordinal_filters %}
+{% load print_filters %}
 
 {% block extra_css %}
   <link rel="stylesheet" href="{% static 'registar/print/vencanica.css' %}">
@@ -133,35 +134,35 @@
     <section class="tab-group__panel" data-show-mode="view">
       <div class="vencanica">
         <div class="vencanica-frame">
-          <div class="venc-field-knjiga">{{ vencanje.knjiga }}</div>
-          <div class="venc-field-strana">{{ vencanje.strana }}</div>
-          <div class="venc-field-tekuci">{{ vencanje.broj }}</div>
-          <div class="venc-field-hram">{{ vencanje.hram }}</div>
+          <div class="venc-field-knjiga">{{ vencanje.knjiga|crtica }}</div>
+          <div class="venc-field-strana">{{ vencanje.strana|crtica }}</div>
+          <div class="venc-field-tekuci">{{ vencanje.broj|crtica }}</div>
+          <div class="venc-field-hram">{{ vencanje.hram|crtica }}</div>
           <div class="venc-field-eparhija">Београдско-Карловачке</div>
-          <div class="venc-field-mesto">{% if vencanje.adresa_zenika %}{{ vencanje.adresa_zenika.mesto }}{% endif %}</div>
-          <div class="venc-field-godina">{{ vencanje.datum|date:"y" }}</div>
-          <div class="venc-table-field venc-field-zenik"><span>{{ vencanje.opis_zenika }}</span></div>
-          <div class="venc-table-field venc-field-nevesta"><span>{{ vencanje.opis_neveste }}</span></div>
-          <div class="venc-table-field venc-field-roditelji_zenika">{% if vencanje.opis_svekra %}<span>{{ vencanje.opis_svekra }}</span>{% endif %}{% if vencanje.opis_svekrve %}<span>{{ vencanje.opis_svekrve }}</span>{% endif %}</div>
-          <div class="venc-table-field venc-field-roditelji_neveste">{% if vencanje.opis_tasta %}<span>{{ vencanje.opis_tasta }}</span>{% endif %}{% if vencanje.opis_taste %}<span>{{ vencanje.opis_taste }}</span>{% endif %}</div>
-          <div class="venc-table-field venc-field-rodjenje_zenika"><span>{{ vencanje.datum_rodjenja_zenika|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_zenika }}</span></div>
-          <div class="venc-table-field venc-field-rodjenje_neveste"><span>{{ vencanje.datum_rodjenja_neveste|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_neveste }}</span></div>
+          <div class="venc-field-mesto">{{ vencanje.adresa_zenika.mesto|crtica }}</div>
+          <div class="venc-field-godina">{{ vencanje.datum|date:"y"|crtica }}</div>
+          <div class="venc-table-field venc-field-zenik"><span>{{ vencanje.opis_zenika|crtica }}</span></div>
+          <div class="venc-table-field venc-field-nevesta"><span>{{ vencanje.opis_neveste|crtica }}</span></div>
+          <div class="venc-table-field venc-field-roditelji_zenika">{% if vencanje.opis_svekra or vencanje.opis_svekrve %}{% if vencanje.opis_svekra %}<span>{{ vencanje.opis_svekra }}</span>{% endif %}{% if vencanje.opis_svekrve %}<span>{{ vencanje.opis_svekrve }}</span>{% endif %}{% else %}<span>-</span>{% endif %}</div>
+          <div class="venc-table-field venc-field-roditelji_neveste">{% if vencanje.opis_tasta or vencanje.opis_taste %}{% if vencanje.opis_tasta %}<span>{{ vencanje.opis_tasta }}</span>{% endif %}{% if vencanje.opis_taste %}<span>{{ vencanje.opis_taste }}</span>{% endif %}{% else %}<span>-</span>{% endif %}</div>
+          <div class="venc-table-field venc-field-rodjenje_zenika">{% if vencanje.datum_rodjenja_zenika or vencanje.mesto_rodjenja_zenika %}<span>{{ vencanje.datum_rodjenja_zenika|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_zenika|default_if_none:"" }}</span>{% else %}<span>-</span>{% endif %}</div>
+          <div class="venc-table-field venc-field-rodjenje_neveste">{% if vencanje.datum_rodjenja_neveste or vencanje.mesto_rodjenja_neveste %}<span>{{ vencanje.datum_rodjenja_neveste|julian_date }}</span><span class="venc-text-sm">{{ vencanje.mesto_rodjenja_neveste|default_if_none:"" }}</span>{% else %}<span>-</span>{% endif %}</div>
           <div class="venc-table-field venc-field-brak_zenika">{{ vencanje.zenik_rb_brak|redni_rec_m }}</div>
           <div class="venc-table-field venc-field-brak_neveste">{{ vencanje.nevesta_rb_brak|redni_rec_m }}</div>
-          <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date }}</div>
-          <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date }}</div>
-          <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika and vencanje.adresa_zenika.mesto %}{{ vencanje.adresa_zenika.mesto }}, {% endif %}{{ vencanje.hram }}</div>
-          <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|default_if_none:"" }}</div>
-          <div class="venc-table-field venc-field-svedoci"><span>{{ vencanje.kum|default_if_none:"" }}</span><span>{{ vencanje.stari_svat|default_if_none:"" }}</span></div>
+          <div class="venc-table-field venc-field-ispit">{{ vencanje.datum_ispita|julian_date|crtica }}</div>
+          <div class="venc-table-field venc-field-datum_vencanja">{{ vencanje.datum|julian_date|crtica }}</div>
+          <div class="venc-table-field venc-field-mesto_hram">{% if vencanje.adresa_zenika and vencanje.adresa_zenika.mesto %}{{ vencanje.adresa_zenika.mesto }}, {% endif %}{{ vencanje.hram|crtica }}</div>
+          <div class="venc-table-field venc-field-svestenik">{{ vencanje.svestenik|crtica }}</div>
+          <div class="venc-table-field venc-field-svedoci">{% if vencanje.kum or vencanje.stari_svat %}<span>{{ vencanje.kum|default_if_none:"" }}</span><span>{{ vencanje.stari_svat|default_if_none:"" }}</span>{% else %}<span>-</span>{% endif %}</div>
           <div class="venc-table-field venc-field-razresenje">{% if vencanje.razresenje %}Да{% else %}Не{% endif %}</div>
-          <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|default_if_none:"" }}</div>
-          <div class="venc-field-footer_hram">{{ vencanje.hram }}</div>
+          <div class="venc-table-field venc-field-primedba">{{ vencanje.primedba|crtica }}</div>
+          <div class="venc-field-footer_hram">{{ vencanje.hram|crtica }}</div>
           <div class="venc-field-footer_eparhija">Београдске</div>
           <div class="venc-field-footer_mesto">Београду</div>
           <div class="venc-field-footer_datum">{% now "j. F" %}</div>
           <div class="venc-field-footer_godina">{% now "y" %}</div>
-          <div class="venc-field-footer_paroh">{% if vencanje.svestenik %}{{ vencanje.svestenik }}{% endif %}</div>
-          <div class="venc-field-footer_parohija">{% if vencanje.svestenik %}{{ vencanje.svestenik.parohija }}{% endif %}</div>
+          <div class="venc-field-footer_paroh">{{ vencanje.svestenik|crtica }}</div>
+          <div class="venc-field-footer_parohija">{{ vencanje.svestenik.parohija|crtica }}</div>
         </div>
       </div>
     </section>

--- a/crkva/registar/templatetags/print_filters.py
+++ b/crkva/registar/templatetags/print_filters.py
@@ -1,0 +1,21 @@
+"""Филтери за штампане обрасце (крштеница/венчаница)."""
+
+from django import template
+
+register = template.Library()
+
+CRTICA = "-"
+
+
+@register.filter
+def crtica(value):
+    """Празну ћелију приказује као „-" уместо празнине или „None".
+
+    Враћа „-" када је вредност ``None`` или празан/празнински стринг;
+    у супротном враћа саму вредност (стрипован текст). Нула и сличне
+    „falsy" али смислене вредности се чувају.
+    """
+    if value is None:
+        return CRTICA
+    text = str(value).strip()
+    return text if text else CRTICA

--- a/crkva/registar/tests/test_print_detail_views.py
+++ b/crkva/registar/tests/test_print_detail_views.py
@@ -334,8 +334,24 @@ class VencanjeDetailRenderTests(TestCase):
         response = self.client.get(
             reverse("vencanje_detail", kwargs={"uid": self.vencanje.uid})
         )
-        # оба родитеља празна → ред је празан, без иједног <span> (нема празних редова)
+        # оба родитеља празна → ћелија приказује цртицу „-" (празна ћелија)
         self.assertContains(
             response,
-            '<div class="venc-table-field venc-field-roditelji_zenika"></div>',
+            '<div class="venc-table-field venc-field-roditelji_zenika">'
+            "<span>-</span></div>",
+        )
+
+    def test_prazne_celije_prikazuju_crticu(self):
+        # без датума/места рођења и без сведока → ћелије приказују „-", не „None"
+        response = self.client.get(
+            reverse("vencanje_detail", kwargs={"uid": self.vencanje.uid})
+        )
+        self.assertContains(
+            response,
+            '<div class="venc-table-field venc-field-rodjenje_zenika">'
+            "<span>-</span></div>",
+        )
+        self.assertContains(
+            response,
+            '<div class="venc-table-field venc-field-svedoci"><span>-</span></div>',
         )

--- a/crkva/registar/tests/test_print_filters.py
+++ b/crkva/registar/tests/test_print_filters.py
@@ -1,0 +1,25 @@
+"""Тестови за `crtica` филтер — празна вредност → „-" на штампи."""
+
+# pylint: disable=missing-function-docstring
+
+from django.test import SimpleTestCase
+from registar.templatetags.print_filters import crtica
+
+
+class CrticaFilterTests(SimpleTestCase):
+    """`crtica`: None/празно/празнине → „-"; иначе непромењена вредност."""
+
+    def test_none_daje_crticu(self):
+        self.assertEqual(crtica(None), "-")
+
+    def test_prazan_string_daje_crticu(self):
+        self.assertEqual(crtica(""), "-")
+
+    def test_samo_razmaci_daju_crticu(self):
+        self.assertEqual(crtica("   "), "-")
+
+    def test_vrednost_se_cuva(self):
+        self.assertEqual(crtica("Београд"), "Београд")
+
+    def test_nula_nije_prazna(self):
+        self.assertEqual(crtica(0), "0")


### PR DESCRIPTION
Нови филтер `crtica` (registar/templatetags/print_filters.py) претвара None/празан стринг у „-". Примењен на скаларне ћелије крштенице и венчанице; сложене вишеделне ћелије добијају „-" само кад су у целини празне. Редни бројеви („није уписано") и domovnik остављени намерно.

Тестови: registar/tests/test_print_filters.py + допуне у VencanjeDetailRenderTests (rodjenje/svedoci/roditelji цртица).