### PR TITLE
refactor(registar): обједини дуплирану логику календара у registar/kalendar.py (#299)

### DIFF
--- a/crkva/registar/kalendar.py
+++ b/crkva/registar/kalendar.py
@@ -1,0 +1,68 @@
+"""Заједничка логика календарских приказа (почетна + календар слава).
+
+Извучено из `home_view.index` и `kalendar_view.kalendar` који су делили
+исте константе (велики празници, ознаке дана, мапа поста) и изградњу ћелија.
+"""
+
+from registar.utils_fasting import tip_posta
+
+# Ознаке дана у недељи (пон..нед), индекс = date.weekday()
+WEEKDAY_LABELS = ["пон", "уто", "сре", "чет", "пет", "суб", "нед"]
+
+# Велики (фиксни) празници: (месец, дан) → назив
+MAJOR_FEASTS = {
+    (1, 7): "Божић",
+    (1, 19): "Богојављење",
+    (8, 28): "Велика Госпојина",
+    (9, 21): "Мала Госпојина",
+    (11, 21): "Ваведење",
+    (1, 27): "Свети Сава",
+    (12, 19): "Свети Никола",
+    (5, 19): "Ђурђевдан",
+}
+
+# Покретни велики празници — препознају се по кључним речима у називу славе
+MAJOR_FEAST_KEYWORDS = ["васкрс", "спасовдан", "тројице", "духови", "вазнесењ"]
+
+# Тип поста → CSS класа (за бојење ћелија)
+FASTING_CSS_CLASS = {
+    "вода": "water",
+    "уље": "oil",
+    "риба": "fish",
+    "бели_мрс": "dairy",
+}
+
+
+def is_major_feast(d, day_slavas):
+    """Да ли је дан велики празник — фиксни (MAJOR_FEASTS) или покретни (кључне речи)."""
+    if (d.month, d.day) in MAJOR_FEASTS:
+        return True
+    return any(
+        keyword in s.naziv.lower()
+        for s in day_slavas
+        for keyword in MAJOR_FEAST_KEYWORDS
+    )
+
+
+def build_day_cell(d, day_slavas, today):
+    """Заједнички подаци ћелије за један дан.
+
+    Приказ-специфичне кључеве (`day_label`, `is_yesterday`, `is_upcoming`,
+    `is_placeholder`) додаје позивалац.
+    """
+    fasting_info = tip_posta(d)
+    return {
+        "date": d,
+        "weekday_label": WEEKDAY_LABELS[d.weekday()],
+        "is_fasting": fasting_info["is_fasting"],
+        "fasting_type": fasting_info["type"],
+        "fasting_class": FASTING_CSS_CLASS.get(fasting_info["type"]) or "",
+        "fasting_display": fasting_info["display"],
+        "fasting_description": fasting_info["description"],
+        "slave": day_slavas,
+        "fixed_slavas": [s for s in day_slavas if not s.pokretni],
+        "moveable_slavas": [s for s in day_slavas if s.pokretni],
+        "is_important": is_major_feast(d, day_slavas),
+        "is_crveno_slovo": any(s.crveno_slovo for s in day_slavas),
+        "is_today": d == today,
+    }

--- a/crkva/registar/views/home_view.py
+++ b/crkva/registar/views/home_view.py
@@ -6,8 +6,9 @@ from collections import defaultdict
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
-from registar.models import Krstenje, Osoba, Slava, Svestenik, Vencanje
-from registar.utils_fasting import tip_posta
+from registar.kalendar import WEEKDAY_LABELS, build_day_cell
+from registar.models import Slava
+from registar.views.search_view import _get_registry_stats
 
 
 @login_required
@@ -48,87 +49,21 @@ def index(request) -> HttpResponse:
         if datum:
             by_day[(datum.month, datum.day)].append(s)
 
-    # Build cells for template
-    weekday_labels = ["пон", "уто", "сре", "чет", "пет", "суб", "нед"]
-
-    # Major feast days
-    major_feasts = {
-        (1, 7): "Божић",
-        (1, 19): "Богојављење",
-        (8, 28): "Велика Госпојина",
-        (9, 21): "Мала Госпојина",
-        (11, 21): "Ваведење",
-        (1, 27): "Свети Сава",
-        (12, 19): "Свети Никола",
-        (5, 19): "Ђурђевдан",
-    }
-
+    # Изградња ћелија (заједничка логика у registar.kalendar)
     cells = []
     for d in days:
-        fasting_info = tip_posta(d)
-        day_slavas = by_day.get((d.month, d.day), [])
-
-        # Separate fixed and moveable feasts
-        fixed_slavas = [s for s in day_slavas if not s.pokretni]
-        moveable_slavas = [s for s in day_slavas if s.pokretni]
-
-        # Check if this day has a "crveno slovo" (red letter day) observance
-        is_crveno_slovo = any(s.crveno_slovo for s in day_slavas)
-
-        # Check if major feast
-        is_important = (d.month, d.day) in major_feasts
-        if day_slavas and not is_important:
-            for slava in day_slavas:
-                slava_lower = slava.naziv.lower()
-                if any(
-                    keyword in slava_lower
-                    for keyword in [
-                        "васкрс",
-                        "спасовдан",
-                        "тројице",
-                        "духови",
-                        "вазнесењ",
-                    ]
-                ):
-                    is_important = True
-                    break
-
-        # Determine day label
+        cell = build_day_cell(d, by_day.get((d.month, d.day), []), today)
         if d == today:
-            day_label = "данас"
+            cell["day_label"] = "данас"
         elif d == today - dt.timedelta(days=1):
-            day_label = "јуче"
+            cell["day_label"] = "јуче"
         elif d == today + dt.timedelta(days=1):
-            day_label = "сутра"
+            cell["day_label"] = "сутра"
         else:
-            day_label = weekday_labels[d.weekday()]
-
-        cells.append(
-            {
-                "date": d,
-                "weekday_label": weekday_labels[d.weekday()],
-                "day_label": day_label,
-                "is_fasting": fasting_info["is_fasting"],
-                "fasting_type": fasting_info["type"],
-                "fasting_class": {
-                    "вода": "water",
-                    "уље": "oil",
-                    "риба": "fish",
-                    "бели_мрс": "dairy",
-                }.get(fasting_info["type"])
-                or "",
-                "fasting_display": fasting_info["display"],
-                "fasting_description": fasting_info["description"],
-                "slave": day_slavas,
-                "fixed_slavas": fixed_slavas,
-                "moveable_slavas": moveable_slavas,
-                "is_important": is_important,
-                "is_crveno_slovo": is_crveno_slovo,
-                "is_today": d == today,
-                "is_yesterday": d == today - dt.timedelta(days=1),
-                "is_upcoming": d > today,
-            }
-        )
+            cell["day_label"] = WEEKDAY_LABELS[d.weekday()]
+        cell["is_yesterday"] = d == today - dt.timedelta(days=1)
+        cell["is_upcoming"] = d > today
+        cells.append(cell)
 
     # Split cells for the home page: today gets the hero, the next 5 days
     # form the upcoming-list. (calendar_cells stays full for backwards compat.)
@@ -136,12 +71,7 @@ def index(request) -> HttpResponse:
     upcoming_cells = [c for c in cells if c["date"] > today]
 
     context = {
-        "stats": {
-            "parohijani": Osoba.objects.count(),
-            "krstenja": Krstenje.objects.count(),
-            "vencanja": Vencanje.objects.count(),
-            "svestenici": Svestenik.objects.count(),
-        },
+        "stats": _get_registry_stats(),
         "calendar_cells": cells,
         "today_cell": today_cell,
         "upcoming_cells": upcoming_cells,

--- a/crkva/registar/views/kalendar_view.py
+++ b/crkva/registar/views/kalendar_view.py
@@ -11,8 +11,8 @@ from django.db.models import Count
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from kalendar.models import Slava
+from registar.kalendar import WEEKDAY_LABELS, build_day_cell
 from registar.utils import MESECI
-from registar.utils_fasting import tip_posta
 
 # crkvenikalendar.rs uses Cyrillic-month-name spelled in Latin script in the URL.
 # Map our 1..12 to the slug they use:
@@ -78,72 +78,15 @@ def kalendar(
         if datum and datum.month == month:
             by_day[datum.day].append(s)
 
-    # Обогаћени подаци за темплат
-    # Weekday labels (Mon..Sun) in Serbian abbreviations
-    weekday_labels = ["пон", "уто", "сре", "чет", "пет", "суб", "нед"]
-
-    # Major feast days (important observances)
-    major_feasts = {
-        (1, 7): "Божић",  # Christmas
-        (1, 19): "Богојављење",  # Epiphany
-        (8, 28): "Велика Госпојина",  # Dormition
-        (9, 21): "Мала Госпојина",  # Nativity of Theotokos
-        (11, 21): "Ваведење",  # Presentation of Mary
-        (1, 27): "Свети Сава",  # Saint Sava
-        (12, 19): "Свети Никола",  # Saint Nicholas
-        (5, 19): "Ђурђевдан",  # Saint George
-    }
-
-    # Build cells with leading placeholders to align under weekday headers
+    # Ћелије са водећим празним местима за поравнање испод заглавља дана
+    # (заједничка логика у registar.kalendar)
     cells = []
     for _ in range(first_weekday):
         cells.append({"is_placeholder": True})
     for d in days:
-        fasting_info = tip_posta(d)
-        day_slavas = by_day.get(d.day, [])
-
-        # Separate fixed and moveable feasts
-        fixed_slavas = [s for s in day_slavas if not s.pokretni]
-        moveable_slavas = [s for s in day_slavas if s.pokretni]
-
-        # Check if this day has a "crveno slovo" (red letter day) observance
-        is_crveno_slovo = any(s.crveno_slovo for s in day_slavas)
-
-        # Check if this is a major feast day
-        is_important = (d.month, d.day) in major_feasts
-        # Also check if any slava name contains major keywords
-        if day_slavas and not is_important:
-            for slava in day_slavas:
-                slava_lower = slava.naziv.lower()
-                keywords = ["васкрс", "спасовдан", "тројице", "духови", "вазнесењ"]
-                if any(keyword in slava_lower for keyword in keywords):
-                    is_important = True
-                    break
-
-        cells.append(
-            {
-                "is_placeholder": False,
-                "date": d,
-                "weekday_label": weekday_labels[d.weekday()],
-                "is_fasting": fasting_info["is_fasting"],
-                "fasting_type": fasting_info["type"],
-                "fasting_class": {
-                    "вода": "water",
-                    "уље": "oil",
-                    "риба": "fish",
-                    "бели_мрс": "dairy",
-                }.get(fasting_info["type"])
-                or "",
-                "fasting_display": fasting_info["display"],
-                "fasting_description": fasting_info["description"],
-                "slave": day_slavas,
-                "fixed_slavas": fixed_slavas,
-                "moveable_slavas": moveable_slavas,
-                "is_important": is_important,
-                "is_crveno_slovo": is_crveno_slovo,
-                "is_today": d == today,
-            }
-        )
+        cell = build_day_cell(d, by_day.get(d.day, []), today)
+        cell["is_placeholder"] = False
+        cells.append(cell)
 
     # Навигација за претходни/наредни месец
     prev_month = month - 1 if month > 1 else 12
@@ -157,7 +100,7 @@ def kalendar(
         "month_name": MESECI.get(month, str(month)),
         "month_label": f"{MESECI.get(month, str(month))} {year}",
         "source_url": crkvenikalendar_url(year, month),
-        "weekday_labels": weekday_labels,
+        "weekday_labels": WEEKDAY_LABELS,
         "cells": cells,
         "prev_year": prev_year,
         "prev_month": prev_month,


### PR DESCRIPTION
## Зашто
`home_view.index` и `kalendar_view.kalendar` су дуплирали: `weekday_labels`, `major_feasts` речник, листу кључних речи, мапу пост→CSS и целу изградњу ћелија дана. `index` је уз то имао **некеширану** копију статистике регистра.

## Измене
- Нов **`registar/kalendar.py`**: `WEEKDAY_LABELS`, `MAJOR_FEASTS`, `MAJOR_FEAST_KEYWORDS`, `FASTING_CSS_CLASS`, `is_major_feast()`, `build_day_cell()`.
- Оба приказа сада зову `build_day_cell()` и додају само приказ-специфичне кључеве (`day_label`/`is_yesterday`/`is_upcoming` за почетну; `is_placeholder` за календар).
- `index` користи кеширани `_get_registry_stats()` (исти као `search_view`) уместо некеширане копије.

Понашање непромењено — кључеви ћелија идентични као пре.

## Тестови
`test_views` + `test_fasting` + `test_template_audit` + `kalendar.tests`: **118 OK**; `check` уредан. (Апсолутни увоз — `registar.kalendar` не засењује `kalendar` апликацију; `from kalendar.models import Slava` и даље ради.)

Closes #299