### PR TITLE
ci(pre-commit): покрени django-tests хук серијски (--parallel 1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: django-tests
         name: django tests
-        entry: python crkva/manage.py test registar.tests tenants.tests --keepdb --parallel auto --verbosity=1
+        entry: python crkva/manage.py test registar.tests tenants.tests --keepdb --parallel 1 --verbosity=1
         language: system
         pass_filenames: false
         files: '\.py$'


### PR DESCRIPTION
## Шта

`django-tests` pre-commit хук је користио `--parallel auto`. На овом
окружењу то детерминистички пуца: неки тест није паралелно-безбедан, па
Django-ов parallel runner не успе да pickle-ује изузетак
(`TypeError: cannot pickle 'traceback'`) и маскира прави узрок.

## Зашто `--parallel 1`

- Цео сет је зелен **серијски** (862 теста, OK) — двапут проверено.
- CI (`tests.yml`) **ионако већ** покреће `--parallel 1`; хук је био
  неусклађен са CI-јем. Овим се усклађују.

## Уз ово (на серверу, ван репоа)

Застареле keepdb тест-базе (`test_crkva_db*`, којима је недостајала
табела `hramovi`) пресоздане су из миграција. Након тога
`pre-commit run django-tests --all-files` **пролази**.