### PR TITLE
fix(config): обавезне променљиве окружења пуцају одмах ако недостају (#292)

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,13 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: ci-pylint-dummy-key-not-for-production
+      DB_HOST: localhost
+      DB_PORT: "5432"
+      DB_NAME: crkva_db
+      DB_USER: postgres
+      DB_PASS: postgres
     strategy:
       matrix:
         python-version: ["3.13"]

--- a/crkva/crkva/settings.py
+++ b/crkva/crkva/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import List
 
 import environ
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -30,9 +31,6 @@ environ.Env.read_env(os.path.join(BASE_DIR.parent, ".env"))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY")
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 
@@ -40,6 +38,26 @@ DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 # продукцијско учвршћивање испод иначе укључило SSL redirect и празан
 # ALLOWED_HOSTS усред тестова. Откривамо тест-рун да то избегнемо (#223).
 _RUNNING_TESTS = "test" in sys.argv or sys.argv[0].endswith(("pytest", "py.test"))
+
+
+def _require_env(name):
+    """Враћа обавезну променљиву окружења или одмах пуца са јасном поруком (#292)."""
+    value = os.environ.get(name)
+    if not value:
+        raise ImproperlyConfigured(
+            f"Недостаје обавезна променљива окружења: {name}. "
+            "Подеси је у .env или у окружењу пре покретања."
+        )
+    return value
+
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# У продукцији је SECRET_KEY обавезан (пуца одмах ако недостаје); у DEBUG-у и
+# при тестовима користи се небезбедан развојни кључ ради лакшег покретања (#292).
+if DEBUG or _RUNNING_TESTS:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-dev-only-key")
+else:
+    SECRET_KEY = _require_env("SECRET_KEY")
 
 # Калибрационе странице (крштеница/венчаница) су подразумевано искључене у
 # продукцији; могу се привремено укључити поставком CALIBRATION_ENABLED=1 у
@@ -158,11 +176,11 @@ DATABASES = {
         "OPTIONS": {
             "client_encoding": "UTF8",
         },
-        "HOST": os.environ.get("DB_HOST"),
-        "PORT": os.environ.get("DB_PORT"),
-        "NAME": os.environ.get("DB_NAME"),
-        "USER": os.environ.get("DB_USER"),
-        "PASSWORD": os.environ.get("DB_PASS"),
+        "HOST": _require_env("DB_HOST"),
+        "PORT": os.environ.get("DB_PORT", "5432"),
+        "NAME": _require_env("DB_NAME"),
+        "USER": _require_env("DB_USER"),
+        "PASSWORD": _require_env("DB_PASS"),
     },
 }
 

--- a/crkva/registar/tests/test_settings_hardening.py
+++ b/crkva/registar/tests/test_settings_hardening.py
@@ -8,8 +8,10 @@ client тестови добијали 301 / 400). Овај тест чува т
 # pylint: disable=missing-function-docstring
 
 import os
+from unittest import mock
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
 
@@ -38,3 +40,27 @@ class SecurityHardeningGatingTests(SimpleTestCase):
         self.assertEqual(
             settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https")
         )
+
+
+class RequireEnvTests(SimpleTestCase):
+    """#292: обавезне променљиве окружења морају одмах да пукну ако недостају."""
+
+    def test_returns_value_when_present(self):
+        from crkva.settings import _require_env
+
+        with mock.patch.dict(os.environ, {"X_REQ_ENV_TEST": "vrednost"}):
+            self.assertEqual(_require_env("X_REQ_ENV_TEST"), "vrednost")
+
+    def test_raises_when_missing(self):
+        from crkva.settings import _require_env
+
+        os.environ.pop("X_REQ_ENV_MISSING", None)
+        with self.assertRaises(ImproperlyConfigured):
+            _require_env("X_REQ_ENV_MISSING")
+
+    def test_raises_when_empty(self):
+        from crkva.settings import _require_env
+
+        with mock.patch.dict(os.environ, {"X_REQ_ENV_EMPTY": ""}):
+            with self.assertRaises(ImproperlyConfigured):
+                _require_env("X_REQ_ENV_EMPTY")


### PR DESCRIPTION
## Шта и зашто
`SECRET_KEY = os.environ.get("SECRET_KEY")` је тихо постајао `None` (Django онда пуца касније са нејасном грешком), а `DB_HOST/NAME/USER/PASS` су подразумевано били `None` — збуњујуће рантајм грешке уместо јасног отказа при покретању.

## Измене
- **`_require_env(name)`** — пуца са `ImproperlyConfigured` и јасном поруком (ћирилица) када променљива недостаје **или је празна**.
- **`SECRET_KEY`**: обавезан у продукцији; у `DEBUG`/тестовима небезбедан развојни кључ (Django-конвенција) ради лакшег покретања без `.env`.
- **`DB_HOST/NAME/USER/PASS`**: обавезни; **`DB_PORT`** подразумевано `5432`.
- **`pylint.yml`**: додато dummy окружење — pylint преко `pylint_django` увози `crkva.settings`, а CI нема `.env`, па би строги fail-fast иначе срушио lint посао. (`tests.yml` већ поставља ово окружење.)
- Тестови за `_require_env` (враћа вредност; пуца на празан стринг и на недостајућу променљиву).

## Зашто је безбедно за постојеће путање
Сва стварна окружења већ постављају ове променљиве: локал/сервер преко `.env` (учитава се у `settings.py` кроз `read_env`), `docker-compose.yml`/`standalone`, и CI `tests.yml`. Једина празнина — pylint CI без `.env` — покривена је dummy окружењем.

## Ван опсега
Шира консолидација `environ.Env` vs сирови `os.environ` (Medium из ревизије) намерно изостављена да PR остане фокусиран на fail-fast.

## Тестови
`manage.py check`: уредно. `test_settings_hardening`: **7 OK** (4 постојећа + 3 нова).

Closes #292