### PR TITLE
docs(setup): OS табови за стандалон покретање (pymdownx.tabbed)

### DIFF
--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -24,12 +24,17 @@ single server. Data is stored in the named volume `postgres_data`.
 - **Docker Desktop** (Windows/macOS, with WSL2) or **Docker Engine + Compose v2** (Linux).
 
 ### Run
-- **Windows:** run **`start.bat`** (double-click or from a terminal).
-- **Linux / macOS:** run **`./start.sh`**.
-- Or directly:
-  ```bash
-  docker compose --profile standalone up -d --build
-  ```
+
+=== "Windows"
+    Run **`start.bat`** (double-click or from a terminal).
+
+=== "Linux / macOS"
+    Run **`./start.sh`**.
+
+=== "Directly (compose)"
+    ```bash
+    docker compose --profile standalone up -d --build
+    ```
 
 App: **http://localhost:8000** · first sign-in **admin / admin**.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,12 +24,17 @@
 - **Docker Desktop** (Windows/macOS, са WSL2) или **Docker Engine + Compose v2** (Linux).
 
 ### Покретање
-- **Windows:** покрените **`start.bat`** (двоклик или из терминала).
-- **Linux / macOS:** покрените **`./start.sh`**.
-- Или директно:
-  ```bash
-  docker compose --profile standalone up -d --build
-  ```
+
+=== "Windows"
+    Покрените **`start.bat`** (двоклик или из терминала).
+
+=== "Linux / macOS"
+    Покрените **`./start.sh`**.
+
+=== "Директно (compose)"
+    ```bash
+    docker compose --profile standalone up -d --build
+    ```
 
 Апликација: **http://localhost:8000** · прва пријава **admin / admin**.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
   - toc:
       permalink: true
       slugify: !!python/name:pymdownx.slugs.uslugify


### PR DESCRIPTION
Накнадно уз #319: упутства за покретање по OS-у као **Material content tabs**.

- Укључен `pymdownx.tabbed` (`alternate_style: true`) у `mkdocs.yml`.
- Секција „Покретање" у `setup.md`/`setup.en.md` претворена у табове **Windows / Linux · macOS / Директно (compose)**.

Табови се рендерују на MkDocs сајту; на GitHub-у (сирови markdown) приказују се као обичан текст — упутства су у `docs/` (сајт), па је то у реду.

`mkdocs build --strict` пролази; `tabbed-set` присутан у излазу.