### PR TITLE
refactor(registar): заједничка PdfDetailView база + HistorySnapshotMixin (#294)

### DIFF
--- a/crkva/registar/tests/test_print_detail_views.py
+++ b/crkva/registar/tests/test_print_detail_views.py
@@ -67,7 +67,7 @@ class _PdfBase(TestCase):
 class KrstenjePDFTests(_PdfBase):
     """KrstenjePDF: контекст + историјски снимци dete/otac/majka (kum=None)."""
 
-    TARGET = "registar.views.krstenje_view.HTML"
+    TARGET = "registar.views.pdf.HTML"
 
     @classmethod
     def setUpTestData(cls):
@@ -123,7 +123,7 @@ class KrstenjePDFTests(_PdfBase):
 class VencanjePDFTests(_PdfBase):
     """VencanjePDF: контекст + историјски снимци ženik/nevesta."""
 
-    TARGET = "registar.views.vencanje_view.HTML"
+    TARGET = "registar.views.pdf.HTML"
 
     @classmethod
     def setUpTestData(cls):
@@ -175,7 +175,7 @@ class SvestenikPDFTests(_PdfBase):
 
     def test_pdf_renders(self):
         self._get_pdf(
-            "registar.views.svestenik_view.HTML",
+            "registar.views.pdf.HTML",
             reverse("svestenik_pdf", kwargs={"uid": self.svestenik.uid}),
             "svestenik",
         )

--- a/crkva/registar/views/krstenje_view.py
+++ b/crkva/registar/views/krstenje_view.py
@@ -3,7 +3,6 @@
 """
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
 from registar.forms import KrstenjeForm
@@ -11,8 +10,8 @@ from registar.models import Krstenje
 from registar.services.izdavalac import get_izdavalac
 from registar.views.calibrate_view import render_calibrate
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from registar.views.pdf import HistorySnapshotMixin, PdfDetailView
 from tenants.permissions import tenant_role_required
-from weasyprint import HTML
 
 KRSTENJE_RELATED = (
     "dete",
@@ -76,57 +75,15 @@ class SpisakKrstenja(
         )
 
 
-class KrstenjePDF(LoginRequiredMixin, DetailView):
+class KrstenjePDF(HistorySnapshotMixin, PdfDetailView):
     """Генерише PDF документ за одређено крштење."""
 
     model = Krstenje
     template_name = "registar/pdf_krstenje.html"
     context_object_name = "krstenje"
-
-    def get_object(self, queryset=None):
-        """Враћа објекат крштења на основу UID-а."""
-        uid = self.kwargs.get("uid")
-        return get_object_or_404(
-            Krstenje.objects.select_related(*KRSTENJE_RELATED),
-            uid=uid,
-        )
-
-    def get_context_data(self, **kwargs):
-        """Додаје историјске снимке особа у контекст."""
-        context = super().get_context_data(**kwargs)
-        from registar.history import history_for
-
-        context["history_entries"] = history_for(self.object)
-        krstenje = context["krstenje"]
-        event_date = krstenje.datum or krstenje.created
-
-        for role in ["dete", "otac", "majka", "kum"]:
-            osoba = getattr(krstenje, role)
-            if osoba:
-                try:
-                    historical = osoba.history.as_of(event_date)
-                    context[f"{role}_snapshot"] = historical
-                except type(osoba).DoesNotExist:
-                    context[f"{role}_snapshot"] = osoba
-            else:
-                context[f"{role}_snapshot"] = None
-
-        return context
-
-    def render_to_response(self, context, **response_kwargs):
-        """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
-        html = render(self.request, self.template_name, context).content.decode()
-        pdf = HTML(string=html, base_url=self.request.build_absolute_uri()).write_pdf()
-        uid = self.kwargs.get("uid")
-        response = HttpResponse(pdf, content_type="application/pdf")
-        response["Content-Disposition"] = f"inline; filename=krstenje-{uid}.pdf"
-        return response
-
-    def get(self, request, *args, **kwargs):
-        """Обрађује GET захтеве за генерисање PDF-а."""
-        self.object = self.get_object()  # pylint: disable=attribute-defined-outside-init
-        context = self.get_context_data(object=self.object)
-        return self.render_to_response(context)
+    related = KRSTENJE_RELATED
+    filename_prefix = "krstenje"
+    snapshot_roles = ["dete", "otac", "majka", "kum"]
 
 
 class PrikazKrstenja(LoginRequiredMixin, DetailView):

--- a/crkva/registar/views/parohijan_view.py
+++ b/crkva/registar/views/parohijan_view.py
@@ -3,7 +3,6 @@
 """
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import DetailView, ListView
@@ -11,8 +10,8 @@ from registar.forms import ParohijanForm
 from registar.models import Krstenje
 from registar.models.parohijan import Osoba
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from registar.views.pdf import HistorySnapshotMixin, PdfDetailView
 from tenants.permissions import tenant_role_required
-from weasyprint import HTML
 
 
 @tenant_role_required("osoba")
@@ -79,33 +78,12 @@ class SpisakParohijana(
         )
 
 
-class ParohijanPDF(LoginRequiredMixin, DetailView):
+class ParohijanPDF(HistorySnapshotMixin, PdfDetailView):
     """Генерише PDF документ за одређеног парохијана."""
 
     model = Osoba
     template_name = "registar/pdf_parohijan.html"
-
-    def get_object(self, queryset=None):
-        """Преузима парохијана на основу UID-а."""
-        uid = self.kwargs.get("uid")
-        return get_object_or_404(Osoba, uid=uid)
-
-    def render_to_response(self, context, **response_kwargs):
-        """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
-        html_string = render(self.request, self.template_name, context).content.decode()
-        pdf = HTML(
-            string=html_string, base_url=self.request.build_absolute_uri()
-        ).write_pdf()
-        uid = self.kwargs.get("uid")
-        response = HttpResponse(content=pdf, content_type="application/pdf")
-        response["Content-Disposition"] = f"inline; filename=parohijan-{uid}.pdf"
-        return response
-
-    def get(self, request, *args, **kwargs):
-        """Обрађује GET захтев за генерисање PDF документа за парохијана."""
-        self.object = self.get_object()  # pylint: disable=attribute-defined-outside-init
-        context = self.get_context_data(object=self.object)
-        return self.render_to_response(context)
+    filename_prefix = "parohijan"
 
 
 class PrikazParohijana(LoginRequiredMixin, DetailView):

--- a/crkva/registar/views/pdf.py
+++ b/crkva/registar/views/pdf.py
@@ -1,0 +1,74 @@
+"""Заједничка база за PDF приказе (WeasyPrint).
+
+Изводи шаблон приказа у PDF. Уклања дуплирани
+``get_object``/``render_to_response``/``get`` који је постојао у приказима
+крштења, венчања, свештеника и парохијана. Сваки приказ дефинише само
+``model``, ``template_name``, ``filename_prefix`` и опционо ``related``
+(за ``select_related``) и ``snapshot_roles`` (за историјске снимке особа).
+"""
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import DetailView
+from weasyprint import HTML
+
+
+class HistorySnapshotMixin:
+    """Додаје ревизиону историју и историјске снимке особа у контекст.
+
+    Увек додаје ``history_entries`` (ревизије самог објекта). Ако приказ
+    дефинише ``snapshot_roles``, за сваку улогу додаје ``<role>_snapshot`` —
+    снимак везане особе на дан догађаја (``datum``, иначе ``created``).
+    """
+
+    snapshot_roles: list[str] = []
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        from registar.history import history_for
+
+        obj = self.object
+        context["history_entries"] = history_for(obj)
+        if self.snapshot_roles:
+            event_date = getattr(obj, "datum", None) or obj.created
+            for role in self.snapshot_roles:
+                osoba = getattr(obj, role)
+                if osoba is None:
+                    context[f"{role}_snapshot"] = None
+                    continue
+                try:
+                    context[f"{role}_snapshot"] = osoba.history.as_of(event_date)
+                except type(osoba).DoesNotExist:
+                    context[f"{role}_snapshot"] = osoba
+        return context
+
+
+class PdfDetailView(LoginRequiredMixin, DetailView):
+    """База за приказе који рендерују шаблон у PDF преко WeasyPrint-а.
+
+    Сваки приказ дефинише ``model``, ``template_name`` и ``filename_prefix``;
+    опционо ``related`` за ``select_related`` при учитавању по ``uid``-у.
+    """
+
+    related: tuple[str, ...] = ()
+    filename_prefix = "dokument"
+
+    def get_object(self, queryset=None):
+        base = self.model.objects
+        qs = base.select_related(*self.related) if self.related else base.all()
+        return get_object_or_404(qs, uid=self.kwargs.get("uid"))
+
+    def render_to_response(self, context, **response_kwargs):
+        html = render(self.request, self.template_name, context).content.decode()
+        pdf = HTML(string=html, base_url=self.request.build_absolute_uri()).write_pdf()
+        response = HttpResponse(pdf, content_type="application/pdf")
+        response["Content-Disposition"] = (
+            f"inline; filename={self.filename_prefix}-{self.kwargs.get('uid')}.pdf"
+        )
+        return response
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()  # pylint: disable=attribute-defined-outside-init
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)

