### PR TITLE
fix(docker): исправна улазна тачка контејнера + SECURE_SSL флег (#7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dev-shell:
 	docker-compose exec app python manage.py shell
 
 dev-migrate:
-	docker-compose exec app python manage.py migrate
+	docker-compose exec app python manage.py migrate_schemas --noinput
 
 dev-makemigrations:
 	docker-compose exec app python manage.py makemigrations
@@ -43,7 +43,7 @@ prod-logs:
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
 
 prod-migrate:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml exec app python manage.py migrate
+	docker-compose -f docker-compose.yml -f docker-compose.prod.yml exec app python manage.py migrate_schemas --noinput
 
 # Common commands
 build:

--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -61,10 +61,13 @@ CSRF_TRUSTED_ORIGINS = list(
     filter(None, os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(","))
 )
 
-# Продукцијско безбедносно учвршћивање (#223) — активно када је DEBUG искључен
-# (и ван тестова). TLS терминира Caddy, па се ово ослања на горњи
-# SECURE_PROXY_SSL_HEADER (Caddy шаље X-Forwarded-Proto=https).
-if not DEBUG and not _RUNNING_TESTS:
+# Продукцијско безбедносно учвршћивање (#223). HTTPS-учвршћивање контролише
+# флег SECURE_SSL (раздвојено од DEBUG — #7): подразумевано укључено ван
+# DEBUG-а, искључено у DEBUG-у. Самосталне инсталације преко plain HTTP на
+# localhost-у постављају SECURE_SSL=0. TLS терминира Caddy, па се ово ослања
+# на горњи SECURE_PROXY_SSL_HEADER (Caddy шаље X-Forwarded-Proto=https).
+SECURE_SSL = (os.environ.get("SECURE_SSL") or ("0" if DEBUG else "1")) == "1"
+if SECURE_SSL and not _RUNNING_TESTS:
     SECURE_SSL_REDIRECT = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
     command: >
       sh -c "python manage.py wait_for_db &&
             python manage.py makemigrations &&
-            python manage.py migrate --database=${DATABASE:-default} &&
+            python manage.py migrate_schemas --noinput &&
             python manage.py collectstatic --noinput &&
             python manage.py runserver 0.0.0.0:8000"
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,9 +8,9 @@ services:
     # Production uses external database, no local db service
     command: >
       sh -c "python manage.py wait_for_db &&
-            python manage.py migrate --database=${DATABASE:-default} &&
+            python manage.py migrate_schemas --noinput &&
             python manage.py collectstatic --noinput &&
-            gunicorn --bind 0.0.0.0:8000 --workers 4 app.wsgi:application"
+            gunicorn --bind 0.0.0.0:8000 --workers 4 crkva.wsgi:application"
     environment:
       - DEBUG=0
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -180,8 +180,6 @@ make prod-migrate       # покрени миграције
 make prod-down          # заустави
 ```
 
-> Напомена: у `docker-compose.prod.yml` команда `gunicorn app.wsgi:application` се односи на стари назив пакета (`app` уместо `crkva`). Поправите у `crkva.wsgi:application` пре прве производње у Docker-у.
-
 ---
 
 ## Након поставке (обавезно)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,22 +1,32 @@
 #!/bin/sh
-
+# Подразумевана улазна тачка контејнера (Dockerfile `CMD`).
+#
+# Compose фајлови за развој и продукцију премошћују ову команду својим
+# `command:`; голи `docker run` слике и самостални (standalone) стек користе
+# ову скрипту. Идемпотентна је — безбедно се извршава при сваком старту.
 set -e
 
-ls -la /vol/
-ls -la /vol/web
-
-whoami
-
+# Сачекај да база прими конекције (management команда у репозиторијуму).
 python manage.py wait_for_db
+
+# Миграције СВИХ шема (public + тенанти). НЕ `migrate` — django-tenants.
+python manage.py migrate_schemas --noinput
+
+# Статички фајлови. `compress` није потребан (COMPRESS_OFFLINE=False).
 python manage.py collectstatic --noinput
-python manage.py migrate
 
-python manage.py loaddata import_auth.json
-python manage.py loaddata import_codetables.json
-python manage.py loaddata import_metadata.json
-python manage.py loaddata import_measures.json
-python manage.py loaddata import_filters.json
-python manage.py loaddata import_topicsets.json
-python manage.py loaddata import_spatialdimensions.json
+# Опциони bootstrap администратора из окружења (идемпотентно): креира налог
+# само ако DJANGO_SUPERUSER_USERNAME/PASSWORD постоје и налог још не постоји.
+if [ -n "$DJANGO_SUPERUSER_USERNAME" ] && [ -n "$DJANGO_SUPERUSER_PASSWORD" ]; then
+    python manage.py createsuperuser --noinput 2>/dev/null \
+        && echo "Креиран суперкорисник $DJANGO_SUPERUSER_USERNAME." \
+        || echo "Суперкорисник већ постоји или подаци непотпуни — прескачем."
+fi
 
-uwsgi --socket :9000 --workers 4 --master --enable-threads --module crkva.wsgi
+# WSGI сервер. Порт/радници су подесиви преко окружења. НЕ користимо
+# scripts/gunicorn.conf.py (он је за bare-metal: bind :9000 + логови у
+# /var/log/spc-registar/ којих нема у контејнеру).
+exec gunicorn crkva.wsgi:application \
+    --bind "0.0.0.0:${GUNICORN_PORT:-8000}" \
+    --workers "${GUNICORN_WORKERS:-3}" \
+    --timeout "${GUNICORN_TIMEOUT:-120}"


### PR DESCRIPTION
Део #7 (PR 1/2 по дизајну у #286) — поправке које чине да самостални Docker заиста ради. Без новог понашања на живом серверу (подразумевано остаје учвршћено).

## Промене
- **scripts/run.sh** (улазна тачка слике): уклоњени `loaddata` за 7 непостојећих fixtures који су рушили старт уз `set -e`; `migrate`→`migrate_schemas`; `gunicorn crkva.wsgi` (порт/радници преко `GUNICORN_*` env); идемпотентан admin bootstrap из `DJANGO_SUPERUSER_*`.
- **settings**: нови `SECURE_SSL` флег раздваја HTTPS-учвршћивање од `DEBUG`. Подразумевано: укључено ван DEBUG-а, искључено у DEBUG-у; празна вредност = подразумевано. Самосталне инсталације постављају `SECURE_SSL=0` за plain HTTP на localhost-у.
- **docker-compose.prod.yml**: `app.wsgi`→`crkva.wsgi` (погрешан модул), `migrate`→`migrate_schemas`.
- **docker-compose.override.yml + Makefile**: `migrate`→`migrate_schemas`.
- **docs/deployment.md**: уклоњена застарела напомена о `app.wsgi`.

## Провера
- Бут под gunicorn-ом (као у run.sh): `SECURE_SSL=0` → HTTP 302 → `http://localhost/prijava/` (plain HTTP ради); `SECURE_SSL=1` → 301 → https (учвршћивање активно).
- `SECURE_SSL` потврђен у 4 режима (unset/0/празно/DEBUG=1).
- Цео сет тестова: **875 OK** (`--parallel 1`).

Крај-до-краја бут целог стека (app + Postgres у контејнеру) долази у PR 2/2 уз `docker-compose.standalone.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)