### PR TITLE
feat(docker): самостални (standalone) стек + Windows wrapper + упутство (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@
 |---|---|---|
 | **Локални развој (bare-metal, pyenv + Postgres)** | Програмери који желе нативни Python тoolchain | [docs/setup.md](docs/setup.md) |
 | **Локални развој (Docker Compose)** | Програмери који желе изоловано окружење | [docs/setup.md#docker](docs/setup.md#docker) |
-| **Производња на серверу (gunicorn + systemd + nginx)** | Тренутна продукциона поставка | [docs/deployment.md#bare-metal](docs/deployment.md#bare-metal) |
+| **Производња на серверу (gunicorn + systemd + Caddy)** | Тренутна продукциона поставка | [docs/deployment.md#bare-metal](docs/deployment.md#bare-metal) |
 | **Производња у Docker-у** | Алтернативна продукциона поставка | [docs/deployment.md#docker](docs/deployment.md#docker) |
+| **Самостални (standalone) Docker** | Локални PC / Windows / један сервер — све у једном | [docs/standalone.md](docs/standalone.md) |
 
 После постављања, апликација слуша на [http://localhost:8000/](http://localhost:8000/) (или порту 9000 на серверу), а пријава је на `/prijava/`.
 
@@ -40,6 +41,7 @@
 |---|---|
 | [docs/setup.md](docs/setup.md) | Подешавање развојног окружења (bare-metal и Docker) |
 | [docs/deployment.md](docs/deployment.md) | Производна поставка (gunicorn+systemd и Docker) |
+| [docs/standalone.md](docs/standalone.md) | Самостални Docker (bundled све-у-једном + слика са спољном базом) |
 | [docs/architecture.md](docs/architecture.md) | Архитектура: django-tenants, ауторизација, кључне компоненте |
 | [docs/testing.md](docs/testing.md) | Тестови, pre-commit (ruff + biome + pylint + djlint) |
 | [docs/MIGRACIJA.md](docs/MIGRACIJA.md) | Миграција података из старе HramSP апликације (DBF → Postgres) |

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,42 @@
+# Самостални (standalone) стек — апликација + сопствени Postgres, „све у једном".
+#
+# Покретање (Linux/mac):
+#   docker compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build
+# Windows: покрените start.bat
+#
+# Отвара http://localhost:8000 (plain HTTP, за локалну/LAN употребу).
+# Прва пријава: admin / admin (промените DJANGO_SUPERUSER_* / SECRET_KEY за изложене инсталације).
+
+services:
+  app:
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    environment:
+      - DEBUG=0
+      - SECURE_SSL=0
+      - SECRET_KEY=${SECRET_KEY:-insecure-standalone-key-change-me}
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=${DB_NAME:-crkva}
+      - DB_SCHEMA=public
+      - DB_USER=${DB_USER:-crkva}
+      - DB_PASS=${DB_PASS:-crkva}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1}
+      - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-http://localhost:8000,http://127.0.0.1:8000}
+      - GUNICORN_PORT=8000
+      - DJANGO_SUPERUSER_USERNAME=${DJANGO_SUPERUSER_USERNAME:-admin}
+      - DJANGO_SUPERUSER_PASSWORD=${DJANGO_SUPERUSER_PASSWORD:-admin}
+      - DJANGO_SUPERUSER_EMAIL=${DJANGO_SUPERUSER_EMAIL:-admin@example.com}
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=${DB_NAME:-crkva}
+      - POSTGRES_USER=${DB_USER:-crkva}
+      - POSTGRES_PASSWORD=${DB_PASS:-crkva}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Производна поставка
 
-Апликација подржава два пута за продукцију. Тренутна жива поставка користи bare-metal (систем gunicorn + systemd + nginx); Docker је алтернатива.
+Апликација подржава два пута за продукцију. Тренутна жива поставка користи bare-metal (gunicorn + systemd + Caddy); Docker је алтернатива.
 
 - [Bare-metal (gunicorn + systemd + nginx)](#bare-metal)
 - [Docker (production compose)](#docker)
@@ -99,33 +99,25 @@ sudo systemctl enable --now spc-registar
 sudo systemctl status spc-registar
 ```
 
-### 7. Nginx прокси
+### 7. Caddy (reverse proxy + аутоматски HTTPS)
 
-```nginx
-# /etc/nginx/sites-available/spc-registar
-server {
-    listen 80;
-    server_name registar.parohija.example;
+Едж је **Caddy** — терминира TLS и аутоматски прибавља/обнавља Let's Encrypt
+сертификат. Статику служи whitenoise из саме апликације, па Caddy само
+прослеђује све ка gunicorn-у. Пример `/etc/caddy/Caddyfile`:
 
-    location /static/  { alias /vol/web/static/; }
-    location /media/   { alias /vol/web/media/;  }
-
-    location / {
-        proxy_pass         http://127.0.0.1:9000;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-    }
+```
+registar.parohija.example {
+    reverse_proxy 127.0.0.1:9000
 }
 ```
 
 ```bash
-sudo ln -s /etc/nginx/sites-available/spc-registar /etc/nginx/sites-enabled/
-sudo nginx -t && sudo systemctl reload nginx
+sudo systemctl reload caddy
 ```
 
-Постављање HTTPS-а кроз Certbot: `sudo certbot --nginx -d registar.parohija.example`.
+Подешавање `SECURE_PROXY_SSL_HEADER` у settings прихвата `X-Forwarded-Proto`
+који Caddy шаље, па `request.is_secure()`, CSRF и secure колачићи раде преко
+HTTPS хоста.
 
 ### 8. Деплој (стандардни ток после `git push origin main`)
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,0 +1,75 @@
+# Самостални (standalone) Docker
+
+Покретање SPC Регистра у Docker-у, без bare-metal подешавања. Два пута:
+
+- **А) Све-у-једном (bundled)** — апликација + сопствени Postgres у контејнерима.
+  Најлакше за локални PC, Windows или један сервер.
+- **Б) Слика + спољна база** — само контејнер апликације, ка постојећем Postgres-у.
+
+> Вишекорисничко (django-tenants) и WeasyPrint (PDF) траже Linux окружење и
+> Postgres — зато се испоручује Linux контејнер (исти на Windows/mac/Linux).
+
+## Услови
+
+- **Docker Desktop** (Windows/mac, са WSL2) или **Docker Engine + Compose v2** (Linux).
+- Команде користе `docker compose` (v2).
+
+## А) Све-у-једном (bundled)
+
+Доноси и Postgres; чува податке у именованим волуменима.
+
+### Windows
+Покрените **`start.bat`** (двоклик или из терминала). Подиже стек и исписује адресу.
+
+### Linux / mac
+```bash
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build
+```
+
+Апликација: **http://localhost:8000** · прва пријава **admin / admin**.
+
+### Иницијално пуњење (опционо)
+Подразумевана парохија се креира аутоматски. Референтне табеле (народности,
+вероисповести, занимања, епархије) и календар слава пуне се једном:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml \
+  run --rm app python manage.py seed_lookups --tenant crkva_sv_petke_cukarica
+```
+
+### Управљање
+```bash
+# заустави
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml down
+# логови
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml logs -f app
+# ажурирање (после git pull)
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build
+```
+
+### Подаци и бекап
+База је у волумену `postgres_data`, статика у `static_data`. Бекап базе:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml \
+  exec db pg_dump -U crkva crkva > backup.sql
+```
+
+## Б) Слика + спољна база
+
+За сервер са постојећим/управљаним Postgres-ом.
+```bash
+cp .env.prod.example .env   # подесите SECRET_KEY, DB_*, ALLOWED_HOSTS
+docker compose up -d --build
+```
+Базни `docker-compose.yml` не доноси базу; повезујете се на спољну преко `.env`.
+Иза реверсног проксија (нпр. Caddy) оставите `SECURE_SSL=1` (подразумевано ван
+DEBUG-а) и проследите `X-Forwarded-Proto`.
+
+## Напомене
+
+- **Plain HTTP / localhost.** Bundled пут ради преко `http://localhost:8000`
+  (`SECURE_SSL=0`), без сертификата — за локалну/LAN употребу.
+- **Промените лозинку и кључ.** За било шта изложено промените
+  `DJANGO_SUPERUSER_PASSWORD` и `SECRET_KEY` (env или `.env`).
+- **LAN приступ.** За приступ са других рачунара додајте IP/име хоста у
+  `ALLOWED_HOSTS`, нпр. `ALLOWED_HOSTS=localhost,192.168.1.50`.
+- **Без SQLite.** django-tenants захтева Postgres.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,15 @@
+@echo off
+chcp 65001 >/dev/null
+REM Покреће SPC Регистар локално преко Docker Desktop-а (Windows, WSL2).
+docker compose -f docker-compose.yml -f docker-compose.standalone.yml up -d --build
+if errorlevel 1 goto err
+echo.
+echo SPC Регистар ради на: http://localhost:8000
+echo Прва пријава: admin / admin
+echo Заустављање: docker compose -f docker-compose.yml -f docker-compose.standalone.yml down
+goto end
+:err
+echo.
+echo Грешка при покретању. Да ли је Docker Desktop покренут?
+:end
+pause


### PR DESCRIPTION
Closes #7. PR 2/2 по дизајну у #286 (PR 1/2 = #287, мерџован).

## Шта доноси
- **docker-compose.standalone.yml** — све-у-једном: `app` (gunicorn, plain HTTP) + `db` (postgres:16), именовани волумени (`postgres_data`, `static_data`), `restart: unless-stopped`, порт `8000:8000`. Окружење подешено за localhost: `DEBUG=0 SECURE_SSL=0 ALLOWED_HOSTS=localhost` + CSRF trusted origins. Користи `run.sh` (из #287) — без override команде.
- **start.bat** — Windows покретач (Docker Desktop/WSL2): једна `docker compose ... up -d --build` команда; исписује адресу и податке за пријаву.
- **docs/standalone.md** — упутство за обе топологије:
  - А) bundled све-у-једном (localhost, admin/admin, опционо `seed_lookups`, бекап),
  - Б) слика + спољна база (`.env`, иза реверсног проксија са `SECURE_SSL=1`).
- **README** — нови ред у матрици путева + табели докумената.
- **docs/deployment.md** — исправљено неслагање: едж је **Caddy** (аутоматски Let's Encrypt), не nginx + certbot.

## Провера
- YAML валидан. Користи улазну тачку и `SECURE_SSL` флег из #287, где је већ потврђено да app под gunicorn-ом ради преко plain HTTP localhost-а (302 → /prijava).
- Крај-до-краја `docker compose ... up` најбоље покренути на машини са Docker Desktop-ом / Compose v2 (на овом серверу Compose v2 није доступан, а градња Alpine слике на дељеном серверу је тешка).