--- a/crkva/registar/views/svestenik_view.py
+++ b/crkva/registar/views/svestenik_view.py
@@ -3,15 +3,14 @@
 """
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import DetailView, ListView
 from registar.forms import SvestenikForm
 from registar.models.svestenik import Svestenik
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from registar.views.pdf import HistorySnapshotMixin, PdfDetailView
 from tenants.permissions import tenant_role_required
-from weasyprint import HTML
 
 
 @tenant_role_required("svestenik")
@@ -55,31 +54,12 @@ class SpisakSvestenika(
         )
 
 
-class SvestenikPDF(LoginRequiredMixin, DetailView):
+class SvestenikPDF(HistorySnapshotMixin, PdfDetailView):
     """Генерише PDF документ за одређеног свештеника."""
 
     model = Svestenik
     template_name = "registar/pdf_svestenik.html"
-
-    def get_object(self):
-        """Враћа објекат свештеника на основу UID-а."""
-        uid = self.kwargs.get("uid")
-        return get_object_or_404(Svestenik, uid=uid)
-
-    def render_to_response(self, context, **response_kwargs):
-        """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
-        html = render(self.request, self.template_name, context).content.decode()
-        pdf = HTML(string=html, base_url=self.request.build_absolute_uri()).write_pdf()
-        uid = self.kwargs.get("uid")
-        response = HttpResponse(pdf, content_type="application/pdf")
-        response["Content-Disposition"] = f"inline; filename=svestenik-{uid}.pdf"
-        return response
-
-    def get(self, request, *args, **kwargs):
-        """Обрађује GET захтеве за генерисање PDF-а."""
-        self.object = self.get_object()  # pylint: disable=attribute-defined-outside-init
-        context = self.get_context_data(object=self.object)
-        return self.render_to_response(context)
+    filename_prefix = "svestenik"
 
 
 class PrikazSvestenika(LoginRequiredMixin, DetailView):

