### PR TITLE
refactor(deploy): Caddy сервис у prod профилу (TLS + reverse proxy) (#314, фаза 3)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -15,3 +15,8 @@ DB_PASS=CHANGE-THIS-PASSWORD
 
 # Allowed hosts - configure your domain
 ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
+
+# Reverse proxy (Caddy) — домен за аутоматски HTTPS, или :80 за plain HTTP
+SITE_ADDRESS=yourdomain.com
+# HTTPS учвршћивање: 1 иза Caddy-ја са доменом; 0 за plain HTTP (:80)
+SECURE_SSL=1

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+# Caddy реверсни прокси за `prod` профил (#314, фаза 3).
+#
+# SITE_ADDRESS се поставља у .env:
+#   - домен (нпр. registar.example.com) → аутоматски HTTPS (Let's Encrypt)
+#   - :80                               → plain HTTP (тада и SECURE_SSL=0)
+{$SITE_ADDRESS} {
+	reverse_proxy app-prod:8000
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,11 @@ services:
     <<: *app
     profiles: ["prod"]
     restart: always
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     environment:
       - DEBUG=0
+      - SECURE_SSL=${SECURE_SSL:-1}
       - SECRET_KEY=${SECRET_KEY}
       - DB_HOST=${DB_HOST}
       - DB_PORT=${DB_PORT:-5432}
@@ -95,5 +96,24 @@ services:
       - DB_PASS=${DB_PASS}
       - ALLOWED_HOSTS=${ALLOWED_HOSTS}
 
+  # Caddy реверсни прокси за prod: TLS терминација + reverse_proxy ка app-prod.
+  caddy:
+    image: caddy:2-alpine
+    profiles: ["prod"]
+    restart: always
+    depends_on:
+      - app-prod
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - SITE_ADDRESS=${SITE_ADDRESS:-:80}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
 volumes:
   postgres_data:
+  caddy_data:
+  caddy_config:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -155,7 +155,7 @@ docker compose --profile prod up -d
 make prod-up
 ```
 
-Апликација излаже gunicorn на порту 8000 (статику служи whitenoise). За HTTPS стави Caddy испред (исти образац као bare-metal, види горе).
+Профил `prod` подиже и **Caddy** сервис (портови 80/443) који реверсно проксира ка gunicorn-у (`app-prod:8000`); статику служи whitenoise. Постави `SITE_ADDRESS` у `.env` на домен (аутоматски HTTPS преко Let's Encrypt) или на `:80` за plain HTTP (тада и `SECURE_SSL=0`).
 
 ### 3. Иницијалне команде
 


### PR DESCRIPTION
Трећа фаза (#314): Docker-prod профил добија **Caddy** испред апликације (одлука: „Caddy свуда").

## Измене
- Нов **`Caddyfile`**: `{$SITE_ADDRESS} { reverse_proxy app-prod:8000 }`.
- Нов **`caddy`** сервис у профилу `prod` — портови **80/443**, volumes `caddy_data`/`caddy_config` за Let's Encrypt сертификате, `depends_on: app-prod`.
- **`app-prod`** више не објављује порт на хост (`expose: 8000`, доступан само Caddy-ју преко интерне мреже) — мање изложености. Додат `SECURE_SSL=${SECURE_SSL:-1}`.
- **`.env.prod.example`**: `SITE_ADDRESS` (домен → аутоматски HTTPS; `:80` → plain HTTP) и `SECURE_SSL`.
- **`docs/deployment.md`**: опис Caddy сервиса.

## Понашање
```bash
SITE_ADDRESS=registar.example.com docker compose --profile prod up -d   # аутоматски HTTPS
# или SITE_ADDRESS=:80 + SECURE_SSL=0 за plain HTTP
```
Caddy шаље `X-Forwarded-Proto`, а Django већ има `SECURE_PROXY_SSL_HEADER` → secure колачићи/CSRF раде преко HTTPS-а.

## Провера
YAML + профили структурно проверени; `mkdocs --strict` пролази. ⚠️ Runtime (`docker compose --profile prod up`) валидацију урадити на машини са compose плагином.

Део #314 (следе: обједињени start скриптови; обједињена документација).