--- a/crkva/registar/views/vencanje_view.py
+++ b/crkva/registar/views/vencanje_view.py
@@ -3,7 +3,6 @@
 """
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView, ListView
 from registar.forms import VencanjeForm
@@ -11,8 +10,8 @@ from registar.models.vencanje import Vencanje
 from registar.services.izdavalac import get_izdavalac
 from registar.views.calibrate_view import render_calibrate
 from registar.views.mixins import InfiniteScrollMixin, PageSizeMixin, SearchMixin
+from registar.views.pdf import HistorySnapshotMixin, PdfDetailView
 from tenants.permissions import tenant_role_required
-from weasyprint import HTML
 
 VENCANJE_RELATED = (
     "zenik",
@@ -59,66 +58,24 @@ class SpisakVencanja(
         )
 
 
-class VencanjePDF(LoginRequiredMixin, DetailView):
+class VencanjePDF(HistorySnapshotMixin, PdfDetailView):
     """Генерише PDF документ за одређено венчање."""
 
     model = Vencanje
     template_name = "registar/pdf_vencanje.html"
     context_object_name = "vencanje"
-
-    def get_object(self, queryset=None):
-        """Враћа објекат венчања на основу UID-а."""
-        uid = self.kwargs.get("uid")
-        return get_object_or_404(
-            Vencanje.objects.select_related(*VENCANJE_RELATED),
-            uid=uid,
-        )
-
-    def get_context_data(self, **kwargs):
-        """Додаје историјске снимке особа у контекст."""
-        context = super().get_context_data(**kwargs)
-        from registar.history import history_for
-
-        context["history_entries"] = history_for(self.object)
-        vencanje = context["vencanje"]
-        event_date = vencanje.datum or vencanje.created
-
-        for role in [
-            "zenik",
-            "nevesta",
-            "kum",
-            "svekar",
-            "svekrva",
-            "tast",
-            "tasta",
-            "stari_svat",
-        ]:
-            osoba = getattr(vencanje, role)
-            if osoba:
-                try:
-                    historical = osoba.history.as_of(event_date)
-                    context[f"{role}_snapshot"] = historical
-                except type(osoba).DoesNotExist:
-                    context[f"{role}_snapshot"] = osoba
-            else:
-                context[f"{role}_snapshot"] = None
-
-        return context
-
-    def render_to_response(self, context, **response_kwargs):
-        """Претвара HTML садржај у PDF и враћа HTTP одговор са PDF документом."""
-        html = render(self.request, self.template_name, context).content.decode()
-        pdf = HTML(string=html, base_url=self.request.build_absolute_uri()).write_pdf()
-        uid = self.kwargs.get("uid")
-        response = HttpResponse(pdf, content_type="application/pdf")
-        response["Content-Disposition"] = f"inline; filename=vencanje-{uid}.pdf"
-        return response
-
-    def get(self, request, *args, **kwargs):
-        """Обрађује GET захтеве за генерисање PDF-а."""
-        self.object = self.get_object()  # pylint: disable=attribute-defined-outside-init
-        context = self.get_context_data(object=self.object)
-        return self.render_to_response(context)
+    related = VENCANJE_RELATED
+    filename_prefix = "vencanje"
+    snapshot_roles = [
+        "zenik",
+        "nevesta",
+        "kum",
+        "svekar",
+        "svekrva",
+        "tast",
+        "tasta",
+        "stari_svat",
+    ]
 
 
 class PrikazVencanja(LoginRequiredMixin, DetailView):


### PR DESCRIPTION
## Шта и зашто
Приказе крштења и венчања биле су ~90% идентичне, а исти PDF образац понављао се и у свештенику и парохијану (4 копије `get_object`/`render_to_response`/`get`). Петља историјских снимака особа била је копирана у крштењу и венчању.

## Измене
- **нов `registar/views/pdf.py`**:
  - `PdfDetailView` — учитавање објекта по `uid`-у (опционо `select_related` преко атрибута `related`), WeasyPrint рендеровање и `Content-Disposition` (`filename_prefix`).
  - `HistorySnapshotMixin` — увек додаје `history_entries`; ако приказ дефинише `snapshot_roles`, додаје и `<role>_snapshot` (снимак везане особе на дан догађаја: `datum`, иначе `created`).
- Сва четири PDF приказа сведена на **чисту конфигурацију** (model/template/filename_prefix/related/snapshot_roles), без дуплираних метода.
- **Историјска ревизија сада на сва 4** приказа (по жељи) — `SvestenikPDF`/`ParohijanPDF` је раније нису имали; `history_for` је генеричан (ради за `Svestenik` и `Osoba`).

## Тестови
- `test_print_detail_views` мокује сада `registar.views.pdf.HTML` (једно место за сва 4 приказа).
- `test_template_audit` нетакнут (рендерује шаблоне директно).
- Покренуто `test_print_detail_views` + `test_template_audit` + `test_views`: **57 OK**. `manage.py check` уредно.

Closes #294